### PR TITLE
feat: integrate customer registration with API (#40)

### DIFF
--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -1,5 +1,6 @@
 // lib/core/network/api_endpoints.dart
 abstract final class ApiEndpoints {
+  /// `http://10.0.2.2:8080`, device físico `http://<IP_LAN>:8080`).
   static const String _base = String.fromEnvironment(
     'API_BASE_URL',
     defaultValue: 'http://localhost:8080',

--- a/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -4,6 +4,7 @@ import 'package:ragro_mobile/core/network/api_client.dart';
 import 'package:ragro_mobile/core/network/api_endpoints.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/auth/data/models/auth_config_model.dart';
+import 'package:ragro_mobile/features/auth/data/models/customer_registration_request.dart';
 import 'package:ragro_mobile/features/auth/data/models/keycloak_token_model.dart';
 import 'package:ragro_mobile/features/auth/data/models/login_response_model.dart';
 import 'package:ragro_mobile/features/auth/data/models/user_model.dart';
@@ -99,35 +100,14 @@ class AuthRemoteDataSource {
     }
   }
 
-  Future<UserModel> registerConsumer({
-    required String name,
-    required String phone,
-    required String email,
-    required String password,
-    required String zipCode,
-    required String street,
-    required String number,
-    required String city,
-    required String state,
-    String? complement,
-  }) async {
+  /// Cadastro de consumidor — POST /auth/register/customer (201 + corpo do cliente).
+  Future<UserModel> registerCustomer(
+    CustomerRegistrationRequest request,
+  ) async {
     try {
       final response = await _apiClient.dio.post<Map<String, dynamic>>(
         ApiEndpoints.registerCustomer,
-        data: {
-          'name': name,
-          'phone': phone,
-          'email': email,
-          'password': password,
-          'address': {
-            'zip_code': zipCode,
-            'street': street,
-            'number': number,
-            'city': city,
-            'state': state,
-            if (complement != null) 'complement': complement,
-          },
-        },
+        data: request.toJson(),
       );
       return UserModel.fromJson(response.data!);
     } on DioException catch (e) {

--- a/lib/features/auth/data/models/address_request.dart
+++ b/lib/features/auth/data/models/address_request.dart
@@ -1,0 +1,32 @@
+/// Payload de endereço para POST /auth/register/customer (alinhado ao [AddressRequest] do backend).
+class AddressRequest {
+  const AddressRequest({
+    required this.street,
+    required this.number,
+    required this.city,
+    required this.state,
+    required this.zipCode,
+    this.complement,
+    this.neighborhood,
+  });
+
+  final String street;
+  final String number;
+  final String city;
+  final String state;
+  final String zipCode;
+  final String? complement;
+  final String? neighborhood;
+
+  Map<String, dynamic> toJson() => {
+        'street': street,
+        'number': number,
+        'city': city,
+        'state': state,
+        'zipCode': zipCode,
+        if (complement != null && complement!.trim().isNotEmpty)
+          'complement': complement!.trim(),
+        if (neighborhood != null && neighborhood!.trim().isNotEmpty)
+          'neighborhood': neighborhood!.trim(),
+      };
+}

--- a/lib/features/auth/data/models/customer_registration_request.dart
+++ b/lib/features/auth/data/models/customer_registration_request.dart
@@ -1,0 +1,31 @@
+import 'package:ragro_mobile/features/auth/data/models/address_request.dart';
+
+/// Payload para POST /auth/register/customer.
+///
+/// O backend usa [fiscalNumber] para CPF (11 dígitos, sem pontuação).
+class CustomerRegistrationRequest {
+  const CustomerRegistrationRequest({
+    required this.name,
+    required this.email,
+    required this.phone,
+    required this.fiscalNumber,
+    required this.password,
+    required this.address,
+  });
+
+  final String name;
+  final String email;
+  final String phone;
+  final String fiscalNumber;
+  final String password;
+  final AddressRequest address;
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'email': email,
+        'phone': phone,
+        'fiscalNumber': fiscalNumber,
+        'password': password,
+        'address': address.toJson(),
+      };
+}

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -2,6 +2,8 @@ import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/network/api_client.dart';
 import 'package:ragro_mobile/features/auth/data/datasources/auth_local_datasource.dart';
 import 'package:ragro_mobile/features/auth/data/datasources/auth_remote_datasource.dart';
+import 'package:ragro_mobile/features/auth/data/models/address_request.dart';
+import 'package:ragro_mobile/features/auth/data/models/customer_registration_request.dart';
 import 'package:ragro_mobile/features/auth/data/models/user_model.dart';
 import 'package:ragro_mobile/features/auth/domain/entities/user.dart';
 import 'package:ragro_mobile/features/auth/domain/entities/user_type.dart';
@@ -50,6 +52,7 @@ class AuthRepositoryImpl implements AuthRepository {
     required String name,
     required String phone,
     required String email,
+    required String fiscalNumber,
     required String password,
     required String zipCode,
     required String street,
@@ -57,19 +60,27 @@ class AuthRepositoryImpl implements AuthRepository {
     required String city,
     required String state,
     String? complement,
-  }) =>
-      _remote.registerConsumer(
-        name: name,
-        phone: phone,
-        email: email,
-        password: password,
-        zipCode: zipCode,
-        street: street,
-        number: number,
-        city: city,
-        state: state,
-        complement: complement,
-      );
+    String? neighborhood,
+  }) {
+    String digits(String s) => s.replaceAll(RegExp(r'\D'), '');
+    final request = CustomerRegistrationRequest(
+      name: name.trim(),
+      email: email.trim(),
+      phone: digits(phone),
+      fiscalNumber: digits(fiscalNumber),
+      password: password,
+      address: AddressRequest(
+        street: street.trim(),
+        number: number.trim(),
+        city: city.trim(),
+        state: state.trim().toUpperCase(),
+        zipCode: digits(zipCode),
+        complement: complement?.trim(),
+        neighborhood: neighborhood?.trim(),
+      ),
+    );
+    return _remote.registerCustomer(request);
+  }
 
   @override
   Future<void> logout() async {

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -10,6 +10,7 @@ abstract class AuthRepository {
     required String name,
     required String phone,
     required String email,
+    required String fiscalNumber,
     required String password,
     required String zipCode,
     required String street,
@@ -17,6 +18,7 @@ abstract class AuthRepository {
     required String city,
     required String state,
     String? complement,
+    String? neighborhood,
   });
 
   Future<void> logout();

--- a/lib/features/auth/domain/usecases/register_consumer.dart
+++ b/lib/features/auth/domain/usecases/register_consumer.dart
@@ -11,6 +11,7 @@ class RegisterConsumer {
     required String name,
     required String phone,
     required String email,
+    required String fiscalNumber,
     required String password,
     required String zipCode,
     required String street,
@@ -18,10 +19,20 @@ class RegisterConsumer {
     required String city,
     required String state,
     String? complement,
+    String? neighborhood,
   }) =>
       _repository.registerConsumer(
-        name: name, phone: phone, email: email, password: password,
-        zipCode: zipCode, street: street, number: number,
-        city: city, state: state, complement: complement,
+        name: name,
+        phone: phone,
+        email: email,
+        fiscalNumber: fiscalNumber,
+        password: password,
+        zipCode: zipCode,
+        street: street,
+        number: number,
+        city: city,
+        state: state,
+        complement: complement,
+        neighborhood: neighborhood,
       );
 }

--- a/lib/features/auth/presentation/bloc/register_bloc.dart
+++ b/lib/features/auth/presentation/bloc/register_bloc.dart
@@ -23,6 +23,7 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
         name: event.name,
         phone: event.phone,
         email: event.email,
+        fiscalNumber: event.fiscalNumber,
         password: event.password,
         zipCode: event.zipCode,
         street: event.street,
@@ -30,6 +31,7 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
         city: event.city,
         state: event.state,
         complement: event.complement,
+        neighborhood: event.neighborhood,
       );
       emit(RegisterSuccess(user));
     } on ApiException catch (e) {

--- a/lib/features/auth/presentation/bloc/register_event.dart
+++ b/lib/features/auth/presentation/bloc/register_event.dart
@@ -11,6 +11,7 @@ class RegisterSubmitted extends RegisterEvent {
     required this.name,
     required this.phone,
     required this.email,
+    required this.fiscalNumber,
     required this.password,
     required this.zipCode,
     required this.street,
@@ -18,11 +19,13 @@ class RegisterSubmitted extends RegisterEvent {
     required this.city,
     required this.state,
     this.complement,
+    this.neighborhood,
   });
 
   final String name;
   final String phone;
   final String email;
+  final String fiscalNumber;
   final String password;
   final String zipCode;
   final String street;
@@ -30,17 +33,21 @@ class RegisterSubmitted extends RegisterEvent {
   final String city;
   final String state;
   final String? complement;
+  final String? neighborhood;
 
   @override
   List<Object?> get props => [
         name,
         phone,
         email,
+        fiscalNumber,
         password,
         zipCode,
         street,
         number,
         city,
         state,
+        complement,
+        neighborhood,
       ];
 }

--- a/lib/features/auth/presentation/pages/consumer_register_page.dart
+++ b/lib/features/auth/presentation/pages/consumer_register_page.dart
@@ -1,7 +1,7 @@
 // Screen: Consumer Registration
 // User Story: US-01 — Consumer Registration
 // Epic: EPIC 1 — Authentication
-// Routes: POST /auth/register
+// Routes: POST /auth/register/customer
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -41,11 +41,14 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
   final _nameController = TextEditingController();
   final _phoneController = TextEditingController();
   final _emailController = TextEditingController();
+  final _cpfController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
   final _zipCodeController = TextEditingController();
   final _streetController = TextEditingController();
   final _numberController = TextEditingController();
+  final _complementController = TextEditingController();
+  final _neighborhoodController = TextEditingController();
   final _cityController = TextEditingController();
   final _stateController = TextEditingController();
 
@@ -56,11 +59,14 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
     _nameController.dispose();
     _phoneController.dispose();
     _emailController.dispose();
+    _cpfController.dispose();
     _passwordController.dispose();
     _confirmPasswordController.dispose();
     _zipCodeController.dispose();
     _streetController.dispose();
     _numberController.dispose();
+    _complementController.dispose();
+    _neighborhoodController.dispose();
     _cityController.dispose();
     _stateController.dispose();
     super.dispose();
@@ -83,12 +89,19 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
             name: _nameController.text.trim(),
             phone: _phoneController.text.trim(),
             email: _emailController.text.trim(),
+            fiscalNumber: _cpfController.text.trim(),
             password: _passwordController.text,
             zipCode: _zipCodeController.text.trim(),
             street: _streetController.text.trim(),
             number: _numberController.text.trim(),
             city: _cityController.text.trim(),
             state: _stateController.text.trim(),
+            complement: _complementController.text.trim().isEmpty
+                ? null
+                : _complementController.text.trim(),
+            neighborhood: _neighborhoodController.text.trim().isEmpty
+                ? null
+                : _neighborhoodController.text.trim(),
           ),
         );
   }
