### PR TITLE
Feature Integrar paginas admin

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -22,6 +22,8 @@ import 'package:ragro_mobile/features/admin/data/repositories/admin_repository_i
     as _i780;
 import 'package:ragro_mobile/features/admin/domain/repositories/admin_repository.dart'
     as _i759;
+import 'package:ragro_mobile/features/admin/domain/usecases/activate_admin_producer.dart'
+    as _i671;
 import 'package:ragro_mobile/features/admin/domain/usecases/create_admin_producer.dart'
     as _i321;
 import 'package:ragro_mobile/features/admin/domain/usecases/deactivate_admin_producer.dart'
@@ -335,6 +337,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i456.UpdateCartItemQuantity>(
       () => _i456.UpdateCartItemQuantity(gh<_i830.CartRepository>()),
     );
+    gh.lazySingleton<_i671.ActivateAdminProducer>(
+      () => _i671.ActivateAdminProducer(gh<_i759.AdminRepository>()),
+    );
     gh.lazySingleton<_i321.CreateAdminProducer>(
       () => _i321.CreateAdminProducer(gh<_i759.AdminRepository>()),
     );
@@ -400,6 +405,13 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i127.ProductDetailRemoteDataSource>(),
       ),
     );
+    gh.factory<_i1056.AdminProducersBloc>(
+      () => _i1056.AdminProducersBloc(
+        gh<_i1054.GetAdminProducers>(),
+        gh<_i514.DeactivateAdminProducer>(),
+        gh<_i671.ActivateAdminProducer>(),
+      ),
+    );
     gh.lazySingleton<_i43.AuthRepository>(
       () => _i579.AuthRepositoryImpl(
         gh<_i201.AuthRemoteDataSource>(),
@@ -456,12 +468,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i894.SearchProducersAndProducts>(
       () => _i894.SearchProducersAndProducts(gh<_i38.SearchRepository>()),
-    );
-    gh.factory<_i1056.AdminProducersBloc>(
-      () => _i1056.AdminProducersBloc(
-        gh<_i1054.GetAdminProducers>(),
-        gh<_i514.DeactivateAdminProducer>(),
-      ),
     );
     gh.lazySingleton<_i47.GetConsumerProfile>(
       () => _i47.GetConsumerProfile(gh<_i810.ConsumerProfileRepository>()),

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -222,9 +222,6 @@ extension GetItInjectableX on _i174.GetIt {
       preResolve: true,
     );
     gh.lazySingleton<_i361.Dio>(() => networkModule.dio);
-    gh.lazySingleton<_i16.AdminRemoteDataSource>(
-      () => _i16.AdminRemoteDataSource(),
-    );
     gh.lazySingleton<_i488.CartLocalDatasource>(
       () => _i488.CartLocalDatasource(),
     );
@@ -316,9 +313,6 @@ extension GetItInjectableX on _i174.GetIt {
       ),
     );
     gh.factory<_i226.OrdersBloc>(() => _i226.OrdersBloc(gh<_i52.GetOrders>()));
-    gh.lazySingleton<_i759.AdminRepository>(
-      () => _i780.AdminRepositoryImpl(gh<_i16.AdminRemoteDataSource>()),
-    );
     gh.factory<_i1.ProducerOrdersBloc>(
       () => _i1.ProducerOrdersBloc(gh<_i935.GetProducerOrders>()),
     );
@@ -336,18 +330,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i456.UpdateCartItemQuantity>(
       () => _i456.UpdateCartItemQuantity(gh<_i830.CartRepository>()),
-    );
-    gh.lazySingleton<_i671.ActivateAdminProducer>(
-      () => _i671.ActivateAdminProducer(gh<_i759.AdminRepository>()),
-    );
-    gh.lazySingleton<_i321.CreateAdminProducer>(
-      () => _i321.CreateAdminProducer(gh<_i759.AdminRepository>()),
-    );
-    gh.lazySingleton<_i514.DeactivateAdminProducer>(
-      () => _i514.DeactivateAdminProducer(gh<_i759.AdminRepository>()),
-    );
-    gh.lazySingleton<_i1054.GetAdminProducers>(
-      () => _i1054.GetAdminProducers(gh<_i759.AdminRepository>()),
     );
     gh.factory<_i432.RateProducerBloc>(
       () => _i432.RateProducerBloc(gh<_i907.RateProducer>()),
@@ -370,6 +352,9 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i291.CreateInventoryProduct>(),
         gh<_i626.UpdateInventoryProduct>(),
       ),
+    );
+    gh.lazySingleton<_i16.AdminRemoteDataSource>(
+      () => _i16.AdminRemoteDataSource(gh<_i873.ApiClient>()),
     );
     gh.lazySingleton<_i201.AuthRemoteDataSource>(
       () => _i201.AuthRemoteDataSource(gh<_i873.ApiClient>()),
@@ -403,13 +388,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i818.ProductDetailRepository>(
       () => _i43.ProductDetailRepositoryImpl(
         gh<_i127.ProductDetailRemoteDataSource>(),
-      ),
-    );
-    gh.factory<_i1056.AdminProducersBloc>(
-      () => _i1056.AdminProducersBloc(
-        gh<_i1054.GetAdminProducers>(),
-        gh<_i514.DeactivateAdminProducer>(),
-        gh<_i671.ActivateAdminProducer>(),
       ),
     );
     gh.lazySingleton<_i43.AuthRepository>(
@@ -451,11 +429,11 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i740.ProductDetailBloc>(
       () => _i740.ProductDetailBloc(gh<_i680.GetProductDetail>()),
     );
+    gh.lazySingleton<_i759.AdminRepository>(
+      () => _i780.AdminRepositoryImpl(gh<_i16.AdminRemoteDataSource>()),
+    );
     gh.factory<_i192.RegisterBloc>(
       () => _i192.RegisterBloc(gh<_i852.RegisterConsumer>()),
-    );
-    gh.factory<_i846.AdminProducerFormBloc>(
-      () => _i846.AdminProducerFormBloc(gh<_i321.CreateAdminProducer>()),
     );
     gh.lazySingleton<_i841.CartBloc>(
       () => _i841.CartBloc(
@@ -474,6 +452,18 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i513.UpdateConsumerProfile>(
       () => _i513.UpdateConsumerProfile(gh<_i810.ConsumerProfileRepository>()),
+    );
+    gh.lazySingleton<_i671.ActivateAdminProducer>(
+      () => _i671.ActivateAdminProducer(gh<_i759.AdminRepository>()),
+    );
+    gh.lazySingleton<_i321.CreateAdminProducer>(
+      () => _i321.CreateAdminProducer(gh<_i759.AdminRepository>()),
+    );
+    gh.lazySingleton<_i514.DeactivateAdminProducer>(
+      () => _i514.DeactivateAdminProducer(gh<_i759.AdminRepository>()),
+    );
+    gh.lazySingleton<_i1054.GetAdminProducers>(
+      () => _i1054.GetAdminProducers(gh<_i759.AdminRepository>()),
     );
     gh.lazySingleton<_i420.ProducerProfileRepository>(
       () => _i86.ProducerProfileRepositoryImpl(
@@ -500,11 +490,21 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i856.SearchBloc(gh<_i894.SearchProducersAndProducts>()),
     );
     gh.factory<_i151.HomeBloc>(() => _i151.HomeBloc(gh<_i159.GetHomeData>()));
+    gh.factory<_i1056.AdminProducersBloc>(
+      () => _i1056.AdminProducersBloc(
+        gh<_i1054.GetAdminProducers>(),
+        gh<_i514.DeactivateAdminProducer>(),
+        gh<_i671.ActivateAdminProducer>(),
+      ),
+    );
     gh.lazySingleton<_i1031.GetProducerProfile>(
       () => _i1031.GetProducerProfile(gh<_i420.ProducerProfileRepository>()),
     );
     gh.lazySingleton<_i419.AppRouter>(
       () => _i419.AppRouter(gh<_i475.AuthBloc>()),
+    );
+    gh.factory<_i846.AdminProducerFormBloc>(
+      () => _i846.AdminProducerFormBloc(gh<_i321.CreateAdminProducer>()),
     );
     gh.factory<_i756.ProducerProfileBloc>(
       () => _i756.ProducerProfileBloc(gh<_i1031.GetProducerProfile>()),

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -37,6 +37,7 @@ class _ErrorInterceptor extends Interceptor {
         404 => const NotFoundException(),
         409 => const ConflictException(),
         429 => const RateLimitedException(),
+        403 => const ForbiddenException(),
         >= 500 => const ServerException(),
         _ => const UnknownApiException(),
       };

--- a/lib/core/network/api_exception.dart
+++ b/lib/core/network/api_exception.dart
@@ -39,3 +39,7 @@ class UnknownApiException extends ApiException {
 class InvalidCredentialsApiException extends ApiException {
   const InvalidCredentialsApiException([super.message = 'E-mail ou senha inválidos']);
 }
+
+class ForbiddenException extends ApiException {
+  const ForbiddenException([super.message = 'Sua conta está desativada. Entre em contato com o suporte.']);
+}

--- a/lib/features/admin/data/Models/admin_producer_model.dart
+++ b/lib/features/admin/data/Models/admin_producer_model.dart
@@ -10,6 +10,9 @@ class AdminProducerModel extends AdminProducer {
     required super.createdAt,
     required super.updatedAt,
     required super.active,
+    required super.fiscalNumber,
+    required super.fiscalNumberType,
+    required super.farmName,
   });
 
   factory AdminProducerModel.fromJson(Map<String, dynamic> json) {
@@ -22,6 +25,9 @@ class AdminProducerModel extends AdminProducer {
       createdAt: DateTime.parse(json['createdAt'] as String ?? DateTime.now().toIso8601String()),
       updatedAt: DateTime.parse(json['updatedAt'] as String ?? DateTime.now().toIso8601String()),
       active: json['active'] as bool,
+      fiscalNumber: json['fiscalNumber'] as String? ?? '',
+      fiscalNumberType: json['fiscalNumberType'] as String? ?? '',
+      farmName: json['farmName'] as String? ?? '',
     );
   }
 
@@ -35,6 +41,9 @@ class AdminProducerModel extends AdminProducer {
       'createdAt': createdAt.toIso8601String(),
       'updatedAt': updatedAt.toIso8601String(),
       'active': active,
+      'fiscalNumber': fiscalNumber,
+      'fiscalNumberType': fiscalNumberType,
+      'farmName': farmName,
     };
   }
 
@@ -48,6 +57,9 @@ class AdminProducerModel extends AdminProducer {
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
       active: entity.active,
+      fiscalNumber: entity.fiscalNumber,
+      fiscalNumberType: entity.fiscalNumberType,
+      farmName: entity.farmName,
     );
   }
 }

--- a/lib/features/admin/data/Models/admin_producer_model.dart
+++ b/lib/features/admin/data/Models/admin_producer_model.dart
@@ -5,7 +5,7 @@ class AdminProducerModel extends AdminProducer {
     required super.id,
     required super.name,
     required super.email,
-    required super.location,
+    required super.phone,
     required super.address,
     required super.createdAt,
     required super.updatedAt,
@@ -14,14 +14,40 @@ class AdminProducerModel extends AdminProducer {
 
   factory AdminProducerModel.fromJson(Map<String, dynamic> json) {
     return AdminProducerModel(
-      id: json['id'] as String,
-      name: json['name'] as String,
-      email: json['email'] as String,
-      location: json['location'] as String,
-      address: json['address'] as String,
-      createdAt: DateTime.parse(json['createdAt'] as String),
-      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      id: json['id'] as String ?? '',
+      name: json['name'] as String ?? '',
+      email: json['email'] as String ?? '',
+      phone: json['phone'] as String ?? '',
+      address: json['address'] as String ?? '',
+      createdAt: DateTime.parse(json['createdAt'] as String ?? DateTime.now().toIso8601String()),
+      updatedAt: DateTime.parse(json['updatedAt'] as String ?? DateTime.now().toIso8601String()),
       active: json['active'] as bool,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'email': email,
+      'phone': phone,
+      'address': address,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+      'active': active,
+    };
+  }
+
+  factory AdminProducerModel.fromEntity(AdminProducer entity) {
+    return AdminProducerModel(
+      id: entity.id,
+      name: entity.name,
+      email: entity.email,
+      phone: entity.phone,
+      address: entity.address,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      active: entity.active,
     );
   }
 }

--- a/lib/features/admin/data/Models/admin_producer_model.dart
+++ b/lib/features/admin/data/Models/admin_producer_model.dart
@@ -1,0 +1,28 @@
+import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart';
+
+class AdminProducerModel extends AdminProducer {
+  const AdminProducerModel({
+    required super.id,
+    required super.name,
+    required super.email,
+    required super.location,
+    required super.address,
+    required super.createdAt,
+    required super.updatedAt,
+    required super.active,
+  });
+
+  factory AdminProducerModel.fromJson(Map<String, dynamic> json) {
+    return AdminProducerModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      email: json['email'] as String,
+      location: json['location'] as String,
+      address: json['address'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      active: json['active'] as bool,
+    );
+  }
+}
+

--- a/lib/features/admin/data/datasources/admin_remote_datasource.dart
+++ b/lib/features/admin/data/datasources/admin_remote_datasource.dart
@@ -5,6 +5,7 @@ import 'package:ragro_mobile/core/network/api_endpoints.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart';
 import 'package:ragro_mobile/features/admin/data/models/admin_producer_model.dart';
+import 'package:ragro_mobile/features/admin/domain/entities/admin_availability.dart';
 
 @lazySingleton
 class AdminRemoteDataSource {
@@ -26,12 +27,22 @@ class AdminRemoteDataSource {
 
   Future<void> createProducer(AdminProducer producer, String password) async {
     try {
-      final model = AdminProducerModel.fromEntity(producer);
-      await _apiClient.dio.post<void>(
+      await _apiClient.dio.post(
         ApiEndpoints.adminProducers,
         data: {
-          ...model.toJson(),
+          'name': producer.name,
+          'email': producer.email,
+          'phone': producer.phone,
           'password': password,
+          'fiscalNumber': producer.fiscalNumber,
+          'fiscalNumberType': producer.fiscalNumberType,
+          'farmName': producer.farmName,
+          'address': producer.producerAddress!.toJson(),
+          if (producer.bankAccount != null)
+            'bankAccount': producer.bankAccount!.toJson(),
+          if (producer.availability != null && producer.availability!.isNotEmpty)
+            'availability': producer.availability!
+                .map((a) => (a as AdminAvailability).toJson()).toList(),
         },
       );
     } on DioException catch (e) {

--- a/lib/features/admin/data/datasources/admin_remote_datasource.dart
+++ b/lib/features/admin/data/datasources/admin_remote_datasource.dart
@@ -1,151 +1,61 @@
+import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/network/api_client.dart';
+import 'package:ragro_mobile/core/network/api_endpoints.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart';
+import 'package:ragro_mobile/features/admin/data/models/admin_producer_model.dart';
 
 @lazySingleton
 class AdminRemoteDataSource {
-  static final _baseDate = DateTime(2026, 3, 24);
+  const AdminRemoteDataSource(this._apiClient);
+  final ApiClient _apiClient;
 
-  static final List<AdminProducer> _mockProducers = [
-    AdminProducer(
-      id: 'ap001',
-      name: 'Ricardo Oliveira',
-      email: 'ricardo.oliveira@ragro.com.br',
-      location: 'Porto Alegre, RS',
-      address: 'Rua das Flores, 123, Porto Alegre, RS',
-      createdAt: _baseDate,
-      updatedAt: _baseDate,
-      active: true,
-    ),
-    AdminProducer(
-      id: 'ap002',
-      name: 'Matheus Silva',
-      email: 'matheus.silva@ragro.com.br',
-      location: 'Porto Alegre, RS',
-      address: 'Av. Independência, 456, Porto Alegre, RS',
-      createdAt: _baseDate,
-      updatedAt: _baseDate,
-      active: true,
-    ),
-    AdminProducer(
-      id: 'ap003',
-      name: 'Giovana Duarte',
-      email: 'giovana.duarte@ragro.com.br',
-      location: 'Porto Alegre, RS',
-      address: 'Rua Osvaldo Aranha, 789, Porto Alegre, RS',
-      createdAt: _baseDate,
-      updatedAt: _baseDate,
-      active: true,
-    ),
-    AdminProducer(
-      id: 'ap004',
-      name: 'Antônio Madeira',
-      email: 'antonio.madeira@ragro.com.br',
-      location: 'Porto Alegre, RS',
-      address: 'Rua 24 de Outubro, 200, Porto Alegre, RS',
-      createdAt: _baseDate,
-      updatedAt: _baseDate,
-      active: true,
-    ),
-  ];
-
-  /// Gets all producers for admin management.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future<List<AdminProducer>> getProducers() async {
-  ///   try {
-  ///     final response = await _apiClient.dio.get<Map<String, dynamic>>(
-  ///       ApiEndpoints.adminProducers,
-  ///     );
-  ///     return (response.data!['data'] as List)
-  ///         .map((e) => AdminProducer.fromJson(e as Map<String, dynamic>))
-  ///         .toList();
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<List<AdminProducer>> getProducers() async {
-    await Future.delayed(const Duration(milliseconds: 400));
-    return List.from(_mockProducers);
-  }
-
-  /// Creates a new producer account.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future<void> createProducer(AdminProducer producer, String password) async {
-  ///   try {
-  ///     await _apiClient.dio.post<void>(
-  ///       ApiEndpoints.adminProducers,
-  ///       data: {
-  ///         ...producer.toJson(),
-  ///         'password': password,
-  ///       },
-  ///     );
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
-  Future<void> createProducer(AdminProducer producer, String password) async {
-    await Future.delayed(const Duration(milliseconds: 400));
-    _mockProducers.add(producer);
-  }
-
-  /// Deactivates a producer account.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future<void> deactivateProducer(String id) async {
-  ///   try {
-  ///     await _apiClient.dio.patch<void>(
-  ///       '${ApiEndpoints.adminProducer(id)}/deactivate',
-  ///     );
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
-  Future<void> deactivateProducer(String id) async {
-    await Future.delayed(const Duration(milliseconds: 300));
-    final idx = _mockProducers.indexWhere((p) => p.id == id);
-    if (idx >= 0) {
-      _mockProducers[idx] = _mockProducers[idx].copyWith(active: false);
+    try {
+      final response = await _apiClient.dio.get<List<dynamic>>(
+        ApiEndpoints.adminProducers,
+      );
+      return (response.data!)
+          .map((e) => AdminProducerModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
     }
   }
 
-  /// Activates a previously deactivated producer account.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future<void> activateProducer(String id) async {
-  ///   try {
-  ///     await _apiClient.dio.patch<void>(
-  ///       '${ApiEndpoints.adminProducer(id)}/activate',
-  ///     );
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
+  Future<void> createProducer(AdminProducer producer, String password) async {
+    try {
+      final model = AdminProducerModel.fromEntity(producer);
+      await _apiClient.dio.post<void>(
+        ApiEndpoints.adminProducers,
+        data: {
+          ...model.toJson(),
+          'password': password,
+        },
+      );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  Future<void> deactivateProducer(String id) async {
+    try {
+      await _apiClient.dio.patch<void>(
+        '${ApiEndpoints.adminProducer(id)}/deactivate',
+      );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
   Future<void> activateProducer(String id) async {
-    await Future.delayed(const Duration(milliseconds: 300));
-    final idx = _mockProducers.indexWhere((p) => p.id == id);
-    if (idx >= 0) {
-      _mockProducers[idx] = _mockProducers[idx].copyWith(active: true);
+    try {
+      await _apiClient.dio.patch<void>(
+        '${ApiEndpoints.adminProducer(id)}/activate',
+      );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
     }
   }
 }

--- a/lib/features/admin/domain/entities/admin_address.dart
+++ b/lib/features/admin/domain/entities/admin_address.dart
@@ -1,0 +1,40 @@
+import 'package:equatable/equatable.dart';
+
+class AdminAddress extends Equatable {
+  const AdminAddress({
+    required this.street,
+    required this.number,
+    required this.city,
+    required this.state,
+    required this.zipCode,
+    this.complement,
+    this.neighborhood,
+    this.latitude,
+    this.longitude,
+  });
+
+  final String street;
+  final String number;
+  final String city;
+  final String state;
+  final String zipCode;
+  final String? complement;
+  final String? neighborhood;
+  final double? latitude;
+  final double? longitude;
+
+  Map<String, dynamic> toJson() => {
+    'street': street,
+    'number': number,
+    'city': city,
+    'state': state,
+    'zipCode': zipCode,
+    if (complement != null) 'complement': complement,
+    if (neighborhood != null) 'neighborhood': neighborhood,
+    if (latitude != null) 'latitude': latitude,
+    if (longitude != null) 'longitude': longitude,
+  };
+
+  @override
+  List<Object?> get props => [street, number, city, state, zipCode];
+}

--- a/lib/features/admin/domain/entities/admin_availability.dart
+++ b/lib/features/admin/domain/entities/admin_availability.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+
+class AdminAvailability extends Equatable {
+  const AdminAvailability({
+    required this.weekday,
+    required this.opensAt,
+    required this.closesAt,
+  });
+
+  final int weekday;
+  final String opensAt;
+  final String closesAt;
+
+  Map<String, dynamic> toJson() => {
+    'weekday': weekday,
+    'opensAt': opensAt,
+    'closesAt': closesAt,
+  };
+
+  @override
+  List<Object?> get props => [weekday, opensAt, closesAt];
+}

--- a/lib/features/admin/domain/entities/admin_bank_account.dart
+++ b/lib/features/admin/domain/entities/admin_bank_account.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+
+class AdminBankAccount extends Equatable {
+  const AdminBankAccount({
+    required this.bankName,
+    required this.agency,
+    required this.accountNumber,
+    required this.holderName,
+    required this.fiscalNumber,
+    this.bankCode,
+  });
+
+  final String bankName;
+  final String agency;
+  final String accountNumber;
+  final String holderName;
+  final String fiscalNumber;
+  final String? bankCode;
+
+  Map<String, dynamic> toJson() => {
+    'bankName': bankName,
+    'agency': agency,
+    'accountNumber': accountNumber,
+    'holderName': holderName,
+    'fiscalNumber': fiscalNumber.replaceAll(RegExp(r'\D'), ''),
+    if (bankCode != null) 'bankCode': bankCode,
+  };
+
+  @override
+  List<Object?> get props => [bankName, agency, accountNumber, holderName, fiscalNumber];
+}

--- a/lib/features/admin/domain/entities/admin_producer.dart
+++ b/lib/features/admin/domain/entities/admin_producer.dart
@@ -5,7 +5,7 @@ class AdminProducer extends Equatable {
     required this.id,
     required this.name,
     required this.email,
-    required this.location,
+    required this.phone,
     required this.address,
     required this.createdAt,
     required this.updatedAt,
@@ -15,7 +15,7 @@ class AdminProducer extends Equatable {
   final String id;
   final String name;
   final String email;
-  final String location;
+  final String phone;
   final String address;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -26,7 +26,7 @@ class AdminProducer extends Equatable {
       id: id,
       name: name,
       email: email,
-      location: location,
+      phone: phone,
       address: address,
       createdAt: createdAt,
       updatedAt: updatedAt,
@@ -36,5 +36,5 @@ class AdminProducer extends Equatable {
 
   @override
   List<Object?> get props =>
-      [id, name, email, location, address, createdAt, updatedAt, active];
+      [id, name, email, phone, address, createdAt, updatedAt, active];
 }

--- a/lib/features/admin/domain/entities/admin_producer.dart
+++ b/lib/features/admin/domain/entities/admin_producer.dart
@@ -1,4 +1,7 @@
 import 'package:equatable/equatable.dart';
+import 'package:ragro_mobile/features/admin/domain/entities/admin_bank_account.dart';
+import 'package:ragro_mobile/features/admin/domain/entities/admin_availability.dart';
+import 'package:ragro_mobile/features/admin/domain/entities/admin_address.dart';
 
 class AdminProducer extends Equatable {
   const AdminProducer({
@@ -10,6 +13,12 @@ class AdminProducer extends Equatable {
     required this.createdAt,
     required this.updatedAt,
     required this.active,
+    required this.fiscalNumber,
+    required this.fiscalNumberType,
+    required this.farmName,
+    this.producerAddress,
+    this.bankAccount,
+    this.availability,
   });
 
   final String id;
@@ -20,6 +29,12 @@ class AdminProducer extends Equatable {
   final DateTime createdAt;
   final DateTime updatedAt;
   final bool active;
+  final String fiscalNumber;
+  final String fiscalNumberType;
+  final String farmName;
+  final AdminAddress? producerAddress;
+  final AdminBankAccount? bankAccount;
+  final List<AdminAvailability>? availability;
 
   AdminProducer copyWith({bool? active}) {
     return AdminProducer(
@@ -31,10 +46,17 @@ class AdminProducer extends Equatable {
       createdAt: createdAt,
       updatedAt: updatedAt,
       active: active ?? this.active,
+      fiscalNumber: fiscalNumber ?? this.fiscalNumber,
+      fiscalNumberType: fiscalNumberType,
+      farmName: farmName ?? this.farmName,
+      producerAddress: producerAddress,
+      bankAccount: bankAccount,
+      availability: availability,
     );
   }
 
   @override
   List<Object?> get props =>
-      [id, name, email, phone, address, createdAt, updatedAt, active];
+      [id, name, email, phone, address, createdAt, updatedAt,
+        active, fiscalNumber, fiscalNumberType, farmName,];
 }

--- a/lib/features/admin/domain/usecases/activate_admin_producer.dart
+++ b/lib/features/admin/domain/usecases/activate_admin_producer.dart
@@ -1,0 +1,11 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/admin/domain/repositories/admin_repository.dart';
+
+@lazySingleton
+class ActivateAdminProducer {
+  const ActivateAdminProducer(this._repository);
+
+  final AdminRepository _repository;
+
+  Future<void> call(String id) => _repository.activateProducer(id);
+}

--- a/lib/features/admin/presentation/bloc/admin_producer_form_bloc.dart
+++ b/lib/features/admin/presentation/bloc/admin_producer_form_bloc.dart
@@ -25,7 +25,7 @@ class AdminProducerFormBloc
         id: DateTime.now().millisecondsSinceEpoch.toString(),
         name: event.name,
         email: event.email,
-        location: '${event.city}, ${event.state}',
+        phone: event.phone,
         address: '${event.address}, ${event.city}, ${event.state}',
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),

--- a/lib/features/admin/presentation/bloc/admin_producer_form_bloc.dart
+++ b/lib/features/admin/presentation/bloc/admin_producer_form_bloc.dart
@@ -4,6 +4,9 @@ import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart'
 import 'package:ragro_mobile/features/admin/domain/usecases/create_admin_producer.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producer_form_event.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producer_form_state.dart';
+import 'package:ragro_mobile/features/admin/domain/entities/admin_address.dart';
+import 'package:ragro_mobile/features/admin/domain/entities/admin_availability.dart';
+import 'package:ragro_mobile/features/admin/domain/entities/admin_bank_account.dart';
 
 @injectable
 class AdminProducerFormBloc
@@ -21,6 +24,16 @@ class AdminProducerFormBloc
   ) async {
     emit(const AdminProducerFormLoading());
     try {
+      final selectedDays = <AdminAvailability>[];
+      for (int i = 0; i < event.scheduleWeekdays.length; i++) {
+        if (event.scheduleWeekdays[i]) {
+          selectedDays.add(AdminAvailability(
+            weekday: i == 6 ? 0 : i + 1,
+            opensAt: event.scheduleStart,
+            closesAt: event.scheduleEnd,
+          ));
+        }
+      }
       final producer = AdminProducer(
         id: DateTime.now().millisecondsSinceEpoch.toString(),
         name: event.name,
@@ -30,6 +43,24 @@ class AdminProducerFormBloc
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),
         active: true,
+        fiscalNumber: event.fiscalNumber,
+        fiscalNumberType: event.fiscalNumberType,
+        farmName: event.farmName,
+        producerAddress: AdminAddress(
+          street: event.address,
+          number: event.number,
+          city: event.city,
+          state: event.state,
+          zipCode: event.cep.replaceAll(RegExp(r'\D'), ''),
+        ),
+        bankAccount: event.bank.isNotEmpty ? AdminBankAccount(
+        bankName: event.bank,
+        agency: event.agency,
+        accountNumber: event.account,
+        holderName: event.accountHolder,
+        fiscalNumber: event.fiscalNumber,
+        ) : null,
+        availability: selectedDays.isNotEmpty ? selectedDays : null,
       );
       await _createProducer(producer, event.password);
       emit(const AdminProducerFormSuccess());

--- a/lib/features/admin/presentation/bloc/admin_producer_form_event.dart
+++ b/lib/features/admin/presentation/bloc/admin_producer_form_event.dart
@@ -15,11 +15,14 @@ class AdminProducerFormSubmitted extends AdminProducerFormEvent {
     required this.address,
     required this.city,
     required this.state,
+    required this.number,
     required this.bank,
     required this.agency,
     required this.account,
     required this.accountHolder,
-    required this.cpfCnpj,
+    required this.fiscalNumber,
+    required this.fiscalNumberType,
+    required this.farmName,
     required this.password,
     required this.scheduleWeekdays,
     required this.scheduleStart,
@@ -33,16 +36,20 @@ class AdminProducerFormSubmitted extends AdminProducerFormEvent {
   final String address;
   final String city;
   final String state;
+  final String number;
   final String bank;
   final String agency;
   final String account;
   final String accountHolder;
-  final String cpfCnpj;
+  final String fiscalNumber;
+  final String fiscalNumberType;
+  final String farmName;
   final String password;
   final List<bool> scheduleWeekdays;
   final String scheduleStart;
   final String scheduleEnd;
 
   @override
-  List<Object?> get props => [name, email, phone];
+  List<Object?> get props => [name, email, phone, address, city, state, number, password,
+    fiscalNumber, fiscalNumberType, farmName,];
 }

--- a/lib/features/admin/presentation/bloc/admin_producers_bloc.dart
+++ b/lib/features/admin/presentation/bloc/admin_producers_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/admin/domain/usecases/activate_admin_producer.dart';
 import 'package:ragro_mobile/features/admin/domain/usecases/deactivate_admin_producer.dart';
 import 'package:ragro_mobile/features/admin/domain/usecases/get_admin_producers.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_event.dart';
@@ -8,15 +9,17 @@ import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_st
 @injectable
 class AdminProducersBloc
     extends Bloc<AdminProducersEvent, AdminProducersState> {
-  AdminProducersBloc(this._getProducers, this._deactivate)
+  AdminProducersBloc(this._getProducers, this._deactivate, this._activate)
       : super(const AdminProducersInitial()) {
     on<AdminProducersStarted>(_onStarted);
     on<AdminProducerDeactivated>(_onDeactivated);
     on<AdminProducersRefreshed>(_onRefreshed);
+    on<AdminProducerActivated>(_onActivated);
   }
 
   final GetAdminProducers _getProducers;
   final DeactivateAdminProducer _deactivate;
+  final ActivateAdminProducer _activate;
 
   Future<void> _onStarted(
     AdminProducersStarted event,
@@ -37,6 +40,19 @@ class AdminProducersBloc
   ) async {
     try {
       await _deactivate(event.producerId);
+      final producers = await _getProducers();
+      emit(AdminProducersLoaded(producers));
+    } catch (e) {
+      emit(AdminProducersFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onActivated(
+      AdminProducerActivated event,
+      Emitter<AdminProducersState> emit,
+      ) async {
+    try {
+      await _activate(event.producerId);
       final producers = await _getProducers();
       emit(AdminProducersLoaded(producers));
     } catch (e) {

--- a/lib/features/admin/presentation/bloc/admin_producers_event.dart
+++ b/lib/features/admin/presentation/bloc/admin_producers_event.dart
@@ -17,6 +17,14 @@ class AdminProducerDeactivated extends AdminProducersEvent {
   List<Object?> get props => [producerId];
 }
 
+class AdminProducerActivated extends AdminProducersEvent {
+  const AdminProducerActivated(this.producerId);
+  final String producerId;
+  @override
+  List<Object?> get props => [producerId];
+}
+
+
 class AdminProducersRefreshed extends AdminProducersEvent {
   const AdminProducersRefreshed();
 }

--- a/lib/features/admin/presentation/pages/admin_create_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_create_producer_page.dart
@@ -45,7 +45,9 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
   final _accountController = TextEditingController();
   final _holderController = TextEditingController();
   final _cpfCnpjController = TextEditingController();
+  final _farmNameController = TextEditingController();
   final _passwordController = TextEditingController();
+  final _numberController = TextEditingController();
   final _scheduleStartController = TextEditingController(text: '08:00');
   final _scheduleEndController = TextEditingController(text: '18:00');
 
@@ -73,6 +75,8 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
     _passwordController.dispose();
     _scheduleStartController.dispose();
     _scheduleEndController.dispose();
+    _farmNameController.dispose();
+    _numberController.dispose();
     super.dispose();
   }
 
@@ -86,6 +90,10 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
       );
       return;
     }
+
+    final cleanFiscal = _cpfCnpjController.text.replaceAll(RegExp(r'[^0-9]'), '');
+    final type = cleanFiscal.length <= 11 ? 'CPF' : 'CNPJ';
+
     if (_nameController.text.trim().isEmpty ||
         _emailController.text.trim().isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -103,13 +111,16 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
             phone: _phoneController.text.trim(),
             cep: _cepController.text.trim(),
             address: _addressController.text.trim(),
+            number: _numberController.text.trim(),
             city: _cityController.text.trim(),
             state: _stateController.text.trim(),
             bank: _bankController.text.trim(),
             agency: _agencyController.text.trim(),
             account: _accountController.text.trim(),
             accountHolder: _holderController.text.trim(),
-            cpfCnpj: _cpfCnpjController.text.trim(),
+            fiscalNumber: cleanFiscal,
+            fiscalNumberType: type,
+            farmName: _farmNameController.text.trim(),
             password: _passwordController.text.trim(),
             scheduleWeekdays: List.from(_weekdays),
             scheduleStart: _scheduleStartController.text.trim(),
@@ -198,6 +209,13 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                     hint: 'Senha de acesso',
                     obscure: true,
                     enabled: !isLoading),
+                const SizedBox(height: 12),
+                _FieldLabel('Nome da Fazenda'),
+                const SizedBox(height: 8),
+                _TextField(
+                    controller: _farmNameController,
+                    hint: 'Ex: Fazenda Santa Luzia',
+                    enabled: !isLoading),
 
                 const SizedBox(height: 20),
                 _sectionTitle('Endereço'),
@@ -212,10 +230,27 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                 const SizedBox(height: 12),
                 _FieldLabel('Endereço'),
                 const SizedBox(height: 8),
-                _TextField(
-                    controller: _addressController,
-                    hint: 'Rua, número, bairro',
-                    enabled: !isLoading),
+                Row(
+                  children: [
+                    Expanded(
+                      flex: 3,
+                      child: _TextField(
+                        controller: _addressController,
+                        hint: 'Rua / Avenida',
+                        enabled: !isLoading,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _TextField(
+                        controller: _numberController,
+                        hint: 'Nº',
+                        keyboardType: TextInputType.number,
+                        enabled: !isLoading,
+                      ),
+                    ),
+                  ],
+                ),
                 const SizedBox(height: 12),
                 Row(
                   children: [

--- a/lib/features/admin/presentation/pages/admin_producers_page.dart
+++ b/lib/features/admin/presentation/pages/admin_producers_page.dart
@@ -12,6 +12,7 @@ import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart'
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_bloc.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_event.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_state.dart';
+import 'package:ragro_mobile/shared/widgets/confirm_dialog.dart';
 
 class AdminProducersPage extends StatelessWidget {
   const AdminProducersPage({super.key});
@@ -20,7 +21,7 @@ class AdminProducersPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) =>
-          getIt<AdminProducersBloc>()..add(const AdminProducersStarted()),
+      getIt<AdminProducersBloc>()..add(const AdminProducersStarted()),
       child: const _AdminProducersView(),
     );
   }
@@ -85,16 +86,14 @@ class _AdminProducersView extends StatelessWidget {
                       final producer = state.producers[index];
                       return _ProducerCard(
                         producer: producer,
-                        onDelete: () => _confirmDeactivate(
-                          context,
-                          producer.id,
-                          producer.name,
-                        ),
+                        onToggleActive: () => producer.active
+                            ? _confirmDeactivate(context, producer)
+                            : _confirmActivate(context, producer),
                         onEdit: () {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
                               content:
-                                  Text('Editar ${producer.name} — em breve'),
+                              Text('Editar ${producer.name} — em breve'),
                             ),
                           );
                         },
@@ -139,41 +138,99 @@ class _AdminProducersView extends StatelessWidget {
     );
   }
 
-  void _confirmDeactivate(
-      BuildContext context, String producerId, String producerName) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Desativar "$producerName"?'),
-        action: SnackBarAction(
-          label: 'Confirmar',
-          textColor: AppColors.white,
-          onPressed: () {
-            context
-                .read<AdminProducersBloc>()
-                .add(AdminProducerDeactivated(producerId));
-          },
+  Future<void> _confirmDeactivate(
+      BuildContext context, AdminProducer producer) async {
+    final confirmed = await ConfirmDialog.show(
+      context: context,
+      title: RichText(
+        textAlign: TextAlign.center,
+        text: TextSpan(
+          style: const TextStyle(
+            fontFamily: 'Figtree',
+            fontWeight: FontWeight.w600,
+            fontSize: 17,
+            color: AppColors.black,
+            height: 1.4,
+          ),
+          children: [
+            const TextSpan(text: 'Tem certeza que deseja\ndesativar '),
+            TextSpan(
+              text: producer.name,
+              style: const TextStyle(color: AppColors.red),
+            ),
+            const TextSpan(text: '?'),
+          ],
         ),
-        backgroundColor: AppColors.red,
       ),
+      confirmLabel: 'Desativar',
+      confirmColor: AppColors.red,
     );
+
+    if (confirmed == true && context.mounted) {
+      context
+          .read<AdminProducersBloc>()
+          .add(AdminProducerDeactivated(producer.id));
+    }
+  }
+
+  Future<void> _confirmActivate(
+      BuildContext context, AdminProducer producer) async {
+    final confirmed = await ConfirmDialog.show(
+      context: context,
+      title: RichText(
+        textAlign: TextAlign.center,
+        text: TextSpan(
+          style: const TextStyle(
+            fontFamily: 'Figtree',
+            fontWeight: FontWeight.w600,
+            fontSize: 17,
+            color: AppColors.black,
+            height: 1.4,
+          ),
+          children: [
+            const TextSpan(text: 'Tem certeza que deseja\nativar '),
+            TextSpan(
+              text: producer.name,
+              style: const TextStyle(color: AppColors.darkGreen),
+            ),
+            const TextSpan(text: '?'),
+          ],
+        ),
+      ),
+      confirmLabel: 'Ativar',
+      confirmColor: AppColors.darkGreen,
+    );
+
+    if (confirmed == true && context.mounted) {
+      context
+          .read<AdminProducersBloc>()
+          .add(AdminProducerActivated(producer.id));
+    }
   }
 }
 
 class _ProducerCard extends StatelessWidget {
   const _ProducerCard({
     required this.producer,
-    required this.onDelete,
+    required this.onToggleActive,
     required this.onEdit,
   });
 
   final AdminProducer producer;
-  final VoidCallback onDelete;
+  final VoidCallback onToggleActive;
   final VoidCallback onEdit;
 
   @override
   Widget build(BuildContext context) {
     String fmtDate(DateTime d) =>
         '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}/${d.year}';
+
+    final toggleColor =
+    producer.active ? AppColors.red : AppColors.darkGreen;
+    final toggleIcon = producer.active
+        ? Icons.delete_outline
+        : Icons.restore;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -191,7 +248,6 @@ class _ProducerCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Name + action buttons row
           Row(
             children: [
               Expanded(
@@ -219,17 +275,15 @@ class _ProducerCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 8),
-              // Delete
               GestureDetector(
-                onTap: onDelete,
+                onTap: onToggleActive,
                 child: Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
-                    color: AppColors.red.withOpacity(0.1),
+                    color: toggleColor.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(8),
                   ),
-                  child: const Icon(Icons.delete_outline,
-                      size: 16, color: AppColors.red),
+                  child: Icon(toggleIcon, size: 16, color: toggleColor),
                 ),
               ),
             ],
@@ -283,7 +337,6 @@ class _ProducerCard extends StatelessWidget {
           const Divider(color: Color(0xFFE2E8F0), height: 1),
           const SizedBox(height: 8),
 
-          // Dates
           Row(
             children: [
               _DateBadge(
@@ -298,7 +351,7 @@ class _ProducerCard extends StatelessWidget {
               const Spacer(),
               Container(
                 padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
                 decoration: BoxDecoration(
                   color: producer.active
                       ? AppColors.lightGreen.withOpacity(0.1)

--- a/lib/features/admin/presentation/pages/admin_producers_page.dart
+++ b/lib/features/admin/presentation/pages/admin_producers_page.dart
@@ -113,7 +113,12 @@ class _AdminProducersView extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: ElevatedButton.icon(
-              onPressed: () => context.push('/admin/producers/new'),
+                onPressed: () async {
+                  await context.push('/admin/producers/new');
+                  if (context.mounted) {
+                    context.read<AdminProducersBloc>().add(const AdminProducersStarted());
+                  }
+                },
               icon: const Icon(Icons.add, size: 18),
               label: const Text(
                 'Novo produtor',

--- a/lib/features/admin/presentation/pages/admin_producers_page.dart
+++ b/lib/features/admin/presentation/pages/admin_producers_page.dart
@@ -116,7 +116,7 @@ class _AdminProducersView extends StatelessWidget {
               onPressed: () => context.push('/admin/producers/new'),
               icon: const Icon(Icons.add, size: 18),
               label: const Text(
-                '+ Novo produtor',
+                'Novo produtor',
                 style: TextStyle(
                   fontFamily: 'Manrope',
                   fontWeight: FontWeight.w700,

--- a/lib/shared/widgets/confirm_dialog.dart
+++ b/lib/shared/widgets/confirm_dialog.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:ragro_mobile/core/theme/app_colors.dart';
+
+class ConfirmDialog extends StatelessWidget {
+  const ConfirmDialog({
+    super.key,
+    required this.title,
+    required this.confirmLabel,
+    required this.confirmColor,
+    this.cancelLabel = 'Cancelar',
+  });
+
+  final Widget title;
+  final String confirmLabel;
+  final Color confirmColor;
+  final String cancelLabel;
+
+  static Future<bool?> show({
+    required BuildContext context,
+    required Widget title,
+    required String confirmLabel,
+    required Color confirmColor,
+    String cancelLabel = 'Cancelar',
+  }) {
+    return showDialog<bool>(
+      context: context,
+      barrierColor: Colors.black.withOpacity(0.4),
+      builder: (_) => ConfirmDialog(
+        title: title,
+        confirmLabel: confirmLabel,
+        confirmColor: confirmColor,
+        cancelLabel: cancelLabel,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 40),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            DefaultTextStyle(
+              style: const TextStyle(
+                fontFamily: 'Figtree',
+                fontWeight: FontWeight.w600,
+                fontSize: 17,
+                color: AppColors.black,
+                height: 1.4,
+              ),
+              textAlign: TextAlign.center,
+              child: title,
+            ),
+            const SizedBox(height: 24),
+            _DialogButton(
+              label: confirmLabel,
+              color: confirmColor,
+              onTap: () => Navigator.of(context).pop(true),
+            ),
+            const SizedBox(height: 10),
+            _DialogButton(
+              label: cancelLabel,
+              color: AppColors.white,
+              textColor: AppColors.black,
+              border: Border.all(color: const Color(0xFFE2E8F0)),
+              onTap: () => Navigator.of(context).pop(false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DialogButton extends StatelessWidget {
+  const _DialogButton({
+    required this.label,
+    required this.color,
+    required this.onTap,
+    this.textColor = AppColors.white,
+    this.border,
+  });
+
+  final String label;
+  final Color color;
+  final Color textColor;
+  final BoxBorder? border;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 13),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(12),
+          border: border,
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: 'Manrope',
+            fontWeight: FontWeight.w700,
+            fontSize: 15,
+            color: textColor,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## O que mudou?
Integração do cadastro de produtores.
Agora quando um produtor inativo tenta logar o exception é tratado.

## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

Para testar pode:
1- logar na pagina de login como admin e cadastrar um novo produtor.
2- logar como admin e inativar um produtor, logo após tentar logar como esse produtor e verá que não é possivel pois está inativo
3- logar novamente como admin e ativar o produtor inativo, poderá logar com o produtor novamente

## Screenshots / Gravações
<img width="400" height="782" alt="Captura de tela 2026-04-10 191439" src="https://github.com/user-attachments/assets/349c31fb-36a0-4d10-aea6-1ef41e9c9a15" />

<!-- Se mudou algo visual, cole prints ou gravações aqui -->
## TASKS:

#141
#96

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
