### PR TITLE
Tag de produtor ativo/desativo e modal generico de confirmação

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -22,6 +22,8 @@ import 'package:ragro_mobile/features/admin/data/repositories/admin_repository_i
     as _i780;
 import 'package:ragro_mobile/features/admin/domain/repositories/admin_repository.dart'
     as _i759;
+import 'package:ragro_mobile/features/admin/domain/usecases/activate_admin_producer.dart'
+    as _i671;
 import 'package:ragro_mobile/features/admin/domain/usecases/create_admin_producer.dart'
     as _i321;
 import 'package:ragro_mobile/features/admin/domain/usecases/deactivate_admin_producer.dart'
@@ -335,6 +337,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i456.UpdateCartItemQuantity>(
       () => _i456.UpdateCartItemQuantity(gh<_i830.CartRepository>()),
     );
+    gh.lazySingleton<_i671.ActivateAdminProducer>(
+      () => _i671.ActivateAdminProducer(gh<_i759.AdminRepository>()),
+    );
     gh.lazySingleton<_i321.CreateAdminProducer>(
       () => _i321.CreateAdminProducer(gh<_i759.AdminRepository>()),
     );
@@ -400,6 +405,13 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i127.ProductDetailRemoteDataSource>(),
       ),
     );
+    gh.factory<_i1056.AdminProducersBloc>(
+      () => _i1056.AdminProducersBloc(
+        gh<_i1054.GetAdminProducers>(),
+        gh<_i514.DeactivateAdminProducer>(),
+        gh<_i671.ActivateAdminProducer>(),
+      ),
+    );
     gh.lazySingleton<_i43.AuthRepository>(
       () => _i579.AuthRepositoryImpl(
         gh<_i201.AuthRemoteDataSource>(),
@@ -456,12 +468,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i894.SearchProducersAndProducts>(
       () => _i894.SearchProducersAndProducts(gh<_i38.SearchRepository>()),
-    );
-    gh.factory<_i1056.AdminProducersBloc>(
-      () => _i1056.AdminProducersBloc(
-        gh<_i1054.GetAdminProducers>(),
-        gh<_i514.DeactivateAdminProducer>(),
-      ),
     );
     gh.lazySingleton<_i47.GetConsumerProfile>(
       () => _i47.GetConsumerProfile(gh<_i810.ConsumerProfileRepository>()),

--- a/lib/features/admin/data/Models/admin_producer_model.dart
+++ b/lib/features/admin/data/Models/admin_producer_model.dart
@@ -1,0 +1,28 @@
+import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart';
+
+class AdminProducerModel extends AdminProducer {
+  const AdminProducerModel({
+    required super.id,
+    required super.name,
+    required super.email,
+    required super.location,
+    required super.address,
+    required super.createdAt,
+    required super.updatedAt,
+    required super.active,
+  });
+
+  factory AdminProducerModel.fromJson(Map<String, dynamic> json) {
+    return AdminProducerModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      email: json['email'] as String,
+      location: json['location'] as String,
+      address: json['address'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      active: json['active'] as bool,
+    );
+  }
+}
+

--- a/lib/features/admin/domain/usecases/activate_admin_producer.dart
+++ b/lib/features/admin/domain/usecases/activate_admin_producer.dart
@@ -1,0 +1,11 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/admin/domain/repositories/admin_repository.dart';
+
+@lazySingleton
+class ActivateAdminProducer {
+  const ActivateAdminProducer(this._repository);
+
+  final AdminRepository _repository;
+
+  Future<void> call(String id) => _repository.activateProducer(id);
+}

--- a/lib/features/admin/presentation/bloc/admin_producers_bloc.dart
+++ b/lib/features/admin/presentation/bloc/admin_producers_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/admin/domain/usecases/activate_admin_producer.dart';
 import 'package:ragro_mobile/features/admin/domain/usecases/deactivate_admin_producer.dart';
 import 'package:ragro_mobile/features/admin/domain/usecases/get_admin_producers.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_event.dart';
@@ -8,15 +9,17 @@ import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_st
 @injectable
 class AdminProducersBloc
     extends Bloc<AdminProducersEvent, AdminProducersState> {
-  AdminProducersBloc(this._getProducers, this._deactivate)
+  AdminProducersBloc(this._getProducers, this._deactivate, this._activate)
       : super(const AdminProducersInitial()) {
     on<AdminProducersStarted>(_onStarted);
     on<AdminProducerDeactivated>(_onDeactivated);
     on<AdminProducersRefreshed>(_onRefreshed);
+    on<AdminProducerActivated>(_onActivated);
   }
 
   final GetAdminProducers _getProducers;
   final DeactivateAdminProducer _deactivate;
+  final ActivateAdminProducer _activate;
 
   Future<void> _onStarted(
     AdminProducersStarted event,
@@ -37,6 +40,19 @@ class AdminProducersBloc
   ) async {
     try {
       await _deactivate(event.producerId);
+      final producers = await _getProducers();
+      emit(AdminProducersLoaded(producers));
+    } catch (e) {
+      emit(AdminProducersFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onActivated(
+      AdminProducerActivated event,
+      Emitter<AdminProducersState> emit,
+      ) async {
+    try {
+      await _activate(event.producerId);
       final producers = await _getProducers();
       emit(AdminProducersLoaded(producers));
     } catch (e) {

--- a/lib/features/admin/presentation/bloc/admin_producers_event.dart
+++ b/lib/features/admin/presentation/bloc/admin_producers_event.dart
@@ -17,6 +17,14 @@ class AdminProducerDeactivated extends AdminProducersEvent {
   List<Object?> get props => [producerId];
 }
 
+class AdminProducerActivated extends AdminProducersEvent {
+  const AdminProducerActivated(this.producerId);
+  final String producerId;
+  @override
+  List<Object?> get props => [producerId];
+}
+
+
 class AdminProducersRefreshed extends AdminProducersEvent {
   const AdminProducersRefreshed();
 }

--- a/lib/features/admin/presentation/pages/admin_producers_page.dart
+++ b/lib/features/admin/presentation/pages/admin_producers_page.dart
@@ -12,6 +12,7 @@ import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart'
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_bloc.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_event.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_state.dart';
+import 'package:ragro_mobile/shared/widgets/confirm_dialog.dart';
 
 class AdminProducersPage extends StatelessWidget {
   const AdminProducersPage({super.key});
@@ -20,7 +21,7 @@ class AdminProducersPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) =>
-          getIt<AdminProducersBloc>()..add(const AdminProducersStarted()),
+      getIt<AdminProducersBloc>()..add(const AdminProducersStarted()),
       child: const _AdminProducersView(),
     );
   }
@@ -85,16 +86,14 @@ class _AdminProducersView extends StatelessWidget {
                       final producer = state.producers[index];
                       return _ProducerCard(
                         producer: producer,
-                        onDelete: () => _confirmDeactivate(
-                          context,
-                          producer.id,
-                          producer.name,
-                        ),
+                        onToggleActive: () => producer.active
+                            ? _confirmDeactivate(context, producer)
+                            : _confirmActivate(context, producer),
                         onEdit: () {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
                               content:
-                                  Text('Editar ${producer.name} — em breve'),
+                              Text('Editar ${producer.name} — em breve'),
                             ),
                           );
                         },
@@ -139,41 +138,99 @@ class _AdminProducersView extends StatelessWidget {
     );
   }
 
-  void _confirmDeactivate(
-      BuildContext context, String producerId, String producerName) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Desativar "$producerName"?'),
-        action: SnackBarAction(
-          label: 'Confirmar',
-          textColor: AppColors.white,
-          onPressed: () {
-            context
-                .read<AdminProducersBloc>()
-                .add(AdminProducerDeactivated(producerId));
-          },
+  Future<void> _confirmDeactivate(
+      BuildContext context, AdminProducer producer) async {
+    final confirmed = await ConfirmDialog.show(
+      context: context,
+      title: RichText(
+        textAlign: TextAlign.center,
+        text: TextSpan(
+          style: const TextStyle(
+            fontFamily: 'Figtree',
+            fontWeight: FontWeight.w600,
+            fontSize: 17,
+            color: AppColors.black,
+            height: 1.4,
+          ),
+          children: [
+            const TextSpan(text: 'Tem certeza que deseja\ndesativar '),
+            TextSpan(
+              text: producer.name,
+              style: const TextStyle(color: AppColors.red),
+            ),
+            const TextSpan(text: '?'),
+          ],
         ),
-        backgroundColor: AppColors.red,
       ),
+      confirmLabel: 'Desativar',
+      confirmColor: AppColors.red,
     );
+
+    if (confirmed == true && context.mounted) {
+      context
+          .read<AdminProducersBloc>()
+          .add(AdminProducerDeactivated(producer.id));
+    }
+  }
+
+  Future<void> _confirmActivate(
+      BuildContext context, AdminProducer producer) async {
+    final confirmed = await ConfirmDialog.show(
+      context: context,
+      title: RichText(
+        textAlign: TextAlign.center,
+        text: TextSpan(
+          style: const TextStyle(
+            fontFamily: 'Figtree',
+            fontWeight: FontWeight.w600,
+            fontSize: 17,
+            color: AppColors.black,
+            height: 1.4,
+          ),
+          children: [
+            const TextSpan(text: 'Tem certeza que deseja\nativar '),
+            TextSpan(
+              text: producer.name,
+              style: const TextStyle(color: AppColors.darkGreen),
+            ),
+            const TextSpan(text: '?'),
+          ],
+        ),
+      ),
+      confirmLabel: 'Ativar',
+      confirmColor: AppColors.darkGreen,
+    );
+
+    if (confirmed == true && context.mounted) {
+      context
+          .read<AdminProducersBloc>()
+          .add(AdminProducerActivated(producer.id));
+    }
   }
 }
 
 class _ProducerCard extends StatelessWidget {
   const _ProducerCard({
     required this.producer,
-    required this.onDelete,
+    required this.onToggleActive,
     required this.onEdit,
   });
 
   final AdminProducer producer;
-  final VoidCallback onDelete;
+  final VoidCallback onToggleActive;
   final VoidCallback onEdit;
 
   @override
   Widget build(BuildContext context) {
     String fmtDate(DateTime d) =>
         '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}/${d.year}';
+
+    final toggleColor =
+    producer.active ? AppColors.red : AppColors.darkGreen;
+    final toggleIcon = producer.active
+        ? Icons.delete_outline
+        : Icons.restore;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -191,7 +248,6 @@ class _ProducerCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Name + action buttons row
           Row(
             children: [
               Expanded(
@@ -219,17 +275,15 @@ class _ProducerCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 8),
-              // Delete
               GestureDetector(
-                onTap: onDelete,
+                onTap: onToggleActive,
                 child: Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
-                    color: AppColors.red.withOpacity(0.1),
+                    color: toggleColor.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(8),
                   ),
-                  child: const Icon(Icons.delete_outline,
-                      size: 16, color: AppColors.red),
+                  child: Icon(toggleIcon, size: 16, color: toggleColor),
                 ),
               ),
             ],
@@ -283,7 +337,6 @@ class _ProducerCard extends StatelessWidget {
           const Divider(color: Color(0xFFE2E8F0), height: 1),
           const SizedBox(height: 8),
 
-          // Dates
           Row(
             children: [
               _DateBadge(
@@ -298,7 +351,7 @@ class _ProducerCard extends StatelessWidget {
               const Spacer(),
               Container(
                 padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
                 decoration: BoxDecoration(
                   color: producer.active
                       ? AppColors.lightGreen.withOpacity(0.1)

--- a/lib/shared/widgets/confirm_dialog.dart
+++ b/lib/shared/widgets/confirm_dialog.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:ragro_mobile/core/theme/app_colors.dart';
+
+class ConfirmDialog extends StatelessWidget {
+  const ConfirmDialog({
+    super.key,
+    required this.title,
+    required this.confirmLabel,
+    required this.confirmColor,
+    this.cancelLabel = 'Cancelar',
+  });
+
+  final Widget title;
+  final String confirmLabel;
+  final Color confirmColor;
+  final String cancelLabel;
+
+  static Future<bool?> show({
+    required BuildContext context,
+    required Widget title,
+    required String confirmLabel,
+    required Color confirmColor,
+    String cancelLabel = 'Cancelar',
+  }) {
+    return showDialog<bool>(
+      context: context,
+      barrierColor: Colors.black.withOpacity(0.4),
+      builder: (_) => ConfirmDialog(
+        title: title,
+        confirmLabel: confirmLabel,
+        confirmColor: confirmColor,
+        cancelLabel: cancelLabel,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 40),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            DefaultTextStyle(
+              style: const TextStyle(
+                fontFamily: 'Figtree',
+                fontWeight: FontWeight.w600,
+                fontSize: 17,
+                color: AppColors.black,
+                height: 1.4,
+              ),
+              textAlign: TextAlign.center,
+              child: title,
+            ),
+            const SizedBox(height: 24),
+            _DialogButton(
+              label: confirmLabel,
+              color: confirmColor,
+              onTap: () => Navigator.of(context).pop(true),
+            ),
+            const SizedBox(height: 10),
+            _DialogButton(
+              label: cancelLabel,
+              color: AppColors.white,
+              textColor: AppColors.black,
+              border: Border.all(color: const Color(0xFFE2E8F0)),
+              onTap: () => Navigator.of(context).pop(false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DialogButton extends StatelessWidget {
+  const _DialogButton({
+    required this.label,
+    required this.color,
+    required this.onTap,
+    this.textColor = AppColors.white,
+    this.border,
+  });
+
+  final String label;
+  final Color color;
+  final Color textColor;
+  final BoxBorder? border;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 13),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(12),
+          border: border,
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: 'Manrope',
+            fontWeight: FontWeight.w700,
+            fontSize: 15,
+            color: textColor,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## O que mudou?
admin_producer_model.dart => Model de dados do produtor
activate_admin_producer.dart => Adiciona o usecase de ativação de produtor, espelhando o padrão do deactivate.
admin_producers_bloc.dart => Adiciona ActivateAdminProducer ao construtor, registra o handler on<AdminProducerActivated>
admin_producers_event.dart => Adiciona o evento de ativação de produtor ao sealed class de eventos.
admin_producers_page.dart => Substitui o botão de delete fixo por um toggle dinâmico — vermelho com ícone de lixeira quando ativo, verde com ícone de restore quando inativo. Adiciona modais de confirmação para ambas as ações.
confirm_dialog.dart => Modal de confirmação genérico reutilizável.

## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

Rode o projeto normalmente e logue como ADMIN para testar as mudanças.

## Screenshots / Gravações
<img width="469" height="342" alt="image" src="https://github.com/user-attachments/assets/6e743b1d-6b81-44ea-aa07-a9e178b75ce4" />
<img width="494" height="430" alt="image" src="https://github.com/user-attachments/assets/0e521554-1cab-4872-af39-294f199bde03" />
<img width="466" height="269" alt="image" src="https://github.com/user-attachments/assets/369a55bf-ebfd-49f6-a581-22f2f4f5e726" />

<!-- Se mudou algo visual, cole prints ou gravações aqui -->

Task
#164

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