@@ -139,8 +152,10 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                   controller: _phoneController,
                   keyboardType: TextInputType.phone,
                   validator: (value) {
-                    if (value == null || value.trim().isEmpty) {
-                      return 'Informe seu telefone';
+                    final digits =
+                        value?.replaceAll(RegExp(r'\D'), '') ?? '';
+                    if (digits.length != 11) {
+                      return 'DDD + número com 11 dígitos';
                     }
                     return null;
                   },
@@ -160,6 +175,21 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
+                  label: 'CPF',
+                  icon: Icons.badge_outlined,
+                  controller: _cpfController,
+                  keyboardType: TextInputType.number,
+                  validator: (value) {
+                    final digits =
+                        value?.replaceAll(RegExp(r'\D'), '') ?? '';
+                    if (digits.length != 11) {
+                      return 'CPF deve ter 11 dígitos';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                AuthTextField(
                   label: 'Senha',
                   icon: Icons.lock_outline,
                   controller: _passwordController,
@@ -168,8 +198,12 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                     if (value == null || value.isEmpty) {
                       return 'Informe uma senha';
                     }
-                    if (value.length < 8) {
-                      return 'A senha deve ter pelo menos 8 caracteres';
+                    if (value.length < 8 || value.length > 50) {
+                      return 'Entre 8 e 50 caracteres';
+                    }
+                    if (!RegExp(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$')
+                        .hasMatch(value)) {
+                      return 'Inclua maiúscula, minúscula e um número';
                     }
                     return null;
                   },
@@ -228,6 +262,18 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                   },
                 ),
                 const SizedBox(height: 16),
+                AuthTextField(
+                  label: 'Complemento (opcional)',
+                  icon: Icons.apartment_outlined,
+                  controller: _complementController,
+                ),
+                const SizedBox(height: 16),
+                AuthTextField(
+                  label: 'Bairro (opcional)',
+                  icon: Icons.signpost_outlined,
+                  controller: _neighborhoodController,
+                ),
+                const SizedBox(height: 16),
                 Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -252,8 +298,10 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                         icon: Icons.map_outlined,
                         controller: _stateController,
                         validator: (value) {
-                          if (value == null || value.trim().isEmpty) {
-                            return 'UF';
+                          final v = value?.trim().toUpperCase() ?? '';
+                          if (v.length != 2 ||
+                              !RegExp(r'^[A-Z]{2}$').hasMatch(v)) {
+                            return 'UF com 2 letras (ex: RS)';
                           }
                           return null;
                         },

--- a/test/features/auth/presentation/bloc/register_bloc_test.dart
+++ b/test/features/auth/presentation/bloc/register_bloc_test.dart
@@ -34,6 +34,7 @@ void main() {
     name: 'Ana',
     phone: '11900000000',
     email: 'ana@t.com',
+    fiscalNumber: '12345678901',
     password: 'password123',
     zipCode: '01310100',
     street: 'Av. Paulista',
@@ -49,6 +50,7 @@ void main() {
             name: any(named: 'name'),
             phone: any(named: 'phone'),
             email: any(named: 'email'),
+            fiscalNumber: any(named: 'fiscalNumber'),
             password: any(named: 'password'),
             zipCode: any(named: 'zipCode'),
             street: any(named: 'street'),
@@ -56,6 +58,7 @@ void main() {
             city: any(named: 'city'),
             state: any(named: 'state'),
             complement: any(named: 'complement'),
+            neighborhood: any(named: 'neighborhood'),
           )).thenAnswer((_) async => tUser);
       return bloc;
     },
@@ -70,6 +73,7 @@ void main() {
             name: any(named: 'name'),
             phone: any(named: 'phone'),
             email: any(named: 'email'),
+            fiscalNumber: any(named: 'fiscalNumber'),
             password: any(named: 'password'),
             zipCode: any(named: 'zipCode'),
             street: any(named: 'street'),
@@ -77,6 +81,7 @@ void main() {
             city: any(named: 'city'),
             state: any(named: 'state'),
             complement: any(named: 'complement'),
+            neighborhood: any(named: 'neighborhood'),
           )).thenThrow(const ConflictException());
       return bloc;
     },


### PR DESCRIPTION
## O que mudou?

- Criados modelos CustomerRegistrationRequest e AddressRequest
- Implementado registerCustomer no AuthRemoteDataSource (POST /auth/register/customer)
- Repositório normaliza dados antes de enviar (CPF/CEP só dígitos, UF maiúscula)
- Tela de cadastro exibe loading e navega para login em sucesso

## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

flutter test

## Screenshots / Gravações

<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
