### PR TITLE
fix: remove duplicate + from new producer button

### DIFF
--- a/lib/features/admin/presentation/pages/admin_producers_page.dart
+++ b/lib/features/admin/presentation/pages/admin_producers_page.dart
@@ -117,7 +117,7 @@ class _AdminProducersView extends StatelessWidget {
               onPressed: () => context.push('/admin/producers/new'),
               icon: const Icon(Icons.add, size: 18),
               label: const Text(
-                '+ Novo produtor',
+                'Novo produtor',
                 style: TextStyle(
                   fontFamily: 'Manrope',
                   fontWeight: FontWeight.w700,


### PR DESCRIPTION
## O que mudou?

Remoção de + duplicado no botão de criação de Produtor

## Tipo de mudança

- [ ] Nova feature
- [x] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

Ver a tela de listagem de produtores e conferir se existe apenas um +

## Screenshots / Gravações

<img width="632" height="915" alt="image" src="https://github.com/user-attachments/assets/ddb94bda-fad7-49d8-bcff-e8bcacc8c84a" />


<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
