### PR TITLE
feat: handle registration errors with typed exceptions (#41)

### DIFF
--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -26,20 +26,50 @@ class ApiClient {
   }
 }
 
+String? _errorFieldFromResponse(Response<dynamic>? response) {
+  final data = response?.data;
+  if (data is Map<String, dynamic>) {
+    final err = data['error'];
+    if (err is String) return err;
+  }
+  return null;
+}
+
+ConflictException _conflictExceptionFromBody(String? errorField) {
+  final lower = (errorField ?? '').toLowerCase();
+  if (lower.contains('email')) {
+    return const ConflictException('Este e-mail já está em uso.');
+  }
+  if (lower.contains('cpf') || lower.contains('fiscal')) {
+    return const ConflictException('Este CPF já está cadastrado.');
+  }
+  return const ConflictException('E-mail ou CPF já cadastrado.');
+}
+
 class _ErrorInterceptor extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
     final statusCode = err.response?.statusCode;
     final ApiException exception;
     if (statusCode != null) {
-      exception = switch (statusCode) {
-        401 => const UnauthorizedException(),
-        404 => const NotFoundException(),
-        409 => const ConflictException(),
-        429 => const RateLimitedException(),
-        >= 500 => const ServerException(),
-        _ => const UnknownApiException(),
-      };
+      if (statusCode == 400) {
+        final raw = _errorFieldFromResponse(err.response);
+        exception = UnknownApiException(
+          raw ?? 'Dados inválidos. Revise o formulário.',
+        );
+      } else if (statusCode == 409) {
+        exception = _conflictExceptionFromBody(
+          _errorFieldFromResponse(err.response),
+        );
+      } else {
+        exception = switch (statusCode) {
+          401 => const UnauthorizedException(),
+          404 => const NotFoundException(),
+          429 => const RateLimitedException(),
+          >= 500 => const ServerException(),
+          _ => const UnknownApiException(),
+        };
+      }
     } else if (err.type == DioExceptionType.connectionTimeout ||
         err.type == DioExceptionType.receiveTimeout ||
         err.type == DioExceptionType.sendTimeout) {
@@ -52,6 +82,8 @@ class _ErrorInterceptor extends Interceptor {
     handler.reject(
       DioException(
         requestOptions: err.requestOptions,
+        response: err.response,
+        type: err.type,
         error: exception,
         message: exception.message,
       ),

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -7,22 +7,22 @@ abstract final class ApiEndpoints {
   );
 
   // Auth
-  static const String authConfig       = '$_base/auth/config';
-  static const String authSession      = '$_base/auth/session';
+  static const String authConfig = '$_base/auth/config';
+  static const String authSession = '$_base/auth/session';
   static const String registerCustomer = '$_base/auth/register/customer';
 
   // Consumers
-  static const String consumers        = '$_base/consumers';
-  static String consumer(String id)   => '$_base/consumers/$id';
+  static const String consumers = '$_base/consumers';
+  static String consumer(String id) => '$_base/consumers/$id';
 
   // Producers / Farmers
-  static const String producers       = '$_base/producers';
+  static const String producers = '$_base/producers';
   static const String recommendations = '$_base/recommendations';
-  static String producer(String id)   => '$_base/producers/$id';
+  static String producer(String id) => '$_base/producers/$id';
 
   // Orders
-  static const String orders          = '$_base/orders';
-  static String order(String id)      => '$_base/orders/$id';
+  static const String orders = '$_base/orders';
+  static String order(String id) => '$_base/orders/$id';
   static String orderRating(String id) => '$_base/orders/$id/rating';
 
   // Cart (local, no API endpoints needed yet)
@@ -42,6 +42,6 @@ abstract final class ApiEndpoints {
   static String producerOrderCancel(String id) => '$_base/orders/$id/cancel';
 
   // Admin
-  static const String adminProducers  = '$_base/admin/producers';
+  static const String adminProducers = '$_base/admin/producers';
   static String adminProducer(String id) => '$_base/admin/producers/$id';
 }

--- a/lib/core/network/api_exception.dart
+++ b/lib/core/network/api_exception.dart
@@ -37,5 +37,7 @@ class UnknownApiException extends ApiException {
 }
 
 class InvalidCredentialsApiException extends ApiException {
-  const InvalidCredentialsApiException([super.message = 'E-mail ou senha inválidos']);
+  const InvalidCredentialsApiException([
+    super.message = 'E-mail ou senha inválidos',
+  ]);
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -63,153 +63,181 @@ class AppRouter {
       routes: [
         // Auth routes
         GoRoute(path: '/login', builder: (_, __) => const LoginPage()),
-        GoRoute(path: '/register', builder: (_, __) => const ConsumerRegisterPage()),
+        GoRoute(
+          path: '/register',
+          builder: (_, __) => const ConsumerRegisterPage(),
+        ),
 
         // Consumer shell with bottom nav
         StatefulShellRoute.indexedStack(
           builder: (_, __, shell) => ConsumerShell(navigationShell: shell),
           branches: [
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/consumer/home',
-                builder: (_, __) => const ConsumerHomePage(),
-                routes: [
-                  GoRoute(
-                    path: 'producer/:producerId',
-                    builder: (context, state) => ProducerPublicProfilePage(
-                      producerId: state.pathParameters['producerId']!,
-                    ),
-                  ),
-                  GoRoute(
-                    path: 'product/:productId',
-                    builder: (context, state) => ProductDetailPage(
-                      productId: state.pathParameters['productId']!,
-                    ),
-                  ),
-                ],
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/consumer/orders',
-                builder: (_, __) => const ConsumerOrdersPage(),
-                routes: [
-                  GoRoute(
-                    path: ':orderId',
-                    builder: (context, state) => OrderDetailPage(
-                      orderId: state.pathParameters['orderId']!,
-                    ),
-                    routes: [
-                      GoRoute(
-                        path: 'rate',
-                        builder: (context, state) => RateProducerPage(
-                          orderId: state.pathParameters['orderId']!,
-                          farmName: state.uri.queryParameters['farmName'] ?? '',
-                          ownerName: state.uri.queryParameters['ownerName'] ?? '',
-                        ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/consumer/home',
+                  builder: (_, __) => const ConsumerHomePage(),
+                  routes: [
+                    GoRoute(
+                      path: 'producer/:producerId',
+                      builder: (context, state) => ProducerPublicProfilePage(
+                        producerId: state.pathParameters['producerId']!,
                       ),
-                    ],
-                  ),
-                ],
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/consumer/profile',
-                builder: (context, __) {
-                  final authState = context.read<AuthBloc>().state;
-                  final userId = authState is AuthAuthenticated ? authState.user.id : '';
-                  return BlocProvider(
-                    create: (_) => getIt<ConsumerProfileBloc>()
-                      ..add(ConsumerProfileStarted(userId)),
-                    child: const ConsumerProfilePage(),
-                  );
-                },
-                routes: [
-                  GoRoute(
-                    path: 'edit',
-                    builder: (context, __) {
-                      final authState = context.read<AuthBloc>().state;
-                      final userId = authState is AuthAuthenticated ? authState.user.id : '';
-                      return BlocProvider(
-                        create: (_) => getIt<ConsumerProfileBloc>()
-                          ..add(ConsumerProfileStarted(userId)),
-                        child: const ConsumerEditProfilePage(),
-                      );
-                    },
-                  ),
-                ],
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/consumer/search',
-                builder: (_, __) => const SearchPage(),
-              ),
-            ]),
+                    ),
+                    GoRoute(
+                      path: 'product/:productId',
+                      builder: (context, state) => ProductDetailPage(
+                        productId: state.pathParameters['productId']!,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/consumer/orders',
+                  builder: (_, __) => const ConsumerOrdersPage(),
+                  routes: [
+                    GoRoute(
+                      path: ':orderId',
+                      builder: (context, state) => OrderDetailPage(
+                        orderId: state.pathParameters['orderId']!,
+                      ),
+                      routes: [
+                        GoRoute(
+                          path: 'rate',
+                          builder: (context, state) => RateProducerPage(
+                            orderId: state.pathParameters['orderId']!,
+                            farmName:
+                                state.uri.queryParameters['farmName'] ?? '',
+                            ownerName:
+                                state.uri.queryParameters['ownerName'] ?? '',
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/consumer/profile',
+                  builder: (context, __) {
+                    final authState = context.read<AuthBloc>().state;
+                    final userId = authState is AuthAuthenticated
+                        ? authState.user.id
+                        : '';
+                    return BlocProvider(
+                      create: (_) =>
+                          getIt<ConsumerProfileBloc>()
+                            ..add(ConsumerProfileStarted(userId)),
+                      child: const ConsumerProfilePage(),
+                    );
+                  },
+                  routes: [
+                    GoRoute(
+                      path: 'edit',
+                      builder: (context, __) {
+                        final authState = context.read<AuthBloc>().state;
+                        final userId = authState is AuthAuthenticated
+                            ? authState.user.id
+                            : '';
+                        return BlocProvider(
+                          create: (_) =>
+                              getIt<ConsumerProfileBloc>()
+                                ..add(ConsumerProfileStarted(userId)),
+                          child: const ConsumerEditProfilePage(),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/consumer/search',
+                  builder: (_, __) => const SearchPage(),
+                ),
+              ],
+            ),
           ],
         ),
 
         // Cart & Checkout routes
         GoRoute(path: '/consumer/cart', builder: (_, __) => const CartPage()),
-        GoRoute(path: '/consumer/checkout', builder: (_, __) => const OrderConfirmationPage()),
+        GoRoute(
+          path: '/consumer/checkout',
+          builder: (_, __) => const OrderConfirmationPage(),
+        ),
 
         // Producer shell with 3 tabs
         StatefulShellRoute.indexedStack(
           builder: (_, __, shell) => ProducerShell(navigationShell: shell),
           branches: [
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/producer/home',
-                builder: (_, __) => const ProducerOrdersPage(),
-                routes: [
-                  GoRoute(
-                    path: 'orders/:orderId',
-                    builder: (context, state) => ProducerOrderDetailPage(
-                      orderId: state.pathParameters['orderId']!,
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/producer/home',
+                  builder: (_, __) => const ProducerOrdersPage(),
+                  routes: [
+                    GoRoute(
+                      path: 'orders/:orderId',
+                      builder: (context, state) => ProducerOrderDetailPage(
+                        orderId: state.pathParameters['orderId']!,
+                      ),
                     ),
-                  ),
-                  GoRoute(
-                    path: 'route',
-                    builder: (_, __) => const RouteCalculationPage(),
-                  ),
-                ],
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/producer/stock',
-                builder: (_, __) => const InventoryPage(),
-                routes: [
-                  GoRoute(
-                    path: 'new',
-                    builder: (_, __) => const ProductFormPage(),
-                  ),
-                  GoRoute(
-                    path: ':productId/edit',
-                    builder: (context, state) => ProductFormPage(
-                      productId: state.pathParameters['productId'],
+                    GoRoute(
+                      path: 'route',
+                      builder: (_, __) => const RouteCalculationPage(),
                     ),
-                  ),
-                ],
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/producer/profile',
-                builder: (_, __) => const ProducerProfilePage(),
-                routes: [
-                  GoRoute(
-                    path: 'edit',
-                    builder: (_, __) => const ProducerEditProfilePage(),
-                  ),
-                  GoRoute(
-                    path: 'settings',
-                    builder: (_, __) => const ProducerSettingsPage(),
-                  ),
-                ],
-              ),
-            ]),
+                  ],
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/producer/stock',
+                  builder: (_, __) => const InventoryPage(),
+                  routes: [
+                    GoRoute(
+                      path: 'new',
+                      builder: (_, __) => const ProductFormPage(),
+                    ),
+                    GoRoute(
+                      path: ':productId/edit',
+                      builder: (context, state) => ProductFormPage(
+                        productId: state.pathParameters['productId'],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/producer/profile',
+                  builder: (_, __) => const ProducerProfilePage(),
+                  routes: [
+                    GoRoute(
+                      path: 'edit',
+                      builder: (_, __) => const ProducerEditProfilePage(),
+                    ),
+                    GoRoute(
+                      path: 'settings',
+                      builder: (_, __) => const ProducerSettingsPage(),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ],
         ),
 

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -4,66 +4,62 @@ import 'package:ragro_mobile/core/theme/app_text_styles.dart';
 
 abstract final class AppTheme {
   static ThemeData get light => ThemeData(
-        useMaterial3: true,
-        colorScheme: const ColorScheme.light(
-          primary: AppColors.darkGreen,
-          secondary: AppColors.lightGreen,
-          onSecondary: AppColors.white,
-          surface: AppColors.cream,
-          onSurface: AppColors.black,
-          error: AppColors.red,
+    useMaterial3: true,
+    colorScheme: const ColorScheme.light(
+      primary: AppColors.darkGreen,
+      secondary: AppColors.lightGreen,
+      onSecondary: AppColors.white,
+      surface: AppColors.cream,
+      onSurface: AppColors.black,
+      error: AppColors.red,
+    ),
+    scaffoldBackgroundColor: AppColors.cream,
+    appBarTheme: const AppBarTheme(
+      backgroundColor: AppColors.cream,
+      foregroundColor: AppColors.black,
+      elevation: 0,
+      centerTitle: true,
+      titleTextStyle: AppTextStyles.title2,
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: AppColors.inputBackground,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(24),
+        borderSide: const BorderSide(color: AppColors.inputBorder),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(24),
+        borderSide: const BorderSide(color: AppColors.inputBorder),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(24),
+        borderSide: const BorderSide(color: AppColors.lightGreen, width: 1.5),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 48, vertical: 18),
+      hintStyle: AppTextStyles.body.copyWith(color: AppColors.placeholder),
+      labelStyle: AppTextStyles.textfieldLabel,
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.darkGreen,
+        foregroundColor: AppColors.cream,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        textStyle: AppTextStyles.highlight.copyWith(
+          fontWeight: FontWeight.w700,
+          color: AppColors.cream,
         ),
-        scaffoldBackgroundColor: AppColors.cream,
-        appBarTheme: const AppBarTheme(
-          backgroundColor: AppColors.cream,
-          foregroundColor: AppColors.black,
-          elevation: 0,
-          centerTitle: true,
-          titleTextStyle: AppTextStyles.title2,
-        ),
-        inputDecorationTheme: InputDecorationTheme(
-          filled: true,
-          fillColor: AppColors.inputBackground,
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(24),
-            borderSide: const BorderSide(color: AppColors.inputBorder),
-          ),
-          enabledBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(24),
-            borderSide: const BorderSide(color: AppColors.inputBorder),
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(24),
-            borderSide:
-                const BorderSide(color: AppColors.lightGreen, width: 1.5),
-          ),
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 48, vertical: 18),
-          hintStyle: AppTextStyles.body.copyWith(color: AppColors.placeholder),
-          labelStyle: AppTextStyles.textfieldLabel,
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: AppColors.darkGreen,
-            foregroundColor: AppColors.cream,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(24),
-            ),
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            textStyle: AppTextStyles.highlight.copyWith(
-              fontWeight: FontWeight.w700,
-              color: AppColors.cream,
-            ),
-            elevation: 4,
-            shadowColor: AppColors.darkGreen.withValues(alpha: 0.2),
-          ),
-        ),
-        bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-          backgroundColor: AppColors.white,
-          selectedItemColor: AppColors.darkGreen,
-          unselectedItemColor: AppColors.placeholder,
-          type: BottomNavigationBarType.fixed,
-          showUnselectedLabels: true,
-        ),
-      );
+        elevation: 4,
+        shadowColor: AppColors.darkGreen.withValues(alpha: 0.2),
+      ),
+    ),
+    bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+      backgroundColor: AppColors.white,
+      selectedItemColor: AppColors.darkGreen,
+      unselectedItemColor: AppColors.placeholder,
+      type: BottomNavigationBarType.fixed,
+      showUnselectedLabels: true,
+    ),
+  );
 }

--- a/lib/features/admin/data/repositories/admin_repository_impl.dart
+++ b/lib/features/admin/data/repositories/admin_repository_impl.dart
@@ -10,8 +10,7 @@ class AdminRepositoryImpl implements AdminRepository {
   final AdminRemoteDataSource _dataSource;
 
   @override
-  Future<List<AdminProducer>> getProducers() =>
-      _dataSource.getProducers();
+  Future<List<AdminProducer>> getProducers() => _dataSource.getProducers();
 
   @override
   Future<void> createProducer(AdminProducer producer, String password) =>
@@ -22,6 +21,5 @@ class AdminRepositoryImpl implements AdminRepository {
       _dataSource.deactivateProducer(id);
 
   @override
-  Future<void> activateProducer(String id) =>
-      _dataSource.activateProducer(id);
+  Future<void> activateProducer(String id) => _dataSource.activateProducer(id);
 }

--- a/lib/features/admin/domain/entities/admin_producer.dart
+++ b/lib/features/admin/domain/entities/admin_producer.dart
@@ -35,6 +35,14 @@ class AdminProducer extends Equatable {
   }
 
   @override
-  List<Object?> get props =>
-      [id, name, email, location, address, createdAt, updatedAt, active];
+  List<Object?> get props => [
+    id,
+    name,
+    email,
+    location,
+    address,
+    createdAt,
+    updatedAt,
+    active,
+  ];
 }

--- a/lib/features/admin/presentation/bloc/admin_producer_form_bloc.dart
+++ b/lib/features/admin/presentation/bloc/admin_producer_form_bloc.dart
@@ -9,7 +9,7 @@ import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producer_for
 class AdminProducerFormBloc
     extends Bloc<AdminProducerFormEvent, AdminProducerFormState> {
   AdminProducerFormBloc(this._createProducer)
-      : super(const AdminProducerFormInitial()) {
+    : super(const AdminProducerFormInitial()) {
     on<AdminProducerFormSubmitted>(_onSubmitted);
   }
 

--- a/lib/features/admin/presentation/bloc/admin_producers_bloc.dart
+++ b/lib/features/admin/presentation/bloc/admin_producers_bloc.dart
@@ -9,7 +9,7 @@ import 'package:ragro_mobile/features/admin/presentation/bloc/admin_producers_st
 class AdminProducersBloc
     extends Bloc<AdminProducersEvent, AdminProducersState> {
   AdminProducersBloc(this._getProducers, this._deactivate)
-      : super(const AdminProducersInitial()) {
+    : super(const AdminProducersInitial()) {
     on<AdminProducersStarted>(_onStarted);
     on<AdminProducerDeactivated>(_onDeactivated);
     on<AdminProducersRefreshed>(_onRefreshed);

--- a/lib/features/admin/presentation/pages/admin_create_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_create_producer_page.dart
@@ -53,7 +53,13 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
   bool _termsAccepted = false;
 
   static const _weekdayLabels = [
-    'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom'
+    'Seg',
+    'Ter',
+    'Qua',
+    'Qui',
+    'Sex',
+    'Sáb',
+    'Dom',
   ];
 
   @override
@@ -97,25 +103,25 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
       return;
     }
     context.read<AdminProducerFormBloc>().add(
-          AdminProducerFormSubmitted(
-            name: _nameController.text.trim(),
-            email: _emailController.text.trim(),
-            phone: _phoneController.text.trim(),
-            cep: _cepController.text.trim(),
-            address: _addressController.text.trim(),
-            city: _cityController.text.trim(),
-            state: _stateController.text.trim(),
-            bank: _bankController.text.trim(),
-            agency: _agencyController.text.trim(),
-            account: _accountController.text.trim(),
-            accountHolder: _holderController.text.trim(),
-            cpfCnpj: _cpfCnpjController.text.trim(),
-            password: _passwordController.text.trim(),
-            scheduleWeekdays: List.from(_weekdays),
-            scheduleStart: _scheduleStartController.text.trim(),
-            scheduleEnd: _scheduleEndController.text.trim(),
-          ),
-        );
+      AdminProducerFormSubmitted(
+        name: _nameController.text.trim(),
+        email: _emailController.text.trim(),
+        phone: _phoneController.text.trim(),
+        cep: _cepController.text.trim(),
+        address: _addressController.text.trim(),
+        city: _cityController.text.trim(),
+        state: _stateController.text.trim(),
+        bank: _bankController.text.trim(),
+        agency: _agencyController.text.trim(),
+        account: _accountController.text.trim(),
+        accountHolder: _holderController.text.trim(),
+        cpfCnpj: _cpfCnpjController.text.trim(),
+        password: _passwordController.text.trim(),
+        scheduleWeekdays: List.from(_weekdays),
+        scheduleStart: _scheduleStartController.text.trim(),
+        scheduleEnd: _scheduleEndController.text.trim(),
+      ),
+    );
   }
 
   @override
@@ -171,33 +177,37 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                 _FieldLabel('Nome Completo'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _nameController,
-                    hint: 'Nome do produtor',
-                    enabled: !isLoading),
+                  controller: _nameController,
+                  hint: 'Nome do produtor',
+                  enabled: !isLoading,
+                ),
                 const SizedBox(height: 12),
                 _FieldLabel('Telefone'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _phoneController,
-                    hint: '(XX) XXXXX-XXXX',
-                    keyboardType: TextInputType.phone,
-                    enabled: !isLoading),
+                  controller: _phoneController,
+                  hint: '(XX) XXXXX-XXXX',
+                  keyboardType: TextInputType.phone,
+                  enabled: !isLoading,
+                ),
                 const SizedBox(height: 12),
                 _FieldLabel('Email'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _emailController,
-                    hint: 'email@exemplo.com',
-                    keyboardType: TextInputType.emailAddress,
-                    enabled: !isLoading),
+                  controller: _emailController,
+                  hint: 'email@exemplo.com',
+                  keyboardType: TextInputType.emailAddress,
+                  enabled: !isLoading,
+                ),
                 const SizedBox(height: 12),
                 _FieldLabel('Senha'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _passwordController,
-                    hint: 'Senha de acesso',
-                    obscure: true,
-                    enabled: !isLoading),
+                  controller: _passwordController,
+                  hint: 'Senha de acesso',
+                  obscure: true,
+                  enabled: !isLoading,
+                ),
 
                 const SizedBox(height: 20),
                 _sectionTitle('Endereço'),
@@ -205,17 +215,19 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                 _FieldLabel('CEP'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _cepController,
-                    hint: '00000-000',
-                    keyboardType: TextInputType.number,
-                    enabled: !isLoading),
+                  controller: _cepController,
+                  hint: '00000-000',
+                  keyboardType: TextInputType.number,
+                  enabled: !isLoading,
+                ),
                 const SizedBox(height: 12),
                 _FieldLabel('Endereço'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _addressController,
-                    hint: 'Rua, número, bairro',
-                    enabled: !isLoading),
+                  controller: _addressController,
+                  hint: 'Rua, número, bairro',
+                  enabled: !isLoading,
+                ),
                 const SizedBox(height: 12),
                 Row(
                   children: [
@@ -227,9 +239,10 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                           _FieldLabel('Cidade'),
                           const SizedBox(height: 8),
                           _TextField(
-                              controller: _cityController,
-                              hint: 'Cidade',
-                              enabled: !isLoading),
+                            controller: _cityController,
+                            hint: 'Cidade',
+                            enabled: !isLoading,
+                          ),
                         ],
                       ),
                     ),
@@ -241,9 +254,10 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                           _FieldLabel('Estado'),
                           const SizedBox(height: 8),
                           _TextField(
-                              controller: _stateController,
-                              hint: 'UF',
-                              enabled: !isLoading),
+                            controller: _stateController,
+                            hint: 'UF',
+                            enabled: !isLoading,
+                          ),
                         ],
                       ),
                     ),
@@ -256,9 +270,10 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                 _FieldLabel('Banco'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _bankController,
-                    hint: 'Nome do banco',
-                    enabled: !isLoading),
+                  controller: _bankController,
+                  hint: 'Nome do banco',
+                  enabled: !isLoading,
+                ),
                 const SizedBox(height: 12),
                 Row(
                   children: [
@@ -269,10 +284,11 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                           _FieldLabel('Agência'),
                           const SizedBox(height: 8),
                           _TextField(
-                              controller: _agencyController,
-                              hint: '0000',
-                              keyboardType: TextInputType.number,
-                              enabled: !isLoading),
+                            controller: _agencyController,
+                            hint: '0000',
+                            keyboardType: TextInputType.number,
+                            enabled: !isLoading,
+                          ),
                         ],
                       ),
                     ),
@@ -284,10 +300,11 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                           _FieldLabel('Conta'),
                           const SizedBox(height: 8),
                           _TextField(
-                              controller: _accountController,
-                              hint: '000000-0',
-                              keyboardType: TextInputType.number,
-                              enabled: !isLoading),
+                            controller: _accountController,
+                            hint: '000000-0',
+                            keyboardType: TextInputType.number,
+                            enabled: !isLoading,
+                          ),
                         ],
                       ),
                     ),
@@ -297,17 +314,19 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                 _FieldLabel('Nome do Titular'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _holderController,
-                    hint: 'Nome completo do titular',
-                    enabled: !isLoading),
+                  controller: _holderController,
+                  hint: 'Nome completo do titular',
+                  enabled: !isLoading,
+                ),
                 const SizedBox(height: 12),
                 _FieldLabel('CPF / CNPJ'),
                 const SizedBox(height: 8),
                 _TextField(
-                    controller: _cpfCnpjController,
-                    hint: '000.000.000-00',
-                    keyboardType: TextInputType.number,
-                    enabled: !isLoading),
+                  controller: _cpfCnpjController,
+                  hint: '000.000.000-00',
+                  keyboardType: TextInputType.number,
+                  enabled: !isLoading,
+                ),
 
                 const SizedBox(height: 20),
                 _sectionTitle('Horário de atendimento'),
@@ -318,11 +337,12 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                   children: List.generate(7, (i) {
                     final isSelected = _weekdays[i];
                     return GestureDetector(
-                      onTap: () =>
-                          setState(() => _weekdays[i] = !_weekdays[i]),
+                      onTap: () => setState(() => _weekdays[i] = !_weekdays[i]),
                       child: Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
                         decoration: BoxDecoration(
                           color: isSelected
                               ? AppColors.darkGreen
@@ -354,17 +374,21 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                           _FieldLabel('Início'),
                           const SizedBox(height: 8),
                           _TextField(
-                              controller: _scheduleStartController,
-                              hint: '08:00',
-                              keyboardType: TextInputType.datetime,
-                              enabled: !isLoading),
+                            controller: _scheduleStartController,
+                            hint: '08:00',
+                            keyboardType: TextInputType.datetime,
+                            enabled: !isLoading,
+                          ),
                         ],
                       ),
                     ),
                     const Padding(
                       padding: EdgeInsets.only(top: 28, left: 12, right: 12),
-                      child: Icon(Icons.arrow_forward,
-                          color: AppColors.placeholder, size: 18),
+                      child: Icon(
+                        Icons.arrow_forward,
+                        color: AppColors.placeholder,
+                        size: 18,
+                      ),
                     ),
                     Expanded(
                       child: Column(
@@ -373,10 +397,11 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                           _FieldLabel('Fim'),
                           const SizedBox(height: 8),
                           _TextField(
-                              controller: _scheduleEndController,
-                              hint: '18:00',
-                              keyboardType: TextInputType.datetime,
-                              enabled: !isLoading),
+                            controller: _scheduleEndController,
+                            hint: '18:00',
+                            keyboardType: TextInputType.datetime,
+                            enabled: !isLoading,
+                          ),
                         ],
                       ),
                     ),
@@ -387,8 +412,7 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
 
                 // Terms checkbox
                 GestureDetector(
-                  onTap: () =>
-                      setState(() => _termsAccepted = !_termsAccepted),
+                  onTap: () => setState(() => _termsAccepted = !_termsAccepted),
                   child: Row(
                     children: [
                       Checkbox(
@@ -397,7 +421,8 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                             setState(() => _termsAccepted = v ?? false),
                         activeColor: AppColors.darkGreen,
                         shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(4)),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
                       ),
                       const Expanded(
                         child: Text(
@@ -422,10 +447,12 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                     style: ElevatedButton.styleFrom(
                       backgroundColor: AppColors.darkGreen,
                       foregroundColor: AppColors.white,
-                      disabledBackgroundColor:
-                          AppColors.darkGreen.withOpacity(0.5),
+                      disabledBackgroundColor: AppColors.darkGreen.withOpacity(
+                        0.5,
+                      ),
                       shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(24)),
+                        borderRadius: BorderRadius.circular(24),
+                      ),
                       padding: const EdgeInsets.symmetric(vertical: 16),
                     ),
                     child: isLoading
@@ -522,8 +549,10 @@ class _TextField extends StatelessWidget {
         ),
         filled: true,
         fillColor: AppColors.inputBackground,
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 14,
+        ),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: const BorderSide(color: AppColors.inputBorder),

--- a/lib/features/admin/presentation/pages/admin_producers_page.dart
+++ b/lib/features/admin/presentation/pages/admin_producers_page.dart
@@ -56,7 +56,8 @@ class _AdminProducersView extends StatelessWidget {
                       state is AdminProducersInitial) {
                     return const Center(
                       child: CircularProgressIndicator(
-                          color: AppColors.darkGreen),
+                        color: AppColors.darkGreen,
+                      ),
                     );
                   }
                   if (state is AdminProducersFailure) {
@@ -93,8 +94,9 @@ class _AdminProducersView extends StatelessWidget {
                         onEdit: () {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content:
-                                  Text('Editar ${producer.name} — em breve'),
+                              content: Text(
+                                'Editar ${producer.name} — em breve',
+                              ),
                             ),
                           );
                         },
@@ -128,7 +130,8 @@ class _AdminProducersView extends StatelessWidget {
                 backgroundColor: AppColors.darkGreen,
                 foregroundColor: AppColors.white,
                 shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(24)),
+                  borderRadius: BorderRadius.circular(24),
+                ),
                 padding: const EdgeInsets.symmetric(vertical: 16),
               ),
             ),
@@ -140,7 +143,10 @@ class _AdminProducersView extends StatelessWidget {
   }
 
   void _confirmDeactivate(
-      BuildContext context, String producerId, String producerName) {
+    BuildContext context,
+    String producerId,
+    String producerName,
+  ) {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text('Desativar "$producerName"?'),
@@ -148,9 +154,9 @@ class _AdminProducersView extends StatelessWidget {
           label: 'Confirmar',
           textColor: AppColors.white,
           onPressed: () {
-            context
-                .read<AdminProducersBloc>()
-                .add(AdminProducerDeactivated(producerId));
+            context.read<AdminProducersBloc>().add(
+              AdminProducerDeactivated(producerId),
+            );
           },
         ),
         backgroundColor: AppColors.red,
@@ -214,8 +220,11 @@ class _ProducerCard extends StatelessWidget {
                     color: AppColors.lightGreen.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(8),
                   ),
-                  child: const Icon(Icons.edit_outlined,
-                      size: 16, color: AppColors.lightGreen),
+                  child: const Icon(
+                    Icons.edit_outlined,
+                    size: 16,
+                    color: AppColors.lightGreen,
+                  ),
                 ),
               ),
               const SizedBox(width: 8),
@@ -228,8 +237,11 @@ class _ProducerCard extends StatelessWidget {
                     color: AppColors.red.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(8),
                   ),
-                  child: const Icon(Icons.delete_outline,
-                      size: 16, color: AppColors.red),
+                  child: const Icon(
+                    Icons.delete_outline,
+                    size: 16,
+                    color: AppColors.red,
+                  ),
                 ),
               ),
             ],
@@ -240,8 +252,11 @@ class _ProducerCard extends StatelessWidget {
           // Email
           Row(
             children: [
-              const Icon(Icons.email_outlined,
-                  size: 14, color: AppColors.placeholder),
+              const Icon(
+                Icons.email_outlined,
+                size: 14,
+                color: AppColors.placeholder,
+              ),
               const SizedBox(width: 6),
               Expanded(
                 child: Text(
@@ -263,8 +278,11 @@ class _ProducerCard extends StatelessWidget {
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Icon(Icons.location_on_outlined,
-                  size: 14, color: AppColors.placeholder),
+              const Icon(
+                Icons.location_on_outlined,
+                size: 14,
+                color: AppColors.placeholder,
+              ),
               const SizedBox(width: 6),
               Expanded(
                 child: Text(
@@ -286,10 +304,7 @@ class _ProducerCard extends StatelessWidget {
           // Dates
           Row(
             children: [
-              _DateBadge(
-                label: 'CADASTRO',
-                date: fmtDate(producer.createdAt),
-              ),
+              _DateBadge(label: 'CADASTRO', date: fmtDate(producer.createdAt)),
               const SizedBox(width: 12),
               _DateBadge(
                 label: 'MODIFICADO',
@@ -297,8 +312,7 @@ class _ProducerCard extends StatelessWidget {
               ),
               const Spacer(),
               Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
                 decoration: BoxDecoration(
                   color: producer.active
                       ? AppColors.lightGreen.withOpacity(0.1)

--- a/lib/features/auth/data/datasources/auth_local_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_local_datasource.dart
@@ -6,16 +6,16 @@ class AuthLocalDataSource {
   const AuthLocalDataSource(this._prefs);
   final SharedPreferences _prefs;
 
-  static const _tokenKey        = 'auth_token';
+  static const _tokenKey = 'auth_token';
   static const _refreshTokenKey = 'auth_refresh_token';
-  static const _tokenUrlKey     = 'auth_token_url';
-  static const _clientIdKey     = 'auth_client_id';
-  static const _userTypeKey     = 'auth_user_type';
-  static const _userIdKey       = 'auth_user_id';
-  static const _userNameKey     = 'auth_user_name';
-  static const _userEmailKey    = 'auth_user_email';
-  static const _userPhoneKey    = 'auth_user_phone';
-  static const _userActiveKey   = 'auth_user_active';
+  static const _tokenUrlKey = 'auth_token_url';
+  static const _clientIdKey = 'auth_client_id';
+  static const _userTypeKey = 'auth_user_type';
+  static const _userIdKey = 'auth_user_id';
+  static const _userNameKey = 'auth_user_name';
+  static const _userEmailKey = 'auth_user_email';
+  static const _userPhoneKey = 'auth_user_phone';
+  static const _userActiveKey = 'auth_user_active';
 
   Future<void> saveSession({
     required String token,
@@ -48,16 +48,16 @@ class AuthLocalDataSource {
     await Future.wait(futures);
   }
 
-  String? getToken()        => _prefs.getString(_tokenKey);
+  String? getToken() => _prefs.getString(_tokenKey);
   String? getRefreshToken() => _prefs.getString(_refreshTokenKey);
-  String? getTokenUrl()     => _prefs.getString(_tokenUrlKey);
-  String? getClientId()     => _prefs.getString(_clientIdKey);
-  String? getUserType()     => _prefs.getString(_userTypeKey);
-  String? getUserId()       => _prefs.getString(_userIdKey);
-  String? getUserName()     => _prefs.getString(_userNameKey);
-  String? getUserEmail()    => _prefs.getString(_userEmailKey);
-  String? getUserPhone()    => _prefs.getString(_userPhoneKey);
-  bool?   getUserActive()   => _prefs.getBool(_userActiveKey);
+  String? getTokenUrl() => _prefs.getString(_tokenUrlKey);
+  String? getClientId() => _prefs.getString(_clientIdKey);
+  String? getUserType() => _prefs.getString(_userTypeKey);
+  String? getUserId() => _prefs.getString(_userIdKey);
+  String? getUserName() => _prefs.getString(_userNameKey);
+  String? getUserEmail() => _prefs.getString(_userEmailKey);
+  String? getUserPhone() => _prefs.getString(_userPhoneKey);
+  bool? getUserActive() => _prefs.getBool(_userActiveKey);
 
   Future<void> clearSession() async {
     await Future.wait([

--- a/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -111,7 +111,19 @@ class AuthRemoteDataSource {
       );
       return UserModel.fromJson(response.data!);
     } on DioException catch (e) {
-      throw e.error as ApiException? ?? const UnknownApiException();
+      final wrapped = e.error;
+      if (wrapped is ApiException) {
+        throw wrapped;
+      }
+      if (e.type == DioExceptionType.connectionError) {
+        throw const NetworkException();
+      }
+      if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw const ApiTimeoutException();
+      }
+      throw const UnknownApiException();
     }
   }
 }

--- a/lib/features/auth/data/models/address_request.dart
+++ b/lib/features/auth/data/models/address_request.dart
@@ -19,14 +19,14 @@ class AddressRequest {
   final String? neighborhood;
 
   Map<String, dynamic> toJson() => {
-        'street': street,
-        'number': number,
-        'city': city,
-        'state': state,
-        'zipCode': zipCode,
-        if (complement != null && complement!.trim().isNotEmpty)
-          'complement': complement!.trim(),
-        if (neighborhood != null && neighborhood!.trim().isNotEmpty)
-          'neighborhood': neighborhood!.trim(),
-      };
+    'street': street,
+    'number': number,
+    'city': city,
+    'state': state,
+    'zipCode': zipCode,
+    if (complement != null && complement!.trim().isNotEmpty)
+      'complement': complement!.trim(),
+    if (neighborhood != null && neighborhood!.trim().isNotEmpty)
+      'neighborhood': neighborhood!.trim(),
+  };
 }

--- a/lib/features/auth/data/models/customer_registration_request.dart
+++ b/lib/features/auth/data/models/customer_registration_request.dart
@@ -21,11 +21,11 @@ class CustomerRegistrationRequest {
   final AddressRequest address;
 
   Map<String, dynamic> toJson() => {
-        'name': name,
-        'email': email,
-        'phone': phone,
-        'fiscalNumber': fiscalNumber,
-        'password': password,
-        'address': address.toJson(),
-      };
+    'name': name,
+    'email': email,
+    'phone': phone,
+    'fiscalNumber': fiscalNumber,
+    'password': password,
+    'address': address.toJson(),
+  };
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -22,10 +22,7 @@ class AuthRepositoryImpl implements AuthRepository {
     required String email,
     required String password,
   }) async {
-    final response = await _remote.loginUser(
-      email: email,
-      password: password,
-    );
+    final response = await _remote.loginUser(email: email, password: password);
     try {
       await _local.saveSession(
         token: response.accessToken,
@@ -93,25 +90,27 @@ class AuthRepositoryImpl implements AuthRepository {
     // DEMO_MODE: bypass auth — used for Playwright visual testing only.
     // Run with: flutter run -d chrome --dart-define=DEMO_MODE=true
     const demoMode = bool.fromEnvironment('DEMO_MODE');
-    const demoRole =
-        String.fromEnvironment('DEMO_ROLE', defaultValue: 'producer');
+    const demoRole = String.fromEnvironment(
+      'DEMO_ROLE',
+      defaultValue: 'producer',
+    );
     if (demoMode) {
       final (id, name, email) = switch (demoRole) {
         'consumer' => (
-            'demo_consumer_001',
-            'Ricardo Aguiar (Demo)',
-            'consumer@ragro.com.br'
-          ),
+          'demo_consumer_001',
+          'Ricardo Aguiar (Demo)',
+          'consumer@ragro.com.br',
+        ),
         'admin' => (
-            'demo_admin_001',
-            'Admin RAGRO (Demo)',
-            'admin@ragro.com.br'
-          ),
+          'demo_admin_001',
+          'Admin RAGRO (Demo)',
+          'admin@ragro.com.br',
+        ),
         _ => (
-            'demo_producer_001',
-            'João Silva (Demo)',
-            'produtor@ragro.com.br'
-          ),
+          'demo_producer_001',
+          'João Silva (Demo)',
+          'produtor@ragro.com.br',
+        ),
       };
       return UserModel(
         id: id,
@@ -167,7 +166,8 @@ class AuthRepositoryImpl implements AuthRepository {
     final email = _local.getUserEmail();
     final type = _local.getUserType();
     final active = _local.getUserActive();
-    if (id == null || name == null || email == null || type == null) return null;
+    if (id == null || name == null || email == null || type == null)
+      return null;
     final phone = _local.getUserPhone();
     return UserModel(
       id: id,

--- a/lib/features/auth/domain/entities/address.dart
+++ b/lib/features/auth/domain/entities/address.dart
@@ -29,7 +29,16 @@ class Address extends Equatable {
 
   @override
   List<Object?> get props => [
-    id, street, number, city, state, zipCode,
-    isPrimary, complement, neighborhood, latitude, longitude,
+    id,
+    street,
+    number,
+    city,
+    state,
+    zipCode,
+    isPrimary,
+    complement,
+    neighborhood,
+    latitude,
+    longitude,
   ];
 }

--- a/lib/features/auth/domain/entities/user_type.dart
+++ b/lib/features/auth/domain/entities/user_type.dart
@@ -7,8 +7,8 @@ enum UserType {
   static UserType fromApiValue(String value) {
     return switch (value) {
       'customer' || 'consumer' => UserType.consumer,
-      'farmer'   || 'producer' => UserType.producer,
-      'admin'                  => UserType.admin,
+      'farmer' || 'producer' => UserType.producer,
+      'admin' => UserType.admin,
       _ => throw ArgumentError('Unknown user type: $value'),
     };
   }

--- a/lib/features/auth/domain/usecases/login_user.dart
+++ b/lib/features/auth/domain/usecases/login_user.dart
@@ -10,6 +10,5 @@ class LoginUser {
   Future<({User user, String token})> call({
     required String email,
     required String password,
-  }) =>
-      _repository.loginUser(email: email, password: password);
+  }) => _repository.loginUser(email: email, password: password);
 }

--- a/lib/features/auth/domain/usecases/register_consumer.dart
+++ b/lib/features/auth/domain/usecases/register_consumer.dart
@@ -20,19 +20,18 @@ class RegisterConsumer {
     required String state,
     String? complement,
     String? neighborhood,
-  }) =>
-      _repository.registerConsumer(
-        name: name,
-        phone: phone,
-        email: email,
-        fiscalNumber: fiscalNumber,
-        password: password,
-        zipCode: zipCode,
-        street: street,
-        number: number,
-        city: city,
-        state: state,
-        complement: complement,
-        neighborhood: neighborhood,
-      );
+  }) => _repository.registerConsumer(
+    name: name,
+    phone: phone,
+    email: email,
+    fiscalNumber: fiscalNumber,
+    password: password,
+    zipCode: zipCode,
+    street: street,
+    number: number,
+    city: city,
+    state: state,
+    complement: complement,
+    neighborhood: neighborhood,
+  );
 }

--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -16,10 +16,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final GetCurrentUser _getCurrentUser;
   final Logout _logout;
 
-  Future<void> _onStarted(
-    AuthStarted event,
-    Emitter<AuthState> emit,
-  ) async {
+  Future<void> _onStarted(AuthStarted event, Emitter<AuthState> emit) async {
     emit(const AuthLoading());
     final user = await _getCurrentUser();
     if (user != null) {

--- a/lib/features/auth/presentation/bloc/login_event.dart
+++ b/lib/features/auth/presentation/bloc/login_event.dart
@@ -7,10 +7,7 @@ sealed class LoginEvent extends Equatable {
 }
 
 class LoginSubmitted extends LoginEvent {
-  const LoginSubmitted({
-    required this.email,
-    required this.password,
-  });
+  const LoginSubmitted({required this.email, required this.password});
 
   final String email;
   final String password;

--- a/lib/features/auth/presentation/bloc/register_event.dart
+++ b/lib/features/auth/presentation/bloc/register_event.dart
@@ -37,17 +37,17 @@ class RegisterSubmitted extends RegisterEvent {
 
   @override
   List<Object?> get props => [
-        name,
-        phone,
-        email,
-        fiscalNumber,
-        password,
-        zipCode,
-        street,
-        number,
-        city,
-        state,
-        complement,
-        neighborhood,
-      ];
+    name,
+    phone,
+    email,
+    fiscalNumber,
+    password,
+    zipCode,
+    street,
+    number,
+    city,
+    state,
+    complement,
+    neighborhood,
+  ];
 }

--- a/lib/features/auth/presentation/pages/consumer_register_page.dart
+++ b/lib/features/auth/presentation/pages/consumer_register_page.dart
@@ -85,25 +85,25 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
     }
 
     context.read<RegisterBloc>().add(
-          RegisterSubmitted(
-            name: _nameController.text.trim(),
-            phone: _phoneController.text.trim(),
-            email: _emailController.text.trim(),
-            fiscalNumber: _cpfController.text.trim(),
-            password: _passwordController.text,
-            zipCode: _zipCodeController.text.trim(),
-            street: _streetController.text.trim(),
-            number: _numberController.text.trim(),
-            city: _cityController.text.trim(),
-            state: _stateController.text.trim(),
-            complement: _complementController.text.trim().isEmpty
-                ? null
-                : _complementController.text.trim(),
-            neighborhood: _neighborhoodController.text.trim().isEmpty
-                ? null
-                : _neighborhoodController.text.trim(),
-          ),
-        );
+      RegisterSubmitted(
+        name: _nameController.text.trim(),
+        phone: _phoneController.text.trim(),
+        email: _emailController.text.trim(),
+        fiscalNumber: _cpfController.text.trim(),
+        password: _passwordController.text,
+        zipCode: _zipCodeController.text.trim(),
+        street: _streetController.text.trim(),
+        number: _numberController.text.trim(),
+        city: _cityController.text.trim(),
+        state: _stateController.text.trim(),
+        complement: _complementController.text.trim().isEmpty
+            ? null
+            : _complementController.text.trim(),
+        neighborhood: _neighborhoodController.text.trim().isEmpty
+            ? null
+            : _neighborhoodController.text.trim(),
+      ),
+    );
   }
 
   @override
@@ -152,8 +152,7 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                   controller: _phoneController,
                   keyboardType: TextInputType.phone,
                   validator: (value) {
-                    final digits =
-                        value?.replaceAll(RegExp(r'\D'), '') ?? '';
+                    final digits = value?.replaceAll(RegExp(r'\D'), '') ?? '';
                     if (digits.length != 11) {
                       return 'DDD + número com 11 dígitos';
                     }
@@ -180,8 +179,7 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                   controller: _cpfController,
                   keyboardType: TextInputType.number,
                   validator: (value) {
-                    final digits =
-                        value?.replaceAll(RegExp(r'\D'), '') ?? '';
+                    final digits = value?.replaceAll(RegExp(r'\D'), '') ?? '';
                     if (digits.length != 11) {
                       return 'CPF deve ter 11 dígitos';
                     }
@@ -201,8 +199,9 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                     if (value.length < 8 || value.length > 50) {
                       return 'Entre 8 e 50 caracteres';
                     }
-                    if (!RegExp(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$')
-                        .hasMatch(value)) {
+                    if (!RegExp(
+                      r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$',
+                    ).hasMatch(value)) {
                       return 'Inclua maiúscula, minúscula e um número';
                     }
                     return null;
@@ -228,8 +227,7 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
                   controller: _zipCodeController,
                   keyboardType: TextInputType.number,
                   validator: (value) {
-                    final digits =
-                        value?.replaceAll(RegExp(r'\D'), '') ?? '';
+                    final digits = value?.replaceAll(RegExp(r'\D'), '') ?? '';
                     if (digits.length != 8) {
                       return 'CEP deve ter 8 dígitos';
                     }
@@ -339,10 +337,7 @@ class _ConsumerRegisterViewState extends State<_ConsumerRegisterView> {
 }
 
 class _TermsCheckbox extends StatefulWidget {
-  const _TermsCheckbox({
-    required this.value,
-    required this.onChanged,
-  });
+  const _TermsCheckbox({required this.value, required this.onChanged});
 
   final bool value;
   final ValueChanged<bool?> onChanged;

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -46,9 +46,7 @@ class LoginPage extends StatelessWidget {
                   const Spacer(flex: 2),
                   const RagroLogo(),
                   const Spacer(flex: 2),
-                  LoginForm(
-                    onRegisterTap: () => context.push('/register'),
-                  ),
+                  LoginForm(onRegisterTap: () => context.push('/register')),
                   const Spacer(),
                 ],
               ),

--- a/lib/features/auth/presentation/widgets/login_form.dart
+++ b/lib/features/auth/presentation/widgets/login_form.dart
@@ -35,8 +35,8 @@ class _LoginFormState extends State<LoginForm> {
   final _passwordController = TextEditingController();
   late final TapGestureRecognizer? _registerTapRecognizer =
       widget.onRegisterTap != null
-          ? (TapGestureRecognizer()..onTap = widget.onRegisterTap)
-          : null;
+      ? (TapGestureRecognizer()..onTap = widget.onRegisterTap)
+      : null;
 
   @override
   void dispose() {
@@ -49,11 +49,11 @@ class _LoginFormState extends State<LoginForm> {
   void _submit() {
     if (_formKey.currentState?.validate() ?? false) {
       context.read<LoginBloc>().add(
-            LoginSubmitted(
-              email: _emailController.text.trim(),
-              password: _passwordController.text,
-            ),
-          );
+        LoginSubmitted(
+          email: _emailController.text.trim(),
+          password: _passwordController.text,
+        ),
+      );
     }
   }
 
@@ -120,9 +120,7 @@ class _LoginFormState extends State<LoginForm> {
             Center(
               child: RichText(
                 text: TextSpan(
-                  style: AppTextStyles.caption.copyWith(
-                    color: AppColors.black,
-                  ),
+                  style: AppTextStyles.caption.copyWith(color: AppColors.black),
                   children: [
                     const TextSpan(text: 'Não tem conta? '),
                     TextSpan(

--- a/lib/features/cart/data/datasources/cart_local_datasource.dart
+++ b/lib/features/cart/data/datasources/cart_local_datasource.dart
@@ -20,7 +20,9 @@ class CartLocalDatasource {
     }
     // same producer: add or increment
     if (_cart.producerId == item.producerId) {
-      final existingIndex = _cart.items.indexWhere((i) => i.productId == item.productId);
+      final existingIndex = _cart.items.indexWhere(
+        (i) => i.productId == item.productId,
+      );
       if (existingIndex >= 0) {
         final updated = List<CartItem>.from(_cart.items);
         updated[existingIndex] = updated[existingIndex].copyWith(
@@ -54,7 +56,9 @@ class CartLocalDatasource {
 
   Cart removeItem(String productId) {
     final updated = _cart.items.where((i) => i.productId != productId).toList();
-    _cart = updated.isEmpty ? const Cart.empty() : _cart.copyWith(items: updated);
+    _cart = updated.isEmpty
+        ? const Cart.empty()
+        : _cart.copyWith(items: updated);
     return _cart;
   }
 

--- a/lib/features/cart/data/repositories/cart_repository_impl.dart
+++ b/lib/features/cart/data/repositories/cart_repository_impl.dart
@@ -16,7 +16,8 @@ class CartRepositoryImpl implements CartRepository {
   Cart addItem(CartItem item) => _datasource.addItem(item);
 
   @override
-  Cart updateQuantity(String productId, int quantity) => _datasource.updateQuantity(productId, quantity);
+  Cart updateQuantity(String productId, int quantity) =>
+      _datasource.updateQuantity(productId, quantity);
 
   @override
   Cart removeItem(String productId) => _datasource.removeItem(productId);

--- a/lib/features/cart/domain/entities/cart.dart
+++ b/lib/features/cart/domain/entities/cart.dart
@@ -10,10 +10,10 @@ class Cart extends Equatable {
   });
 
   const Cart.empty()
-      : producerId = '',
-        farmName = '',
-        farmLocation = '',
-        items = const [];
+    : producerId = '',
+      farmName = '',
+      farmLocation = '',
+      items = const [];
 
   final String producerId;
   final String farmName;
@@ -25,11 +25,11 @@ class Cart extends Equatable {
   double get totalAmount => items.fold(0, (sum, item) => sum + item.totalPrice);
 
   Cart copyWith({List<CartItem>? items}) => Cart(
-        producerId: producerId,
-        farmName: farmName,
-        farmLocation: farmLocation,
-        items: items ?? this.items,
-      );
+    producerId: producerId,
+    farmName: farmName,
+    farmLocation: farmLocation,
+    items: items ?? this.items,
+  );
 
   @override
   List<Object?> get props => [producerId, farmName, farmLocation, items];

--- a/lib/features/cart/domain/entities/cart_item.dart
+++ b/lib/features/cart/domain/entities/cart_item.dart
@@ -26,17 +26,27 @@ class CartItem extends Equatable {
   double get totalPrice => unitPrice * quantity;
 
   CartItem copyWith({int? quantity}) => CartItem(
-        productId: productId,
-        productName: productName,
-        imageUrl: imageUrl,
-        unitPrice: unitPrice,
-        unityType: unityType,
-        quantity: quantity ?? this.quantity,
-        farmName: farmName,
-        farmLocation: farmLocation,
-        producerId: producerId,
-      );
+    productId: productId,
+    productName: productName,
+    imageUrl: imageUrl,
+    unitPrice: unitPrice,
+    unityType: unityType,
+    quantity: quantity ?? this.quantity,
+    farmName: farmName,
+    farmLocation: farmLocation,
+    producerId: producerId,
+  );
 
   @override
-  List<Object?> get props => [productId, productName, imageUrl, unitPrice, unityType, quantity, farmName, farmLocation, producerId];
+  List<Object?> get props => [
+    productId,
+    productName,
+    imageUrl,
+    unitPrice,
+    unityType,
+    quantity,
+    farmName,
+    farmLocation,
+    producerId,
+  ];
 }

--- a/lib/features/cart/domain/usecases/update_cart_item_quantity.dart
+++ b/lib/features/cart/domain/usecases/update_cart_item_quantity.dart
@@ -6,5 +6,6 @@ import 'package:ragro_mobile/features/cart/domain/repositories/cart_repository.d
 class UpdateCartItemQuantity {
   const UpdateCartItemQuantity(this._repository);
   final CartRepository _repository;
-  Cart call(String productId, int quantity) => _repository.updateQuantity(productId, quantity);
+  Cart call(String productId, int quantity) =>
+      _repository.updateQuantity(productId, quantity);
 }

--- a/lib/features/cart/presentation/bloc/cart_bloc.dart
+++ b/lib/features/cart/presentation/bloc/cart_bloc.dart
@@ -38,7 +38,10 @@ class CartBloc extends Bloc<CartEvent, CartState> {
     emit(CartLoaded(_addToCart(event.item)));
   }
 
-  void _onQuantityUpdated(CartItemQuantityUpdated event, Emitter<CartState> emit) {
+  void _onQuantityUpdated(
+    CartItemQuantityUpdated event,
+    Emitter<CartState> emit,
+  ) {
     emit(CartLoaded(_updateQuantity(event.productId, event.quantity)));
   }
 

--- a/lib/features/cart/presentation/pages/cart_page.dart
+++ b/lib/features/cart/presentation/pages/cart_page.dart
@@ -39,7 +39,9 @@ class CartPage extends StatelessWidget {
                     padding: const EdgeInsets.fromLTRB(16, 16, 20, 17),
                     decoration: const BoxDecoration(
                       color: AppColors.white,
-                      border: Border(bottom: BorderSide(color: Color(0xFFF1F5F9))),
+                      border: Border(
+                        bottom: BorderSide(color: Color(0xFFF1F5F9)),
+                      ),
                     ),
                     child: Row(
                       children: [
@@ -64,14 +66,18 @@ class CartPage extends StatelessWidget {
                         GestureDetector(
                           onTap: isEmpty
                               ? null
-                              : () => context.read<CartBloc>().add(const CartCleared()),
+                              : () => context.read<CartBloc>().add(
+                                  const CartCleared(),
+                                ),
                           child: Text(
                             'Limpar',
                             style: TextStyle(
                               fontFamily: 'Manrope',
                               fontWeight: FontWeight.w700,
                               fontSize: 14,
-                              color: isEmpty ? Colors.transparent : AppColors.red,
+                              color: isEmpty
+                                  ? Colors.transparent
+                                  : AppColors.red,
                             ),
                           ),
                         ),
@@ -85,7 +91,11 @@ class CartPage extends StatelessWidget {
                         child: Column(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Icon(Icons.shopping_cart_outlined, size: 64, color: AppColors.placeholder),
+                            Icon(
+                              Icons.shopping_cart_outlined,
+                              size: 64,
+                              color: AppColors.placeholder,
+                            ),
                             SizedBox(height: 16),
                             Text(
                               'Seu carrinho está vazio',
@@ -111,16 +121,23 @@ class CartPage extends StatelessWidget {
                             decoration: BoxDecoration(
                               color: const Color(0xFF487ACB).withOpacity(0.15),
                               borderRadius: BorderRadius.circular(16),
-                              border: Border.all(color: const Color(0xFF487ACB)),
+                              border: Border.all(
+                                color: const Color(0xFF487ACB),
+                              ),
                             ),
                             child: const Row(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Icon(Icons.info_outline, color: Color(0xFF487ACB), size: 20),
+                                Icon(
+                                  Icons.info_outline,
+                                  color: Color(0xFF487ACB),
+                                  size: 20,
+                                ),
                                 SizedBox(width: 12),
                                 Expanded(
                                   child: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         'Aviso de Produtor Único',
@@ -172,7 +189,9 @@ class CartPage extends StatelessWidget {
                       padding: const EdgeInsets.fromLTRB(24, 9, 24, 24),
                       decoration: const BoxDecoration(
                         color: AppColors.white,
-                        border: Border(top: BorderSide(color: Color(0xFFF1F5F9))),
+                        border: Border(
+                          top: BorderSide(color: Color(0xFFF1F5F9)),
+                        ),
                       ),
                       child: Column(
                         children: [

--- a/lib/features/cart/presentation/widgets/cart_item_tile.dart
+++ b/lib/features/cart/presentation/widgets/cart_item_tile.dart
@@ -93,7 +93,10 @@ class CartItemTile extends StatelessWidget {
                   children: [
                     // Quantity selector
                     Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 4,
+                      ),
                       decoration: BoxDecoration(
                         color: const Color(0xFFF1F5F9),
                         borderRadius: BorderRadius.circular(9999),
@@ -102,8 +105,11 @@ class CartItemTile extends StatelessWidget {
                         children: [
                           GestureDetector(
                             onTap: () => context.read<CartBloc>().add(
-                                  CartItemQuantityUpdated(item.productId, item.quantity - 1),
-                                ),
+                              CartItemQuantityUpdated(
+                                item.productId,
+                                item.quantity - 1,
+                              ),
+                            ),
                             child: const Icon(Icons.remove, size: 14),
                           ),
                           const SizedBox(width: 12),
@@ -118,8 +124,11 @@ class CartItemTile extends StatelessWidget {
                           const SizedBox(width: 12),
                           GestureDetector(
                             onTap: () => context.read<CartBloc>().add(
-                                  CartItemQuantityUpdated(item.productId, item.quantity + 1),
-                                ),
+                              CartItemQuantityUpdated(
+                                item.productId,
+                                item.quantity + 1,
+                              ),
+                            ),
                             child: const Icon(Icons.add, size: 14),
                           ),
                         ],
@@ -129,9 +138,13 @@ class CartItemTile extends StatelessWidget {
                     // Delete
                     GestureDetector(
                       onTap: () => context.read<CartBloc>().add(
-                            CartItemRemoved(item.productId),
-                          ),
-                      child: const Icon(Icons.delete_outline, color: AppColors.red, size: 20),
+                        CartItemRemoved(item.productId),
+                      ),
+                      child: const Icon(
+                        Icons.delete_outline,
+                        color: AppColors.red,
+                        size: 20,
+                      ),
                     ),
                   ],
                 ),

--- a/lib/features/consumer_profile/data/repositories/consumer_profile_repository_impl.dart
+++ b/lib/features/consumer_profile/data/repositories/consumer_profile_repository_impl.dart
@@ -20,12 +20,11 @@ class ConsumerProfileRepositoryImpl implements ConsumerProfileRepository {
     required String phone,
     required String address,
     String? fiscalNumber,
-  }) =>
-      _dataSource.updateProfile(
-        userId: userId,
-        name: name,
-        phone: phone,
-        address: address,
-        fiscalNumber: fiscalNumber,
-      );
+  }) => _dataSource.updateProfile(
+    userId: userId,
+    name: name,
+    phone: phone,
+    address: address,
+    fiscalNumber: fiscalNumber,
+  );
 }

--- a/lib/features/consumer_profile/domain/entities/consumer_profile.dart
+++ b/lib/features/consumer_profile/domain/entities/consumer_profile.dart
@@ -39,5 +39,13 @@ class ConsumerProfile extends Equatable {
   }
 
   @override
-  List<Object?> get props => [id, userId, name, email, phone, address, fiscalNumber];
+  List<Object?> get props => [
+    id,
+    userId,
+    name,
+    email,
+    phone,
+    address,
+    fiscalNumber,
+  ];
 }

--- a/lib/features/consumer_profile/domain/usecases/update_consumer_profile.dart
+++ b/lib/features/consumer_profile/domain/usecases/update_consumer_profile.dart
@@ -14,12 +14,11 @@ class UpdateConsumerProfile {
     required String phone,
     required String address,
     String? fiscalNumber,
-  }) =>
-      _repository.updateProfile(
-        userId: userId,
-        name: name,
-        phone: phone,
-        address: address,
-        fiscalNumber: fiscalNumber,
-      );
+  }) => _repository.updateProfile(
+    userId: userId,
+    name: name,
+    phone: phone,
+    address: address,
+    fiscalNumber: fiscalNumber,
+  );
 }

--- a/lib/features/consumer_profile/presentation/bloc/consumer_profile_bloc.dart
+++ b/lib/features/consumer_profile/presentation/bloc/consumer_profile_bloc.dart
@@ -10,7 +10,7 @@ import 'package:ragro_mobile/features/consumer_profile/presentation/bloc/consume
 class ConsumerProfileBloc
     extends Bloc<ConsumerProfileEvent, ConsumerProfileState> {
   ConsumerProfileBloc(this._getProfile, this._updateProfile)
-      : super(const ConsumerProfileInitial()) {
+    : super(const ConsumerProfileInitial()) {
     on<ConsumerProfileStarted>(_onStarted);
     on<ConsumerProfileUpdateSubmitted>(_onUpdateSubmitted);
   }

--- a/lib/features/consumer_profile/presentation/pages/consumer_edit_profile_page.dart
+++ b/lib/features/consumer_profile/presentation/pages/consumer_edit_profile_page.dart
@@ -17,7 +17,8 @@ class ConsumerEditProfilePage extends StatefulWidget {
   const ConsumerEditProfilePage({super.key});
 
   @override
-  State<ConsumerEditProfilePage> createState() => _ConsumerEditProfilePageState();
+  State<ConsumerEditProfilePage> createState() =>
+      _ConsumerEditProfilePageState();
 }
 
 class _ConsumerEditProfilePageState extends State<ConsumerEditProfilePage> {
@@ -156,7 +157,10 @@ class _ConsumerEditProfilePageState extends State<ConsumerEditProfilePage> {
                               GestureDetector(
                                 onTap: isLoading ? null : _onSave,
                                 child: Container(
-                                  padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: 16,
+                                    horizontal: 24,
+                                  ),
                                   decoration: BoxDecoration(
                                     color: AppColors.darkGreen,
                                     borderRadius: BorderRadius.circular(16),
@@ -181,7 +185,11 @@ class _ConsumerEditProfilePageState extends State<ConsumerEditProfilePage> {
                                           ),
                                         )
                                       else ...[
-                                        const Icon(Icons.save_outlined, color: AppColors.white, size: 18),
+                                        const Icon(
+                                          Icons.save_outlined,
+                                          color: AppColors.white,
+                                          size: 18,
+                                        ),
                                         const SizedBox(width: 8),
                                       ],
                                       const SizedBox(width: 8),

--- a/lib/features/consumer_profile/presentation/pages/consumer_profile_page.dart
+++ b/lib/features/consumer_profile/presentation/pages/consumer_profile_page.dart
@@ -44,15 +44,22 @@ class _ConsumerProfileView extends StatelessWidget {
         body: SafeArea(
           child: BlocBuilder<ConsumerProfileBloc, ConsumerProfileState>(
             builder: (context, state) {
-              if (state is ConsumerProfileLoading || state is ConsumerProfileInitial) {
-                return const Center(child: CircularProgressIndicator(color: AppColors.darkGreen));
+              if (state is ConsumerProfileLoading ||
+                  state is ConsumerProfileInitial) {
+                return const Center(
+                  child: CircularProgressIndicator(color: AppColors.darkGreen),
+                );
               }
               if (state is ConsumerProfileFailure) {
                 return Center(
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      const Icon(Icons.error_outline, color: AppColors.red, size: 48),
+                      const Icon(
+                        Icons.error_outline,
+                        color: AppColors.red,
+                        size: 48,
+                      ),
                       const SizedBox(height: 16),
                       Text(state.message),
                     ],
@@ -98,11 +105,20 @@ class _ConsumerProfileView extends StatelessWidget {
                     ),
                     const SizedBox(height: 8),
                     // User info rows
-                    ProfileInfoRow(icon: Icons.email_outlined, text: profile.email),
+                    ProfileInfoRow(
+                      icon: Icons.email_outlined,
+                      text: profile.email,
+                    ),
                     const SizedBox(height: 7),
-                    ProfileInfoRow(icon: Icons.phone_outlined, text: profile.phone),
+                    ProfileInfoRow(
+                      icon: Icons.phone_outlined,
+                      text: profile.phone,
+                    ),
                     const SizedBox(height: 7),
-                    ProfileInfoRow(icon: Icons.location_on_outlined, text: profile.address),
+                    ProfileInfoRow(
+                      icon: Icons.location_on_outlined,
+                      text: profile.address,
+                    ),
                     const SizedBox(height: 32),
                     // Management section
                     const Padding(

--- a/lib/features/consumer_profile/presentation/widgets/profile_info_row.dart
+++ b/lib/features/consumer_profile/presentation/widgets/profile_info_row.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
 
 class ProfileInfoRow extends StatelessWidget {
-  const ProfileInfoRow({
-    super.key,
-    required this.icon,
-    required this.text,
-  });
+  const ProfileInfoRow({super.key, required this.icon, required this.text});
 
   final IconData icon;
   final String text;

--- a/lib/features/consumer_profile/presentation/widgets/profile_menu_item.dart
+++ b/lib/features/consumer_profile/presentation/widgets/profile_menu_item.dart
@@ -33,9 +33,7 @@ class ProfileMenuItem extends StatelessWidget {
         decoration: BoxDecoration(
           color: backgroundColor ?? AppColors.white,
           borderRadius: BorderRadius.circular(24),
-          border: Border.all(
-            color: borderColor ?? const Color(0x0D2E5729),
-          ),
+          border: Border.all(color: borderColor ?? const Color(0x0D2E5729)),
           boxShadow: const [
             BoxShadow(
               color: Color(0x0D000000),

--- a/lib/features/home/data/datasources/home_remote_datasource.dart
+++ b/lib/features/home/data/datasources/home_remote_datasource.dart
@@ -30,7 +30,10 @@ class HomeRemoteDataSource {
   /// === END REAL IMPLEMENTATION ===
   ///
   /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
-  Future<List<ProducerModel>> getProducers({int page = 1, int limit = 10}) async {
+  Future<List<ProducerModel>> getProducers({
+    int page = 1,
+    int limit = 10,
+  }) async {
     await Future.delayed(const Duration(milliseconds: 800));
     return List.generate(4, ProducerModel.mock);
   }

--- a/lib/features/home/data/models/home_product_model.dart
+++ b/lib/features/home/data/models/home_product_model.dart
@@ -17,29 +17,51 @@ class HomeProductModel extends HomeProduct {
       name: json['name'] as String,
       category: json['category'] as String? ?? '',
       price: (json['price'] as num).toDouble(),
-      imageUrl: json['image_s3'] as String? ?? json['imageUrl'] as String? ?? '',
+      imageUrl:
+          json['image_s3'] as String? ?? json['imageUrl'] as String? ?? '',
       farmName: json['farm_name'] as String? ?? '',
-      producerId: json['farmer_id'] as String? ?? json['producerId'] as String? ?? '',
+      producerId:
+          json['farmer_id'] as String? ?? json['producerId'] as String? ?? '',
     );
   }
 
   static List<HomeProductModel> mocks() {
     return [
       const HomeProductModel(
-        id: 'p1', name: 'Kiwi Orgânico', category: 'FRUTAS',
-        price: 8.90, imageUrl: '', farmName: 'Fazenda Sol Nascente', producerId: 'producer_1',
+        id: 'p1',
+        name: 'Kiwi Orgânico',
+        category: 'FRUTAS',
+        price: 8.90,
+        imageUrl: '',
+        farmName: 'Fazenda Sol Nascente',
+        producerId: 'producer_1',
       ),
       const HomeProductModel(
-        id: 'p2', name: 'Alface Crespa', category: 'HORTA',
-        price: 3.50, imageUrl: '', farmName: 'Fazenda Sol Nascente', producerId: 'producer_1',
+        id: 'p2',
+        name: 'Alface Crespa',
+        category: 'HORTA',
+        price: 3.50,
+        imageUrl: '',
+        farmName: 'Fazenda Sol Nascente',
+        producerId: 'producer_1',
       ),
       const HomeProductModel(
-        id: 'p3', name: 'Tomate Cereja', category: 'HORTA',
-        price: 12.90, imageUrl: '', farmName: 'Sítio Verde Vivo', producerId: 'producer_2',
+        id: 'p3',
+        name: 'Tomate Cereja',
+        category: 'HORTA',
+        price: 12.90,
+        imageUrl: '',
+        farmName: 'Sítio Verde Vivo',
+        producerId: 'producer_2',
       ),
       const HomeProductModel(
-        id: 'p4', name: 'Manga Palmer', category: 'FRUTAS',
-        price: 6.00, imageUrl: '', farmName: 'Sítio Verde Vivo', producerId: 'producer_2',
+        id: 'p4',
+        name: 'Manga Palmer',
+        category: 'FRUTAS',
+        price: 6.00,
+        imageUrl: '',
+        farmName: 'Sítio Verde Vivo',
+        producerId: 'producer_2',
       ),
     ];
   }

--- a/lib/features/home/data/models/producer_model.dart
+++ b/lib/features/home/data/models/producer_model.dart
@@ -15,7 +15,8 @@ class ProducerModel extends Producer {
       id: json['id'] as String,
       name: json['farm_name'] as String? ?? json['name'] as String,
       description: json['description'] as String? ?? '',
-      avatarUrl: json['avatar_s3'] as String? ?? json['avatarUrl'] as String? ?? '',
+      avatarUrl:
+          json['avatar_s3'] as String? ?? json['avatarUrl'] as String? ?? '',
       averageRating: (json['average_rating'] as num?)?.toDouble() ?? 0.0,
       ownerName: json['owner_name'] as String? ?? '',
     );

--- a/lib/features/home/domain/entities/home_product.dart
+++ b/lib/features/home/domain/entities/home_product.dart
@@ -20,5 +20,13 @@ class HomeProduct extends Equatable {
   final String producerId;
 
   @override
-  List<Object?> get props => [id, name, category, price, imageUrl, farmName, producerId];
+  List<Object?> get props => [
+    id,
+    name,
+    category,
+    price,
+    imageUrl,
+    farmName,
+    producerId,
+  ];
 }

--- a/lib/features/home/domain/entities/producer.dart
+++ b/lib/features/home/domain/entities/producer.dart
@@ -18,5 +18,12 @@ class Producer extends Equatable {
   final String ownerName;
 
   @override
-  List<Object?> get props => [id, name, description, avatarUrl, averageRating, ownerName];
+  List<Object?> get props => [
+    id,
+    name,
+    description,
+    avatarUrl,
+    averageRating,
+    ownerName,
+  ];
 }

--- a/lib/features/home/domain/usecases/get_home_data.dart
+++ b/lib/features/home/domain/usecases/get_home_data.dart
@@ -9,7 +9,8 @@ class GetHomeData {
 
   final HomeRepository _repository;
 
-  Future<({List<Producer> producers, List<HomeProduct> products})> call() async {
+  Future<({List<Producer> producers, List<HomeProduct> products})>
+  call() async {
     final results = await Future.wait([
       _repository.getProducers(),
       _repository.getRecommendedProducts(),

--- a/lib/features/home/presentation/pages/consumer_home_page.dart
+++ b/lib/features/home/presentation/pages/consumer_home_page.dart
@@ -40,62 +40,67 @@ class _ConsumerHomeView extends StatelessWidget {
             return switch (state) {
               HomeLoading() || HomeInitial() => const _HomeLoadingView(),
               HomeLoaded(:final producers, :final products) => RefreshIndicator(
-                  onRefresh: () async {
-                    context.read<HomeBloc>().add(const HomeRefreshed());
-                  },
-                  child: CustomScrollView(
-                    slivers: [
-                      SliverToBoxAdapter(
-                        child: Padding(
-                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-                          child: const Text(
-                            'Início',
-                            style: TextStyle(
-                              fontFamily: 'Figtree',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 34,
-                              color: AppColors.darkGreen,
-                            ),
+                onRefresh: () async {
+                  context.read<HomeBloc>().add(const HomeRefreshed());
+                },
+                child: CustomScrollView(
+                  slivers: [
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                        child: const Text(
+                          'Início',
+                          style: TextStyle(
+                            fontFamily: 'Figtree',
+                            fontWeight: FontWeight.w700,
+                            fontSize: 34,
+                            color: AppColors.darkGreen,
                           ),
                         ),
                       ),
-                      const SliverToBoxAdapter(child: SizedBox(height: 24)),
-                      SliverToBoxAdapter(
-                        child: ProducersSection(
-                          producers: producers,
-                          onProducerTap: (p) => _onProducerTap(context, p),
-                        ),
+                    ),
+                    const SliverToBoxAdapter(child: SizedBox(height: 24)),
+                    SliverToBoxAdapter(
+                      child: ProducersSection(
+                        producers: producers,
+                        onProducerTap: (p) => _onProducerTap(context, p),
                       ),
-                      const SliverToBoxAdapter(child: SizedBox(height: 32)),
-                      SliverToBoxAdapter(
-                        child: ProductsGrid(
-                          products: products,
-                          onProductTap: (p) => context.push('/consumer/home/product/${p.id}'),
-                          onAddToCart: (_) {
-                            // TODO: navigate to cart / add to cart
-                          },
-                        ),
+                    ),
+                    const SliverToBoxAdapter(child: SizedBox(height: 32)),
+                    SliverToBoxAdapter(
+                      child: ProductsGrid(
+                        products: products,
+                        onProductTap: (p) =>
+                            context.push('/consumer/home/product/${p.id}'),
+                        onAddToCart: (_) {
+                          // TODO: navigate to cart / add to cart
+                        },
                       ),
-                      const SliverToBoxAdapter(child: SizedBox(height: 32)),
-                    ],
-                  ),
+                    ),
+                    const SliverToBoxAdapter(child: SizedBox(height: 32)),
+                  ],
                 ),
+              ),
               HomeFailure(:final message) => Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Icon(Icons.error_outline, color: AppColors.red, size: 48),
-                      const SizedBox(height: 16),
-                      Text(message, textAlign: TextAlign.center),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                        onPressed: () =>
-                            context.read<HomeBloc>().add(const HomeRefreshed()),
-                        child: const Text('Tentar novamente'),
-                      ),
-                    ],
-                  ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      color: AppColors.red,
+                      size: 48,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(message, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () =>
+                          context.read<HomeBloc>().add(const HomeRefreshed()),
+                      child: const Text('Tentar novamente'),
+                    ),
+                  ],
                 ),
+              ),
             };
           },
         ),

--- a/lib/features/home/presentation/widgets/home_product_card.dart
+++ b/lib/features/home/presentation/widgets/home_product_card.dart
@@ -19,112 +19,112 @@ class HomeProductCard extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-      decoration: BoxDecoration(
-        color: AppColors.inputBackground,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0x00381717)),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x0D000000),
-            blurRadius: 2,
-            offset: Offset(0, 1),
-          ),
-        ],
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Product image
-          AspectRatio(
-            aspectRatio: 1,
-            child: product.imageUrl.isNotEmpty
-                ? Image.network(
-                    product.imageUrl,
-                    fit: BoxFit.cover,
-                    errorBuilder: (_, __, ___) => const _ProductPlaceholder(),
-                  )
-                : const _ProductPlaceholder(),
-          ),
-          // Product info
-          Padding(
-            padding: const EdgeInsets.fromLTRB(4, 4, 4, 0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  product.category.toUpperCase(),
-                  style: const TextStyle(
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 10,
-                    color: AppColors.darkGreen,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  product.name,
-                  style: const TextStyle(
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 14,
-                    color: AppColors.black,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  product.farmName,
-                  style: const TextStyle(
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w300,
-                    fontSize: 12,
-                    color: AppColors.black,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 8),
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        'R\$ ${product.price.toStringAsFixed(2).replaceAll('.', ',')}',
-                        style: const TextStyle(
-                          fontFamily: 'Figtree',
-                          fontWeight: FontWeight.w700,
-                          fontSize: 16,
-                          color: AppColors.black,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    GestureDetector(
-                      onTap: onAddToCart,
-                      child: Container(
-                        width: 32,
-                        height: 32,
-                        decoration: BoxDecoration(
-                          color: AppColors.darkGreen,
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        child: const Icon(
-                          Icons.add_shopping_cart,
-                          color: AppColors.white,
-                          size: 16,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 9),
-              ],
+        decoration: BoxDecoration(
+          color: AppColors.inputBackground,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: const Color(0x00381717)),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x0D000000),
+              blurRadius: 2,
+              offset: Offset(0, 1),
             ),
-          ),
-        ],
-      ),
+          ],
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Product image
+            AspectRatio(
+              aspectRatio: 1,
+              child: product.imageUrl.isNotEmpty
+                  ? Image.network(
+                      product.imageUrl,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => const _ProductPlaceholder(),
+                    )
+                  : const _ProductPlaceholder(),
+            ),
+            // Product info
+            Padding(
+              padding: const EdgeInsets.fromLTRB(4, 4, 4, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    product.category.toUpperCase(),
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w700,
+                      fontSize: 10,
+                      color: AppColors.darkGreen,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    product.name,
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w700,
+                      fontSize: 14,
+                      color: AppColors.black,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    product.farmName,
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w300,
+                      fontSize: 12,
+                      color: AppColors.black,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          'R\$ ${product.price.toStringAsFixed(2).replaceAll('.', ',')}',
+                          style: const TextStyle(
+                            fontFamily: 'Figtree',
+                            fontWeight: FontWeight.w700,
+                            fontSize: 16,
+                            color: AppColors.black,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      GestureDetector(
+                        onTap: onAddToCart,
+                        child: Container(
+                          width: 32,
+                          height: 32,
+                          decoration: BoxDecoration(
+                            color: AppColors.darkGreen,
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: const Icon(
+                            Icons.add_shopping_cart,
+                            color: AppColors.white,
+                            size: 16,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 9),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/presentation/widgets/producer_card.dart
+++ b/lib/features/home/presentation/widgets/producer_card.dart
@@ -3,11 +3,7 @@ import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/home/domain/entities/producer.dart';
 
 class ProducerCard extends StatelessWidget {
-  const ProducerCard({
-    super.key,
-    required this.producer,
-    required this.onTap,
-  });
+  const ProducerCard({super.key, required this.producer, required this.onTap});
 
   final Producer producer;
   final VoidCallback onTap;
@@ -49,7 +45,8 @@ class ProducerCard extends StatelessWidget {
                       ? Image.network(
                           producer.avatarUrl,
                           fit: BoxFit.cover,
-                          errorBuilder: (_, __, ___) => const _PlaceholderImage(),
+                          errorBuilder: (_, __, ___) =>
+                              const _PlaceholderImage(),
                         )
                       : const _PlaceholderImage(),
                 ),
@@ -58,7 +55,10 @@ class ProducerCard extends StatelessWidget {
                   top: 12,
                   left: 12,
                   child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
                     decoration: BoxDecoration(
                       color: Colors.white.withOpacity(0.9),
                       borderRadius: BorderRadius.circular(9999),
@@ -66,7 +66,11 @@ class ProducerCard extends StatelessWidget {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const Icon(Icons.star, color: Color(0xFFFFC107), size: 12),
+                        const Icon(
+                          Icons.star,
+                          color: Color(0xFFFFC107),
+                          size: 12,
+                        ),
                         const SizedBox(width: 4),
                         Text(
                           producer.averageRating.toStringAsFixed(1),
@@ -118,7 +122,11 @@ class ProducerCard extends StatelessWidget {
                       CircleAvatar(
                         radius: 12,
                         backgroundColor: AppColors.mintGreen.withOpacity(0.3),
-                        child: const Icon(Icons.person, size: 14, color: AppColors.darkGreen),
+                        child: const Icon(
+                          Icons.person,
+                          size: 14,
+                          color: AppColors.darkGreen,
+                        ),
                       ),
                       const SizedBox(width: 8),
                       Text(

--- a/lib/features/inventory/data/datasources/inventory_remote_datasource.dart
+++ b/lib/features/inventory/data/datasources/inventory_remote_datasource.dart
@@ -8,7 +8,8 @@ class InventoryRemoteDataSource {
       id: 'inv001',
       producerId: 'prod001',
       name: 'Tomate Cereja Orgânico',
-      description: 'Tomate cereja cultivado sem agrotóxicos, colhido fresco da horta.',
+      description:
+          'Tomate cereja cultivado sem agrotóxicos, colhido fresco da horta.',
       imageUrl: '',
       price: 2.50,
       unit: 'kg',
@@ -30,7 +31,8 @@ class InventoryRemoteDataSource {
       id: 'inv003',
       producerId: 'prod001',
       name: 'Batata Monalisa',
-      description: 'Batata de casca fina e polpa macia, perfeita para purês e cozidos.',
+      description:
+          'Batata de casca fina e polpa macia, perfeita para purês e cozidos.',
       imageUrl: '',
       price: 8.20,
       unit: 'kg',

--- a/lib/features/inventory/domain/entities/inventory_product.dart
+++ b/lib/features/inventory/domain/entities/inventory_product.dart
@@ -48,6 +48,15 @@ class InventoryProduct extends Equatable {
   }
 
   @override
-  List<Object?> get props =>
-      [id, producerId, name, description, imageUrl, price, unit, stock, active];
+  List<Object?> get props => [
+    id,
+    producerId,
+    name,
+    description,
+    imageUrl,
+    price,
+    unit,
+    stock,
+    active,
+  ];
 }

--- a/lib/features/inventory/presentation/bloc/inventory_bloc.dart
+++ b/lib/features/inventory/presentation/bloc/inventory_bloc.dart
@@ -9,7 +9,7 @@ import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_stat
 @injectable
 class InventoryBloc extends Bloc<InventoryEvent, InventoryState> {
   InventoryBloc(this._getProducts, this._deleteProduct)
-      : super(const InventoryInitial()) {
+    : super(const InventoryInitial()) {
     on<InventoryStarted>(_onStarted);
     on<InventoryFilterChanged>(_onFilterChanged);
     on<InventoryProductDeleted>(_onProductDeleted);
@@ -76,8 +76,10 @@ class InventoryBloc extends Bloc<InventoryEvent, InventoryState> {
         _allProducts.where((p) => !p.active || p.stock == 0).toList(),
       _ => List<InventoryProduct>.from(_allProducts),
     };
-    final totalValue =
-        _allProducts.fold(0.0, (sum, p) => sum + p.price * p.stock);
+    final totalValue = _allProducts.fold(
+      0.0,
+      (sum, p) => sum + p.price * p.stock,
+    );
     return InventoryLoaded(
       products: filtered,
       activeFilter: _activeFilter,

--- a/lib/features/inventory/presentation/bloc/product_form_bloc.dart
+++ b/lib/features/inventory/presentation/bloc/product_form_bloc.dart
@@ -9,11 +9,8 @@ import 'package:ragro_mobile/features/inventory/presentation/bloc/product_form_s
 
 @injectable
 class ProductFormBloc extends Bloc<ProductFormEvent, ProductFormState> {
-  ProductFormBloc(
-    this._getProducts,
-    this._createProduct,
-    this._updateProduct,
-  ) : super(const ProductFormInitial()) {
+  ProductFormBloc(this._getProducts, this._createProduct, this._updateProduct)
+    : super(const ProductFormInitial()) {
     on<ProductFormStarted>(_onStarted);
     on<ProductFormSaved>(_onSaved);
   }

--- a/lib/features/inventory/presentation/pages/inventory_page.dart
+++ b/lib/features/inventory/presentation/pages/inventory_page.dart
@@ -67,15 +67,20 @@ class _InventoryView extends StatelessWidget {
                           onTap: () => context.push('/producer/stock/new'),
                           child: Container(
                             padding: const EdgeInsets.symmetric(
-                                horizontal: 16, vertical: 8),
+                              horizontal: 16,
+                              vertical: 8,
+                            ),
                             decoration: BoxDecoration(
                               color: AppColors.darkGreen,
                               borderRadius: BorderRadius.circular(24),
                             ),
                             child: const Row(
                               children: [
-                                Icon(Icons.add,
-                                    size: 16, color: AppColors.white),
+                                Icon(
+                                  Icons.add,
+                                  size: 16,
+                                  color: AppColors.white,
+                                ),
                                 SizedBox(width: 4),
                                 Text(
                                   'Novo',
@@ -144,19 +149,21 @@ class _InventoryView extends StatelessWidget {
                         final count = f.$1 == 'all'
                             ? state.totalItems
                             : f.$1 == 'active'
-                                ? state.products
-                                    .where((p) => p.active && p.stock > 0)
-                                    .length
-                                : null;
+                            ? state.products
+                                  .where((p) => p.active && p.stock > 0)
+                                  .length
+                            : null;
                         return Padding(
                           padding: const EdgeInsets.only(right: 8),
                           child: GestureDetector(
-                            onTap: () => context
-                                .read<InventoryBloc>()
-                                .add(InventoryFilterChanged(f.$1)),
+                            onTap: () => context.read<InventoryBloc>().add(
+                              InventoryFilterChanged(f.$1),
+                            ),
                             child: Container(
                               padding: const EdgeInsets.symmetric(
-                                  horizontal: 16, vertical: 8),
+                                horizontal: 16,
+                                vertical: 8,
+                              ),
                               decoration: BoxDecoration(
                                 color: isActive
                                     ? AppColors.darkGreen
@@ -195,8 +202,11 @@ class _InventoryView extends StatelessWidget {
                             child: Column(
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                Icon(Icons.inventory_2_outlined,
-                                    size: 64, color: AppColors.placeholder),
+                                Icon(
+                                  Icons.inventory_2_outlined,
+                                  size: 64,
+                                  color: AppColors.placeholder,
+                                ),
                                 SizedBox(height: 16),
                                 Text(
                                   'Nenhum produto encontrado',
@@ -210,8 +220,7 @@ class _InventoryView extends StatelessWidget {
                             ),
                           )
                         : ListView.separated(
-                            padding:
-                                const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                             itemCount: state.products.length,
                             separatorBuilder: (_, __) =>
                                 const SizedBox(height: 12),
@@ -235,13 +244,12 @@ class _InventoryView extends StatelessWidget {
                   const Expanded(
                     child: Center(
                       child: CircularProgressIndicator(
-                          color: AppColors.darkGreen),
+                        color: AppColors.darkGreen,
+                      ),
                     ),
                   ),
                 ] else if (state is InventoryFailure) ...[
-                  Expanded(
-                    child: Center(child: Text(state.message)),
-                  ),
+                  Expanded(child: Center(child: Text(state.message))),
                 ] else ...[
                   const Expanded(child: SizedBox.shrink()),
                 ],
@@ -253,17 +261,18 @@ class _InventoryView extends StatelessWidget {
     );
   }
 
-  void _confirmDelete(BuildContext context, String productId, String productName) {
+  void _confirmDelete(
+    BuildContext context,
+    String productId,
+    String productName,
+  ) {
     showDialog<void>(
       context: context,
       builder: (dialogContext) => AlertDialog(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         title: const Text(
           'Excluir produto?',
-          style: TextStyle(
-            fontFamily: 'Figtree',
-            fontWeight: FontWeight.w700,
-          ),
+          style: TextStyle(fontFamily: 'Figtree', fontWeight: FontWeight.w700),
         ),
         content: Text(
           'Tem certeza que deseja excluir "$productName"?',
@@ -280,19 +289,23 @@ class _InventoryView extends StatelessWidget {
           ElevatedButton(
             onPressed: () {
               Navigator.of(dialogContext).pop();
-              context
-                  .read<InventoryBloc>()
-                  .add(InventoryProductDeleted(productId));
+              context.read<InventoryBloc>().add(
+                InventoryProductDeleted(productId),
+              );
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColors.red,
               foregroundColor: AppColors.white,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8)),
+                borderRadius: BorderRadius.circular(8),
+              ),
             ),
             child: const Text(
               'Excluir',
-              style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700),
+              style: TextStyle(
+                fontFamily: 'Manrope',
+                fontWeight: FontWeight.w700,
+              ),
             ),
           ),
         ],

--- a/lib/features/inventory/presentation/pages/product_form_page.dart
+++ b/lib/features/inventory/presentation/pages/product_form_page.dart
@@ -20,8 +20,9 @@ class ProductFormPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getIt<ProductFormBloc>()
-        ..add(ProductFormStarted(productId: productId)),
+      create: (_) =>
+          getIt<ProductFormBloc>()
+            ..add(ProductFormStarted(productId: productId)),
       child: _ProductFormView(isEditMode: productId != null),
     );
   }
@@ -59,8 +60,7 @@ class _ProductFormViewState extends State<_ProductFormView> {
     if (state.product != null) {
       _nameController.text = state.product!.name;
       _descriptionController.text = state.product!.description;
-      _priceController.text =
-          state.product!.price.toStringAsFixed(2);
+      _priceController.text = state.product!.price.toStringAsFixed(2);
       _selectedUnit = state.product!.unit;
       _stockCount = state.product!.stock;
     }
@@ -81,14 +81,14 @@ class _ProductFormViewState extends State<_ProductFormView> {
     }
     final price = double.tryParse(priceText) ?? 0.0;
     context.read<ProductFormBloc>().add(
-          ProductFormSaved(
-            name: name,
-            description: description,
-            price: price,
-            unit: _selectedUnit,
-            stock: _stockCount,
-          ),
-        );
+      ProductFormSaved(
+        name: name,
+        description: description,
+        price: price,
+        unit: _selectedUnit,
+        stock: _stockCount,
+      ),
+    );
   }
 
   @override
@@ -99,9 +99,11 @@ class _ProductFormViewState extends State<_ProductFormView> {
         if (state is ProductFormSuccess) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(widget.isEditMode
-                  ? 'Produto atualizado com sucesso!'
-                  : 'Produto criado com sucesso!'),
+              content: Text(
+                widget.isEditMode
+                    ? 'Produto atualizado com sucesso!'
+                    : 'Produto criado com sucesso!',
+              ),
               backgroundColor: AppColors.darkGreen,
             ),
           );
@@ -164,22 +166,26 @@ class _ProductFormViewState extends State<_ProductFormView> {
                           onTap: () {
                             ScaffoldMessenger.of(context).showSnackBar(
                               const SnackBar(
-                                content:
-                                    Text('Seleção de imagem em breve...'),
+                                content: Text('Seleção de imagem em breve...'),
                               ),
                             );
                           },
                           child: Container(
                             padding: const EdgeInsets.symmetric(
-                                horizontal: 16, vertical: 8),
+                              horizontal: 16,
+                              vertical: 8,
+                            ),
                             decoration: BoxDecoration(
                               color: AppColors.darkGreen,
                               borderRadius: BorderRadius.circular(24),
                             ),
                             child: const Row(
                               children: [
-                                Icon(Icons.camera_alt_outlined,
-                                    size: 16, color: AppColors.white),
+                                Icon(
+                                  Icons.camera_alt_outlined,
+                                  size: 16,
+                                  color: AppColors.white,
+                                ),
                                 SizedBox(width: 6),
                                 Text(
                                   'Alterar Foto',
@@ -238,7 +244,8 @@ class _ProductFormViewState extends State<_ProductFormView> {
                             controller: _priceController,
                             hint: '0,00',
                             keyboardType: const TextInputType.numberWithOptions(
-                                decimal: true),
+                              decimal: true,
+                            ),
                             enabled: !isLoading,
                           ),
                         ],
@@ -257,25 +264,26 @@ class _ProductFormViewState extends State<_ProductFormView> {
                             decoration: BoxDecoration(
                               color: AppColors.inputBackground,
                               borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                  color: AppColors.inputBorder),
+                              border: Border.all(color: AppColors.inputBorder),
                             ),
                             child: DropdownButton<String>(
                               value: _selectedUnit,
                               isExpanded: true,
                               underline: const SizedBox.shrink(),
                               items: _units
-                                  .map((u) => DropdownMenuItem(
-                                        value: u,
-                                        child: Text(
-                                          u,
-                                          style: const TextStyle(
-                                            fontFamily: 'Manrope',
-                                            fontSize: 15,
-                                            color: AppColors.black,
-                                          ),
+                                  .map(
+                                    (u) => DropdownMenuItem(
+                                      value: u,
+                                      child: Text(
+                                        u,
+                                        style: const TextStyle(
+                                          fontFamily: 'Manrope',
+                                          fontSize: 15,
+                                          color: AppColors.black,
                                         ),
-                                      ))
+                                      ),
+                                    ),
+                                  )
                                   .toList(),
                               onChanged: isLoading
                                   ? null
@@ -314,10 +322,12 @@ class _ProductFormViewState extends State<_ProductFormView> {
                     style: ElevatedButton.styleFrom(
                       backgroundColor: AppColors.darkGreen,
                       foregroundColor: AppColors.white,
-                      disabledBackgroundColor:
-                          AppColors.darkGreen.withOpacity(0.5),
+                      disabledBackgroundColor: AppColors.darkGreen.withOpacity(
+                        0.5,
+                      ),
                       shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(24)),
+                        borderRadius: BorderRadius.circular(24),
+                      ),
                       padding: const EdgeInsets.symmetric(vertical: 16),
                     ),
                     child: isLoading
@@ -399,8 +409,10 @@ class _TextField extends StatelessWidget {
         ),
         filled: true,
         fillColor: AppColors.inputBackground,
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 14,
+        ),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: const BorderSide(color: AppColors.inputBorder),
@@ -467,8 +479,7 @@ class _StockStepper extends StatelessWidget {
             ),
           ),
           GestureDetector(
-            onTap:
-                onChanged != null ? () => onChanged!(value + 1) : null,
+            onTap: onChanged != null ? () => onChanged!(value + 1) : null,
             child: Container(
               padding: const EdgeInsets.all(4),
               child: const Icon(

--- a/lib/features/inventory/presentation/widgets/inventory_product_card.dart
+++ b/lib/features/inventory/presentation/widgets/inventory_product_card.dart
@@ -77,7 +77,9 @@ class InventoryProductCard extends StatelessWidget {
                     const SizedBox(width: 8),
                     Container(
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 3),
+                        horizontal: 8,
+                        vertical: 3,
+                      ),
                       decoration: BoxDecoration(
                         color: isAvailable
                             ? AppColors.lightGreen.withOpacity(0.12)
@@ -136,15 +138,20 @@ class InventoryProductCard extends StatelessWidget {
                       onTap: onEditTap,
                       child: Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 6),
+                          horizontal: 12,
+                          vertical: 6,
+                        ),
                         decoration: BoxDecoration(
                           color: AppColors.lightGreen.withOpacity(0.1),
                           borderRadius: BorderRadius.circular(8),
                         ),
                         child: const Row(
                           children: [
-                            Icon(Icons.edit_outlined,
-                                size: 14, color: AppColors.lightGreen),
+                            Icon(
+                              Icons.edit_outlined,
+                              size: 14,
+                              color: AppColors.lightGreen,
+                            ),
                             SizedBox(width: 4),
                             Text(
                               'Editar',
@@ -165,15 +172,20 @@ class InventoryProductCard extends StatelessWidget {
                       onTap: onDeleteTap,
                       child: Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 6),
+                          horizontal: 12,
+                          vertical: 6,
+                        ),
                         decoration: BoxDecoration(
                           color: AppColors.red.withOpacity(0.1),
                           borderRadius: BorderRadius.circular(8),
                         ),
                         child: const Row(
                           children: [
-                            Icon(Icons.delete_outline,
-                                size: 14, color: AppColors.red),
+                            Icon(
+                              Icons.delete_outline,
+                              size: 14,
+                              color: AppColors.red,
+                            ),
                             SizedBox(width: 4),
                             Text(
                               'Excluir',

--- a/lib/features/orders/data/datasources/orders_remote_datasource.dart
+++ b/lib/features/orders/data/datasources/orders_remote_datasource.dart
@@ -13,10 +13,38 @@ class OrdersRemoteDatasource {
       farmAvatarUrl: '',
       ownerName: 'Manoel Silva',
       items: const [
-        OrderItem(productId: 'prod1', name: 'Tomate', imageUrl: '', quantity: 1, unityType: 'un', totalPrice: 12.90),
-        OrderItem(productId: 'prod2', name: 'Bananas', imageUrl: '', quantity: 3, unityType: 'kg', totalPrice: 18.00),
-        OrderItem(productId: 'prod3', name: 'Maçã', imageUrl: '', quantity: 1, unityType: 'kg', totalPrice: 9.00),
-        OrderItem(productId: 'prod4', name: 'Alface Crespa', imageUrl: '', quantity: 1, unityType: 'un', totalPrice: 4.50),
+        OrderItem(
+          productId: 'prod1',
+          name: 'Tomate',
+          imageUrl: '',
+          quantity: 1,
+          unityType: 'un',
+          totalPrice: 12.90,
+        ),
+        OrderItem(
+          productId: 'prod2',
+          name: 'Bananas',
+          imageUrl: '',
+          quantity: 3,
+          unityType: 'kg',
+          totalPrice: 18.00,
+        ),
+        OrderItem(
+          productId: 'prod3',
+          name: 'Maçã',
+          imageUrl: '',
+          quantity: 1,
+          unityType: 'kg',
+          totalPrice: 9.00,
+        ),
+        OrderItem(
+          productId: 'prod4',
+          name: 'Alface Crespa',
+          imageUrl: '',
+          quantity: 1,
+          unityType: 'un',
+          totalPrice: 4.50,
+        ),
       ],
       totalAmount: 145.90,
       status: OrderStatus.pending,
@@ -42,9 +70,30 @@ class OrdersRemoteDatasource {
       farmAvatarUrl: '',
       ownerName: 'Manoel Silva',
       items: const [
-        OrderItem(productId: 'prod1', name: 'Tomate', imageUrl: '', quantity: 1, unityType: 'un', totalPrice: 12.90),
-        OrderItem(productId: 'prod2', name: 'Bananas', imageUrl: '', quantity: 3, unityType: 'kg', totalPrice: 18.00),
-        OrderItem(productId: 'prod3', name: 'Maçã', imageUrl: '', quantity: 1, unityType: 'kg', totalPrice: 9.00),
+        OrderItem(
+          productId: 'prod1',
+          name: 'Tomate',
+          imageUrl: '',
+          quantity: 1,
+          unityType: 'un',
+          totalPrice: 12.90,
+        ),
+        OrderItem(
+          productId: 'prod2',
+          name: 'Bananas',
+          imageUrl: '',
+          quantity: 3,
+          unityType: 'kg',
+          totalPrice: 18.00,
+        ),
+        OrderItem(
+          productId: 'prod3',
+          name: 'Maçã',
+          imageUrl: '',
+          quantity: 1,
+          unityType: 'kg',
+          totalPrice: 9.00,
+        ),
       ],
       totalAmount: 145.90,
       status: OrderStatus.accepted,
@@ -70,8 +119,22 @@ class OrdersRemoteDatasource {
       farmAvatarUrl: '',
       ownerName: 'Manoel Silva',
       items: const [
-        OrderItem(productId: 'prod1', name: 'Tomate', imageUrl: '', quantity: 1, unityType: 'un', totalPrice: 12.90),
-        OrderItem(productId: 'prod5', name: 'Maçã', imageUrl: '', quantity: 1, unityType: 'kg', totalPrice: 9.00),
+        OrderItem(
+          productId: 'prod1',
+          name: 'Tomate',
+          imageUrl: '',
+          quantity: 1,
+          unityType: 'un',
+          totalPrice: 12.90,
+        ),
+        OrderItem(
+          productId: 'prod5',
+          name: 'Maçã',
+          imageUrl: '',
+          quantity: 1,
+          unityType: 'kg',
+          totalPrice: 9.00,
+        ),
       ],
       totalAmount: 145.90,
       status: OrderStatus.delivered,
@@ -97,7 +160,14 @@ class OrdersRemoteDatasource {
       farmAvatarUrl: '',
       ownerName: 'Manoel Silva',
       items: const [
-        OrderItem(productId: 'prod2', name: 'Bananas', imageUrl: '', quantity: 3, unityType: 'kg', totalPrice: 18.00),
+        OrderItem(
+          productId: 'prod2',
+          name: 'Bananas',
+          imageUrl: '',
+          quantity: 3,
+          unityType: 'kg',
+          totalPrice: 18.00,
+        ),
       ],
       totalAmount: 145.90,
       status: OrderStatus.cancelled,
@@ -167,7 +237,10 @@ class OrdersRemoteDatasource {
   /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<Order> getOrderById(String id) async {
     await Future<void>.delayed(const Duration(milliseconds: 400));
-    return _mockOrders.firstWhere((o) => o.id == id, orElse: () => _mockOrders.first);
+    return _mockOrders.firstWhere(
+      (o) => o.id == id,
+      orElse: () => _mockOrders.first,
+    );
   }
 
   /// Confirms an order from cart (POST /orders).

--- a/lib/features/orders/data/repositories/orders_repository_impl.dart
+++ b/lib/features/orders/data/repositories/orders_repository_impl.dart
@@ -10,7 +10,8 @@ class OrdersRepositoryImpl implements OrdersRepository {
   final OrdersRemoteDatasource _datasource;
 
   @override
-  Future<List<Order>> getOrders({OrderStatus? status}) => _datasource.getOrders(status: status);
+  Future<List<Order>> getOrders({OrderStatus? status}) =>
+      _datasource.getOrders(status: status);
 
   @override
   Future<Order> getOrderById(String id) => _datasource.getOrderById(id);
@@ -19,5 +20,6 @@ class OrdersRepositoryImpl implements OrdersRepository {
   Future<Order> confirmOrder(String cartId) => _datasource.confirmOrder(cartId);
 
   @override
-  Future<void> rateProducer(String orderId, int rating) => _datasource.rateProducer(orderId, rating);
+  Future<void> rateProducer(String orderId, int rating) =>
+      _datasource.rateProducer(orderId, rating);
 }

--- a/lib/features/orders/domain/entities/order.dart
+++ b/lib/features/orders/domain/entities/order.dart
@@ -70,10 +70,25 @@ class Order extends Equatable {
 
   String get shortItemsPreview {
     if (items.isEmpty) return '';
-    return items.take(3).map((i) => '${i.name} ${i.quantity}${i.unityType}').join(' | ') +
+    return items
+            .take(3)
+            .map((i) => '${i.name} ${i.quantity}${i.unityType}')
+            .join(' | ') +
         (items.length > 3 ? ' ...' : '');
   }
 
   @override
-  List<Object?> get props => [id, producerId, farmName, farmAvatarUrl, ownerName, items, totalAmount, status, createdAt, deliveryAddress, bankInfo];
+  List<Object?> get props => [
+    id,
+    producerId,
+    farmName,
+    farmAvatarUrl,
+    ownerName,
+    items,
+    totalAmount,
+    status,
+    createdAt,
+    deliveryAddress,
+    bankInfo,
+  ];
 }

--- a/lib/features/orders/domain/entities/order_item.dart
+++ b/lib/features/orders/domain/entities/order_item.dart
@@ -18,5 +18,12 @@ class OrderItem extends Equatable {
   final double totalPrice;
 
   @override
-  List<Object?> get props => [productId, name, imageUrl, quantity, unityType, totalPrice];
+  List<Object?> get props => [
+    productId,
+    name,
+    imageUrl,
+    quantity,
+    unityType,
+    totalPrice,
+  ];
 }

--- a/lib/features/orders/domain/entities/order_status.dart
+++ b/lib/features/orders/domain/entities/order_status.dart
@@ -2,9 +2,9 @@ enum OrderStatus { pending, accepted, delivered, cancelled }
 
 extension OrderStatusLabel on OrderStatus {
   String get label => switch (this) {
-        OrderStatus.pending => 'PENDENTE',
-        OrderStatus.accepted => 'ACEITO',
-        OrderStatus.delivered => 'ENTREGUE',
-        OrderStatus.cancelled => 'CANCELADO',
-      };
+    OrderStatus.pending => 'PENDENTE',
+    OrderStatus.accepted => 'ACEITO',
+    OrderStatus.delivered => 'ENTREGUE',
+    OrderStatus.cancelled => 'CANCELADO',
+  };
 }

--- a/lib/features/orders/domain/usecases/get_orders.dart
+++ b/lib/features/orders/domain/usecases/get_orders.dart
@@ -7,5 +7,6 @@ import 'package:ragro_mobile/features/orders/domain/repositories/orders_reposito
 class GetOrders {
   const GetOrders(this._repository);
   final OrdersRepository _repository;
-  Future<List<Order>> call({OrderStatus? status}) => _repository.getOrders(status: status);
+  Future<List<Order>> call({OrderStatus? status}) =>
+      _repository.getOrders(status: status);
 }

--- a/lib/features/orders/domain/usecases/rate_producer.dart
+++ b/lib/features/orders/domain/usecases/rate_producer.dart
@@ -5,5 +5,6 @@ import 'package:ragro_mobile/features/orders/domain/repositories/orders_reposito
 class RateProducer {
   const RateProducer(this._repository);
   final OrdersRepository _repository;
-  Future<void> call(String orderId, int rating) => _repository.rateProducer(orderId, rating);
+  Future<void> call(String orderId, int rating) =>
+      _repository.rateProducer(orderId, rating);
 }

--- a/lib/features/orders/presentation/bloc/checkout_bloc.dart
+++ b/lib/features/orders/presentation/bloc/checkout_bloc.dart
@@ -13,7 +13,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
 
   final ConfirmOrder _confirmOrder;
 
-  Future<void> _onStarted(CheckoutStarted event, Emitter<CheckoutState> emit) async {
+  Future<void> _onStarted(
+    CheckoutStarted event,
+    Emitter<CheckoutState> emit,
+  ) async {
     emit(const CheckoutLoading());
     try {
       // Load the order preview from the cart
@@ -24,7 +27,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     }
   }
 
-  Future<void> _onConfirmed(CheckoutConfirmed event, Emitter<CheckoutState> emit) async {
+  Future<void> _onConfirmed(
+    CheckoutConfirmed event,
+    Emitter<CheckoutState> emit,
+  ) async {
     emit(const CheckoutLoading());
     try {
       final order = await _confirmOrder(event.cartId);

--- a/lib/features/orders/presentation/bloc/order_detail_bloc.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_bloc.dart
@@ -12,7 +12,10 @@ class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
 
   final GetOrderDetail _getOrderDetail;
 
-  Future<void> _onStarted(OrderDetailStarted event, Emitter<OrderDetailState> emit) async {
+  Future<void> _onStarted(
+    OrderDetailStarted event,
+    Emitter<OrderDetailState> emit,
+  ) async {
     emit(const OrderDetailLoading());
     try {
       final order = await _getOrderDetail(event.orderId);

--- a/lib/features/orders/presentation/bloc/orders_bloc.dart
+++ b/lib/features/orders/presentation/bloc/orders_bloc.dart
@@ -16,7 +16,10 @@ class OrdersBloc extends Bloc<OrdersEvent, OrdersState> {
   final GetOrders _getOrders;
   OrderStatus _activeTab = OrderStatus.pending;
 
-  Future<void> _onStarted(OrdersStarted event, Emitter<OrdersState> emit) async {
+  Future<void> _onStarted(
+    OrdersStarted event,
+    Emitter<OrdersState> emit,
+  ) async {
     _activeTab = event.status;
     emit(OrdersLoading(_activeTab));
     try {
@@ -27,7 +30,10 @@ class OrdersBloc extends Bloc<OrdersEvent, OrdersState> {
     }
   }
 
-  Future<void> _onTabChanged(OrdersTabChanged event, Emitter<OrdersState> emit) async {
+  Future<void> _onTabChanged(
+    OrdersTabChanged event,
+    Emitter<OrdersState> emit,
+  ) async {
     _activeTab = event.status;
     emit(OrdersLoading(_activeTab));
     try {
@@ -38,7 +44,10 @@ class OrdersBloc extends Bloc<OrdersEvent, OrdersState> {
     }
   }
 
-  Future<void> _onRefreshed(OrdersRefreshed event, Emitter<OrdersState> emit) async {
+  Future<void> _onRefreshed(
+    OrdersRefreshed event,
+    Emitter<OrdersState> emit,
+  ) async {
     emit(OrdersLoading(_activeTab));
     try {
       final orders = await _getOrders(status: _activeTab);

--- a/lib/features/orders/presentation/bloc/rate_producer_bloc.dart
+++ b/lib/features/orders/presentation/bloc/rate_producer_bloc.dart
@@ -13,12 +13,24 @@ class RateProducerBloc extends Bloc<RateProducerEvent, RateProducerState> {
 
   final RateProducer _rateProducer;
 
-  void _onStarSelected(RateProducerStarSelected event, Emitter<RateProducerState> emit) {
-    final current = state is RateProducerInitial ? (state as RateProducerInitial).selectedRating : 0;
-    emit(RateProducerInitial(selectedRating: event.rating == current ? 0 : event.rating));
+  void _onStarSelected(
+    RateProducerStarSelected event,
+    Emitter<RateProducerState> emit,
+  ) {
+    final current = state is RateProducerInitial
+        ? (state as RateProducerInitial).selectedRating
+        : 0;
+    emit(
+      RateProducerInitial(
+        selectedRating: event.rating == current ? 0 : event.rating,
+      ),
+    );
   }
 
-  Future<void> _onSubmitted(RateProducerSubmitted event, Emitter<RateProducerState> emit) async {
+  Future<void> _onSubmitted(
+    RateProducerSubmitted event,
+    Emitter<RateProducerState> emit,
+  ) async {
     emit(const RateProducerSubmitting());
     try {
       await _rateProducer(event.orderId, event.rating);

--- a/lib/features/orders/presentation/pages/consumer_orders_page.dart
+++ b/lib/features/orders/presentation/pages/consumer_orders_page.dart
@@ -19,7 +19,8 @@ class ConsumerOrdersPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getIt<OrdersBloc>()..add(const OrdersStarted(OrderStatus.pending)),
+      create: (_) =>
+          getIt<OrdersBloc>()..add(const OrdersStarted(OrderStatus.pending)),
       child: const _OrdersView(),
     );
   }
@@ -62,8 +63,8 @@ class _OrdersView extends StatelessWidget {
                 final activeTab = state is OrdersLoading
                     ? state.activeTab
                     : state is OrdersLoaded
-                        ? state.activeTab
-                        : OrderStatus.pending;
+                    ? state.activeTab
+                    : OrderStatus.pending;
                 return SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   padding: const EdgeInsets.only(left: 16),
@@ -71,13 +72,18 @@ class _OrdersView extends StatelessWidget {
                     children: _tabs.map((tab) {
                       final isActive = activeTab == tab.$1;
                       return GestureDetector(
-                        onTap: () => context.read<OrdersBloc>().add(OrdersTabChanged(tab.$1)),
+                        onTap: () => context.read<OrdersBloc>().add(
+                          OrdersTabChanged(tab.$1),
+                        ),
                         child: Container(
                           padding: const EdgeInsets.fromLTRB(24, 17, 24, 18),
                           decoration: BoxDecoration(
                             border: isActive
                                 ? const Border(
-                                    bottom: BorderSide(color: AppColors.darkGreen, width: 3),
+                                    bottom: BorderSide(
+                                      color: AppColors.darkGreen,
+                                      width: 3,
+                                    ),
                                   )
                                 : null,
                           ),
@@ -85,9 +91,13 @@ class _OrdersView extends StatelessWidget {
                             tab.$2,
                             style: TextStyle(
                               fontFamily: 'Manrope',
-                              fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
+                              fontWeight: isActive
+                                  ? FontWeight.w700
+                                  : FontWeight.w500,
                               fontSize: 14,
-                              color: isActive ? AppColors.darkGreen : AppColors.placeholder,
+                              color: isActive
+                                  ? AppColors.darkGreen
+                                  : AppColors.placeholder,
                             ),
                           ),
                         ),
@@ -103,7 +113,9 @@ class _OrdersView extends StatelessWidget {
                 builder: (context, state) {
                   if (state is OrdersLoading) {
                     return const Center(
-                      child: CircularProgressIndicator(color: AppColors.darkGreen),
+                      child: CircularProgressIndicator(
+                        color: AppColors.darkGreen,
+                      ),
                     );
                   }
                   if (state is OrdersFailure) {
@@ -115,7 +127,11 @@ class _OrdersView extends StatelessWidget {
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          const Icon(Icons.shopping_bag_outlined, size: 64, color: AppColors.placeholder),
+                          const Icon(
+                            Icons.shopping_bag_outlined,
+                            size: 64,
+                            color: AppColors.placeholder,
+                          ),
                           const SizedBox(height: 16),
                           Text(
                             'Nenhum pedido ${state.activeTab.label.toLowerCase()}',
@@ -133,7 +149,8 @@ class _OrdersView extends StatelessWidget {
                     padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                     itemCount: state.orders.length,
                     separatorBuilder: (_, __) => const SizedBox(height: 13),
-                    itemBuilder: (context, index) => OrderCard(order: state.orders[index]),
+                    itemBuilder: (context, index) =>
+                        OrderCard(order: state.orders[index]),
                   );
                 },
               ),

--- a/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -36,13 +36,16 @@ class OrderConfirmationPage extends StatelessWidget {
           builder: (context, state) {
             if (state is CheckoutLoading || state is CheckoutInitial) {
               return const Scaffold(
-                body: Center(child: CircularProgressIndicator(color: AppColors.darkGreen)),
+                body: Center(
+                  child: CircularProgressIndicator(color: AppColors.darkGreen),
+                ),
               );
             }
             if (state is CheckoutFailure) {
               return Scaffold(body: Center(child: Text(state.message)));
             }
-            if (state is! CheckoutReady && state is! CheckoutSuccess) return const Scaffold();
+            if (state is! CheckoutReady && state is! CheckoutSuccess)
+              return const Scaffold();
 
             final order = state is CheckoutReady
                 ? state.order
@@ -141,7 +144,9 @@ class _CheckoutView extends StatelessWidget {
                           decoration: BoxDecoration(
                             color: AppColors.lightGreen.withOpacity(0.05),
                             borderRadius: BorderRadius.circular(24),
-                            border: Border.all(color: AppColors.lightGreen.withOpacity(0.1)),
+                            border: Border.all(
+                              color: AppColors.lightGreen.withOpacity(0.1),
+                            ),
                           ),
                           child: Row(
                             children: [
@@ -151,7 +156,11 @@ class _CheckoutView extends StatelessWidget {
                                   color: AppColors.darkGreen,
                                   borderRadius: BorderRadius.circular(16),
                                 ),
-                                child: const Icon(Icons.location_on, color: AppColors.white, size: 20),
+                                child: const Icon(
+                                  Icons.location_on,
+                                  color: AppColors.white,
+                                  size: 20,
+                                ),
                               ),
                               const SizedBox(width: 16),
                               Expanded(
@@ -194,7 +203,11 @@ class _CheckoutView extends StatelessWidget {
                             child: Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                Icon(Icons.map_outlined, color: AppColors.darkGreen, size: 24),
+                                Icon(
+                                  Icons.map_outlined,
+                                  color: AppColors.darkGreen,
+                                  size: 24,
+                                ),
                                 SizedBox(width: 8),
                                 Text(
                                   'Mapa de Entrega',
@@ -234,7 +247,10 @@ class _CheckoutView extends StatelessWidget {
                               ),
                             ),
                             Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 4,
+                              ),
                               decoration: BoxDecoration(
                                 color: AppColors.lightGreen.withOpacity(0.1),
                                 borderRadius: BorderRadius.circular(9999),
@@ -290,14 +306,35 @@ class _CheckoutView extends StatelessWidget {
                               // Bank
                               Row(
                                 children: [
-                                  const Icon(Icons.account_balance_outlined, size: 20, color: AppColors.darkGreen),
+                                  const Icon(
+                                    Icons.account_balance_outlined,
+                                    size: 20,
+                                    color: AppColors.darkGreen,
+                                  ),
                                   const SizedBox(width: 16),
                                   Expanded(
                                     child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       children: [
-                                        const Text('Banco', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.placeholder)),
-                                        Text(order.bankInfo.bank, style: const TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.black)),
+                                        const Text(
+                                          'Banco',
+                                          style: TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 14,
+                                            color: AppColors.placeholder,
+                                          ),
+                                        ),
+                                        Text(
+                                          order.bankInfo.bank,
+                                          style: const TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 14,
+                                            color: AppColors.black,
+                                          ),
+                                        ),
                                       ],
                                     ),
                                   ),
@@ -309,36 +346,94 @@ class _CheckoutView extends StatelessWidget {
                                 children: [
                                   Expanded(
                                     child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       children: [
-                                        const Text('Agência', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 12, color: AppColors.placeholder)),
-                                        Text(order.bankInfo.agency, style: const TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.black)),
+                                        const Text(
+                                          'Agência',
+                                          style: TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 12,
+                                            color: AppColors.placeholder,
+                                          ),
+                                        ),
+                                        Text(
+                                          order.bankInfo.agency,
+                                          style: const TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 14,
+                                            color: AppColors.black,
+                                          ),
+                                        ),
                                       ],
                                     ),
                                   ),
                                   Expanded(
                                     child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       children: [
-                                        const Text('Conta Corrente', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 12, color: AppColors.placeholder)),
-                                        Text(order.bankInfo.account, style: const TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.black)),
+                                        const Text(
+                                          'Conta Corrente',
+                                          style: TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 12,
+                                            color: AppColors.placeholder,
+                                          ),
+                                        ),
+                                        Text(
+                                          order.bankInfo.account,
+                                          style: const TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 14,
+                                            color: AppColors.black,
+                                          ),
+                                        ),
                                       ],
                                     ),
                                   ),
                                 ],
                               ),
-                              const Divider(color: Color(0xFFF1F5F9), height: 24),
+                              const Divider(
+                                color: Color(0xFFF1F5F9),
+                                height: 24,
+                              ),
                               // PIX
                               Row(
                                 children: [
-                                  const Icon(Icons.pix, size: 22, color: AppColors.lightGreen),
+                                  const Icon(
+                                    Icons.pix,
+                                    size: 22,
+                                    color: AppColors.lightGreen,
+                                  ),
                                   const SizedBox(width: 16),
                                   Expanded(
                                     child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       children: [
-                                        const Text('Chave PIX', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 12, color: AppColors.placeholder)),
-                                        Text(order.bankInfo.pixKey, style: const TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.black)),
+                                        const Text(
+                                          'Chave PIX',
+                                          style: TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 12,
+                                            color: AppColors.placeholder,
+                                          ),
+                                        ),
+                                        Text(
+                                          order.bankInfo.pixKey,
+                                          style: const TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 14,
+                                            color: AppColors.black,
+                                          ),
+                                        ),
                                       ],
                                     ),
                                   ),
@@ -374,12 +469,35 @@ class _CheckoutView extends StatelessWidget {
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
-                                    Text('Frete RAGRO Logística', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.black)),
-                                    Text('Previsão: 3 a 5 dias úteis', style: TextStyle(fontFamily: 'Manrope', fontSize: 12, color: AppColors.placeholder)),
+                                    Text(
+                                      'Frete RAGRO Logística',
+                                      style: TextStyle(
+                                        fontFamily: 'Manrope',
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 14,
+                                        color: AppColors.black,
+                                      ),
+                                    ),
+                                    Text(
+                                      'Previsão: 3 a 5 dias úteis',
+                                      style: TextStyle(
+                                        fontFamily: 'Manrope',
+                                        fontSize: 12,
+                                        color: AppColors.placeholder,
+                                      ),
+                                    ),
                                   ],
                                 ),
                               ),
-                              Text('Grátis', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.darkGreen)),
+                              Text(
+                                'Grátis',
+                                style: TextStyle(
+                                  fontFamily: 'Manrope',
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 14,
+                                  color: AppColors.darkGreen,
+                                ),
+                              ),
                             ],
                           ),
                         ),
@@ -396,7 +514,9 @@ class _CheckoutView extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(24, 25, 24, 24),
               decoration: BoxDecoration(
                 color: AppColors.white,
-                border: const Border(top: BorderSide(color: AppColors.placeholder)),
+                border: const Border(
+                  top: BorderSide(color: AppColors.placeholder),
+                ),
                 boxShadow: const [
                   BoxShadow(
                     color: Color(0x0D000000),
@@ -411,8 +531,22 @@ class _CheckoutView extends StatelessWidget {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      const Text('Subtotal', style: TextStyle(fontFamily: 'Manrope', fontSize: 14, color: AppColors.black)),
-                      Text(_formatPrice(order.totalAmount), style: const TextStyle(fontFamily: 'Manrope', fontSize: 14, color: AppColors.black)),
+                      const Text(
+                        'Subtotal',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontSize: 14,
+                          color: AppColors.black,
+                        ),
+                      ),
+                      Text(
+                        _formatPrice(order.totalAmount),
+                        style: const TextStyle(
+                          fontFamily: 'Manrope',
+                          fontSize: 14,
+                          color: AppColors.black,
+                        ),
+                      ),
                     ],
                   ),
                   const SizedBox(height: 8),
@@ -420,8 +554,23 @@ class _CheckoutView extends StatelessWidget {
                   const Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Text('Frete', style: TextStyle(fontFamily: 'Manrope', fontSize: 14, color: AppColors.black)),
-                      Text('Grátis', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 14, color: AppColors.darkGreen)),
+                      Text(
+                        'Frete',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontSize: 14,
+                          color: AppColors.black,
+                        ),
+                      ),
+                      Text(
+                        'Grátis',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontWeight: FontWeight.w700,
+                          fontSize: 14,
+                          color: AppColors.darkGreen,
+                        ),
+                      ),
                     ],
                   ),
                   const SizedBox(height: 8),
@@ -429,8 +578,24 @@ class _CheckoutView extends StatelessWidget {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      const Text('Total do Pedido', style: TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 16, color: AppColors.black)),
-                      Text(_formatPrice(order.totalAmount), style: const TextStyle(fontFamily: 'Manrope', fontWeight: FontWeight.w700, fontSize: 16, color: AppColors.black)),
+                      const Text(
+                        'Total do Pedido',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontWeight: FontWeight.w700,
+                          fontSize: 16,
+                          color: AppColors.black,
+                        ),
+                      ),
+                      Text(
+                        _formatPrice(order.totalAmount),
+                        style: const TextStyle(
+                          fontFamily: 'Manrope',
+                          fontWeight: FontWeight.w700,
+                          fontSize: 16,
+                          color: AppColors.black,
+                        ),
+                      ),
                     ],
                   ),
                   const SizedBox(height: 16),
@@ -441,7 +606,9 @@ class _CheckoutView extends StatelessWidget {
                       return GestureDetector(
                         onTap: isLoading
                             ? null
-                            : () => context.read<CheckoutBloc>().add(const CheckoutConfirmed('cart')),
+                            : () => context.read<CheckoutBloc>().add(
+                                const CheckoutConfirmed('cart'),
+                              ),
                         child: Container(
                           height: 56,
                           decoration: BoxDecoration(
@@ -450,7 +617,9 @@ class _CheckoutView extends StatelessWidget {
                           ),
                           child: Center(
                             child: isLoading
-                                ? const CircularProgressIndicator(color: AppColors.white)
+                                ? const CircularProgressIndicator(
+                                    color: AppColors.white,
+                                  )
                                 : const Row(
                                     mainAxisSize: MainAxisSize.min,
                                     children: [
@@ -464,7 +633,11 @@ class _CheckoutView extends StatelessWidget {
                                         ),
                                       ),
                                       SizedBox(width: 8),
-                                      Icon(Icons.check_circle_outline, color: AppColors.white, size: 20),
+                                      Icon(
+                                        Icons.check_circle_outline,
+                                        color: AppColors.white,
+                                        size: 20,
+                                      ),
                                     ],
                                   ),
                           ),

--- a/lib/features/orders/presentation/pages/order_detail_page.dart
+++ b/lib/features/orders/presentation/pages/order_detail_page.dart
@@ -30,7 +30,9 @@ class OrderDetailPage extends StatelessWidget {
         builder: (context, state) {
           if (state is OrderDetailLoading || state is OrderDetailInitial) {
             return const Scaffold(
-              body: Center(child: CircularProgressIndicator(color: AppColors.darkGreen)),
+              body: Center(
+                child: CircularProgressIndicator(color: AppColors.darkGreen),
+              ),
             );
           }
           if (state is OrderDetailFailure) {
@@ -99,7 +101,9 @@ class OrderDetailPage extends StatelessWidget {
                           decoration: BoxDecoration(
                             color: AppColors.white,
                             borderRadius: BorderRadius.circular(24),
-                            border: Border.all(color: AppColors.lightGreen.withOpacity(0.05)),
+                            border: Border.all(
+                              color: AppColors.lightGreen.withOpacity(0.05),
+                            ),
                             boxShadow: const [
                               BoxShadow(
                                 color: Color(0x0D000000),
@@ -111,16 +115,21 @@ class OrderDetailPage extends StatelessWidget {
                           child: Column(
                             children: [
                               ...order.items.asMap().entries.map((entry) {
-                                final isLast = entry.key == order.items.length - 1;
+                                final isLast =
+                                    entry.key == order.items.length - 1;
                                 return Column(
                                   children: [
                                     Padding(
-                                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 16,
+                                      ),
                                       child: OrderItemRow(item: entry.value),
                                     ),
                                     if (!isLast)
                                       Divider(
-                                        color: AppColors.lightGreen.withOpacity(0.05),
+                                        color: AppColors.lightGreen.withOpacity(
+                                          0.05,
+                                        ),
                                         height: 1,
                                       ),
                                   ],
@@ -135,13 +144,21 @@ class OrderDetailPage extends StatelessWidget {
                                   ),
                                   border: Border(
                                     top: BorderSide(
-                                      color: AppColors.lightGreen.withOpacity(0.1),
+                                      color: AppColors.lightGreen.withOpacity(
+                                        0.1,
+                                      ),
                                     ),
                                   ),
                                 ),
-                                padding: const EdgeInsets.fromLTRB(16, 17, 16, 16),
+                                padding: const EdgeInsets.fromLTRB(
+                                  16,
+                                  17,
+                                  16,
+                                  16,
+                                ),
                                 child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
                                   children: [
                                     const Text(
                                       'Total',
@@ -190,7 +207,9 @@ class OrderDetailPage extends StatelessWidget {
                           decoration: BoxDecoration(
                             color: AppColors.white,
                             borderRadius: BorderRadius.circular(24),
-                            border: Border.all(color: AppColors.lightGreen.withOpacity(0.05)),
+                            border: Border.all(
+                              color: AppColors.lightGreen.withOpacity(0.05),
+                            ),
                             boxShadow: const [
                               BoxShadow(
                                 color: Color(0x0D000000),
@@ -202,7 +221,11 @@ class OrderDetailPage extends StatelessWidget {
                           child: Row(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const Icon(Icons.location_on_outlined, size: 20, color: AppColors.darkGreen),
+                              const Icon(
+                                Icons.location_on_outlined,
+                                size: 20,
+                                color: AppColors.darkGreen,
+                              ),
                               const SizedBox(width: 12),
                               Expanded(
                                 child: Column(

--- a/lib/features/orders/presentation/pages/rate_producer_page.dart
+++ b/lib/features/orders/presentation/pages/rate_producer_page.dart
@@ -53,7 +53,9 @@ class RateProducerPage extends StatelessWidget {
               ),
               child: BlocBuilder<RateProducerBloc, RateProducerState>(
                 builder: (context, state) {
-                  final selectedRating = state is RateProducerInitial ? state.selectedRating : 0;
+                  final selectedRating = state is RateProducerInitial
+                      ? state.selectedRating
+                      : 0;
                   final isSubmitting = state is RateProducerSubmitting;
 
                   return Column(
@@ -91,7 +93,11 @@ class RateProducerPage extends StatelessWidget {
                       CircleAvatar(
                         radius: 40,
                         backgroundColor: AppColors.lightGreen.withOpacity(0.2),
-                        child: const Icon(Icons.storefront, size: 40, color: AppColors.lightGreen),
+                        child: const Icon(
+                          Icons.storefront,
+                          size: 40,
+                          color: AppColors.lightGreen,
+                        ),
                       ),
                       const SizedBox(height: 12),
                       // Farm name
@@ -119,12 +125,16 @@ class RateProducerPage extends StatelessWidget {
                           final starValue = index + 1;
                           return GestureDetector(
                             onTap: () => context.read<RateProducerBloc>().add(
-                                  RateProducerStarSelected(starValue),
-                                ),
+                              RateProducerStarSelected(starValue),
+                            ),
                             child: Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 4),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 4,
+                              ),
                               child: Icon(
-                                starValue <= selectedRating ? Icons.star : Icons.star_border,
+                                starValue <= selectedRating
+                                    ? Icons.star
+                                    : Icons.star_border,
                                 color: const Color(0xFFFFB413),
                                 size: 36,
                               ),
@@ -138,18 +148,22 @@ class RateProducerPage extends StatelessWidget {
                         onTap: (isSubmitting || selectedRating == 0)
                             ? null
                             : () => context.read<RateProducerBloc>().add(
-                                  RateProducerSubmitted(orderId, selectedRating),
-                                ),
+                                RateProducerSubmitted(orderId, selectedRating),
+                              ),
                         child: Container(
                           width: double.infinity,
                           height: 56,
                           decoration: BoxDecoration(
-                            color: selectedRating > 0 ? AppColors.darkGreen : AppColors.placeholder,
+                            color: selectedRating > 0
+                                ? AppColors.darkGreen
+                                : AppColors.placeholder,
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Center(
                             child: isSubmitting
-                                ? const CircularProgressIndicator(color: AppColors.white)
+                                ? const CircularProgressIndicator(
+                                    color: AppColors.white,
+                                  )
                                 : const Text(
                                     'Enviar',
                                     style: TextStyle(

--- a/lib/features/orders/presentation/widgets/order_card.dart
+++ b/lib/features/orders/presentation/widgets/order_card.dart
@@ -78,7 +78,11 @@ class OrderCard extends StatelessWidget {
                       ? NetworkImage(order.farmAvatarUrl)
                       : null,
                   child: order.farmAvatarUrl.isEmpty
-                      ? const Icon(Icons.storefront, size: 16, color: AppColors.lightGreen)
+                      ? const Icon(
+                          Icons.storefront,
+                          size: 16,
+                          color: AppColors.lightGreen,
+                        )
                       : null,
                 ),
                 const SizedBox(width: 8),

--- a/lib/features/orders/presentation/widgets/order_status_badge.dart
+++ b/lib/features/orders/presentation/widgets/order_status_badge.dart
@@ -8,11 +8,11 @@ class OrderStatusBadge extends StatelessWidget {
   final OrderStatus status;
 
   Color get _backgroundColor => switch (status) {
-        OrderStatus.pending => const Color(0xFFFFB413),
-        OrderStatus.accepted => AppColors.lightGreen,
-        OrderStatus.delivered => const Color(0xFF3B82F6),
-        OrderStatus.cancelled => AppColors.red,
-      };
+    OrderStatus.pending => const Color(0xFFFFB413),
+    OrderStatus.accepted => AppColors.lightGreen,
+    OrderStatus.delivered => const Color(0xFF3B82F6),
+    OrderStatus.cancelled => AppColors.red,
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +26,11 @@ class OrderStatusBadge extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           if (status != OrderStatus.cancelled) ...[
-            const Icon(Icons.check_circle_outline, color: Colors.white, size: 12),
+            const Icon(
+              Icons.check_circle_outline,
+              color: Colors.white,
+              size: 12,
+            ),
             const SizedBox(width: 4),
           ],
           Text(

--- a/lib/features/producer_management/domain/entities/producer_dashboard.dart
+++ b/lib/features/producer_management/domain/entities/producer_dashboard.dart
@@ -29,16 +29,16 @@ class ProducerDashboard extends Equatable {
 
   @override
   List<Object?> get props => [
-        producerName,
-        producerTitle,
-        avatarUrl,
-        totalSales,
-        salesGrowthPercent,
-        totalOrders,
-        ordersGrowthPercent,
-        stockPercentage,
-        stockChangePercent,
-        weeklyChartData,
-        currentMonth,
-      ];
+    producerName,
+    producerTitle,
+    avatarUrl,
+    totalSales,
+    salesGrowthPercent,
+    totalOrders,
+    ordersGrowthPercent,
+    stockPercentage,
+    stockChangePercent,
+    weeklyChartData,
+    currentMonth,
+  ];
 }

--- a/lib/features/producer_management/presentation/bloc/producer_management_bloc.dart
+++ b/lib/features/producer_management/presentation/bloc/producer_management_bloc.dart
@@ -8,7 +8,7 @@ import 'package:ragro_mobile/features/producer_management/presentation/bloc/prod
 class ProducerManagementBloc
     extends Bloc<ProducerManagementEvent, ProducerManagementState> {
   ProducerManagementBloc(this._getDashboard)
-      : super(const ProducerManagementInitial()) {
+    : super(const ProducerManagementInitial()) {
     on<ProducerManagementStarted>(_onStarted);
     on<ProducerManagementRefreshed>(_onRefreshed);
   }

--- a/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
@@ -21,8 +21,7 @@ class _ProducerEditProfilePageState extends State<ProducerEditProfilePage> {
     text: 'Produtor orgânico certificado com mais de 10 anos de experiência.',
   );
   final _phoneController = TextEditingController(text: '(51) 99999-0001');
-  final _locationController =
-      TextEditingController(text: 'Porto Alegre, RS');
+  final _locationController = TextEditingController(text: 'Porto Alegre, RS');
   bool _saving = false;
 
   @override
@@ -99,7 +98,8 @@ class _ProducerEditProfilePageState extends State<ProducerEditProfilePage> {
                       onTap: () {
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(
-                              content: Text('Seleção de foto em breve...')),
+                            content: Text('Seleção de foto em breve...'),
+                          ),
                         );
                       },
                       child: Container(
@@ -108,8 +108,11 @@ class _ProducerEditProfilePageState extends State<ProducerEditProfilePage> {
                           color: AppColors.darkGreen,
                           shape: BoxShape.circle,
                         ),
-                        child: const Icon(Icons.camera_alt,
-                            size: 16, color: AppColors.white),
+                        child: const Icon(
+                          Icons.camera_alt,
+                          size: 16,
+                          color: AppColors.white,
+                        ),
                       ),
                     ),
                   ),
@@ -147,10 +150,7 @@ class _ProducerEditProfilePageState extends State<ProducerEditProfilePage> {
 
             _FieldLabel('Localização'),
             const SizedBox(height: 8),
-            _TextField(
-              controller: _locationController,
-              hint: 'Cidade, Estado',
-            ),
+            _TextField(controller: _locationController, hint: 'Cidade, Estado'),
 
             const SizedBox(height: 32),
 
@@ -161,10 +161,10 @@ class _ProducerEditProfilePageState extends State<ProducerEditProfilePage> {
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppColors.darkGreen,
                   foregroundColor: AppColors.white,
-                  disabledBackgroundColor:
-                      AppColors.darkGreen.withOpacity(0.5),
+                  disabledBackgroundColor: AppColors.darkGreen.withOpacity(0.5),
                   shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(24)),
+                    borderRadius: BorderRadius.circular(24),
+                  ),
                   padding: const EdgeInsets.symmetric(vertical: 16),
                 ),
                 child: _saving
@@ -239,8 +239,10 @@ class _TextField extends StatelessWidget {
         ),
         filled: true,
         fillColor: AppColors.inputBackground,
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 14,
+        ),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: const BorderSide(color: AppColors.inputBorder),

--- a/lib/features/producer_management/presentation/pages/producer_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_profile_page.dart
@@ -19,8 +19,9 @@ class ProducerProfilePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getIt<ProducerManagementBloc>()
-        ..add(const ProducerManagementStarted()),
+      create: (_) =>
+          getIt<ProducerManagementBloc>()
+            ..add(const ProducerManagementStarted()),
       child: const _ProducerProfileView(),
     );
   }
@@ -120,8 +121,11 @@ class _ProducerProfileView extends StatelessWidget {
                             color: AppColors.darkGreen,
                             shape: BoxShape.circle,
                           ),
-                          child: const Icon(Icons.camera_alt,
-                              size: 14, color: AppColors.white),
+                          child: const Icon(
+                            Icons.camera_alt,
+                            size: 14,
+                            color: AppColors.white,
+                          ),
                         ),
                       ),
                     ],
@@ -154,7 +158,8 @@ class _ProducerProfileView extends StatelessWidget {
                       foregroundColor: AppColors.darkGreen,
                       side: const BorderSide(color: AppColors.darkGreen),
                       shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(24)),
+                        borderRadius: BorderRadius.circular(24),
+                      ),
                       textStyle: const TextStyle(
                         fontFamily: 'Manrope',
                         fontWeight: FontWeight.w600,
@@ -226,7 +231,9 @@ class _ProducerProfileView extends StatelessWidget {
                 ),
                 Container(
                   padding: const EdgeInsets.symmetric(
-                      horizontal: 12, vertical: 6),
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
                   decoration: BoxDecoration(
                     border: Border.all(color: AppColors.darkGreen),
                     borderRadius: BorderRadius.circular(24),
@@ -243,8 +250,11 @@ class _ProducerProfileView extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(width: 4),
-                      const Icon(Icons.keyboard_arrow_down,
-                          size: 16, color: AppColors.darkGreen),
+                      const Icon(
+                        Icons.keyboard_arrow_down,
+                        size: 16,
+                        color: AppColors.darkGreen,
+                      ),
                     ],
                   ),
                 ),
@@ -292,7 +302,9 @@ class _ProducerProfileView extends StatelessWidget {
                       const Spacer(),
                       Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 10, vertical: 4),
+                          horizontal: 10,
+                          vertical: 4,
+                        ),
                         decoration: BoxDecoration(
                           color: Colors.white.withOpacity(0.15),
                           borderRadius: BorderRadius.circular(20),
@@ -558,11 +570,11 @@ class _WeeklyChart extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     fontFamily: 'Manrope',
-                    fontWeight:
-                        isActive ? FontWeight.w700 : FontWeight.w500,
+                    fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
                     fontSize: 12,
-                    color:
-                        isActive ? AppColors.darkGreen : AppColors.placeholder,
+                    color: isActive
+                        ? AppColors.darkGreen
+                        : AppColors.placeholder,
                   ),
                 ),
               );

--- a/lib/features/producer_orders/domain/entities/producer_order.dart
+++ b/lib/features/producer_orders/domain/entities/producer_order.dart
@@ -56,19 +56,19 @@ class ProducerOrder extends Equatable {
 
   @override
   List<Object?> get props => [
-        id,
-        consumerName,
-        consumerAvatarUrl,
-        consumerSince,
-        status,
-        totalPrice,
-        deliveryAddress,
-        deliveryNeighborhood,
-        deliveryCityState,
-        deliveryComplement,
-        items,
-        createdAt,
-        isNew,
-        consumerPhone,
-      ];
+    id,
+    consumerName,
+    consumerAvatarUrl,
+    consumerSince,
+    status,
+    totalPrice,
+    deliveryAddress,
+    deliveryNeighborhood,
+    deliveryCityState,
+    deliveryComplement,
+    items,
+    createdAt,
+    isNew,
+    consumerPhone,
+  ];
 }

--- a/lib/features/producer_orders/domain/entities/producer_order_item.dart
+++ b/lib/features/producer_orders/domain/entities/producer_order_item.dart
@@ -20,5 +20,13 @@ class ProducerOrderItem extends Equatable {
   final String unityType;
 
   @override
-  List<Object?> get props => [productId, name, imageUrl, unitPrice, totalPrice, quantity, unityType];
+  List<Object?> get props => [
+    productId,
+    name,
+    imageUrl,
+    unitPrice,
+    totalPrice,
+    quantity,
+    unityType,
+  ];
 }

--- a/lib/features/producer_orders/domain/entities/producer_order_status.dart
+++ b/lib/features/producer_orders/domain/entities/producer_order_status.dart
@@ -2,10 +2,10 @@ enum ProducerOrderStatus { pending, accepted, inDelivery, delivered, cancelled }
 
 extension ProducerOrderStatusLabel on ProducerOrderStatus {
   String get label => switch (this) {
-        ProducerOrderStatus.pending => 'Pendente',
-        ProducerOrderStatus.accepted => 'Aceito',
-        ProducerOrderStatus.inDelivery => 'A caminho',
-        ProducerOrderStatus.delivered => 'Entregue',
-        ProducerOrderStatus.cancelled => 'Cancelado',
-      };
+    ProducerOrderStatus.pending => 'Pendente',
+    ProducerOrderStatus.accepted => 'Aceito',
+    ProducerOrderStatus.inDelivery => 'A caminho',
+    ProducerOrderStatus.delivered => 'Entregue',
+    ProducerOrderStatus.cancelled => 'Cancelado',
+  };
 }

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
@@ -84,7 +84,9 @@ class ProducerOrderDetailBloc
     try {
       await _updateStatus(event.orderId, event.status);
       final updated = await _getDetail(event.orderId);
-      emit(ProducerOrderDetailSuccess(order: updated, action: 'status_updated'));
+      emit(
+        ProducerOrderDetailSuccess(order: updated, action: 'status_updated'),
+      );
       emit(ProducerOrderDetailLoaded(updated));
     } catch (e) {
       emit(ProducerOrderDetailFailure(e.toString()));

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
@@ -6,8 +6,10 @@ import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_state.dart';
 
 @injectable
-class ProducerOrdersBloc extends Bloc<ProducerOrdersEvent, ProducerOrdersState> {
-  ProducerOrdersBloc(this._getProducerOrders) : super(const ProducerOrdersInitial()) {
+class ProducerOrdersBloc
+    extends Bloc<ProducerOrdersEvent, ProducerOrdersState> {
+  ProducerOrdersBloc(this._getProducerOrders)
+    : super(const ProducerOrdersInitial()) {
     on<ProducerOrdersStarted>(_onStarted);
     on<ProducerOrdersTabChanged>(_onTabChanged);
     on<ProducerOrdersRefreshed>(_onRefreshed);
@@ -16,7 +18,10 @@ class ProducerOrdersBloc extends Bloc<ProducerOrdersEvent, ProducerOrdersState> 
   final GetProducerOrders _getProducerOrders;
   ProducerOrderStatus _activeTab = ProducerOrderStatus.pending;
 
-  Future<void> _onStarted(ProducerOrdersStarted event, Emitter<ProducerOrdersState> emit) async {
+  Future<void> _onStarted(
+    ProducerOrdersStarted event,
+    Emitter<ProducerOrdersState> emit,
+  ) async {
     _activeTab = event.tab;
     emit(ProducerOrdersLoading(_activeTab));
     try {
@@ -27,7 +32,10 @@ class ProducerOrdersBloc extends Bloc<ProducerOrdersEvent, ProducerOrdersState> 
     }
   }
 
-  Future<void> _onTabChanged(ProducerOrdersTabChanged event, Emitter<ProducerOrdersState> emit) async {
+  Future<void> _onTabChanged(
+    ProducerOrdersTabChanged event,
+    Emitter<ProducerOrdersState> emit,
+  ) async {
     _activeTab = event.tab;
     emit(ProducerOrdersLoading(_activeTab));
     try {
@@ -38,7 +46,10 @@ class ProducerOrdersBloc extends Bloc<ProducerOrdersEvent, ProducerOrdersState> 
     }
   }
 
-  Future<void> _onRefreshed(ProducerOrdersRefreshed event, Emitter<ProducerOrdersState> emit) async {
+  Future<void> _onRefreshed(
+    ProducerOrdersRefreshed event,
+    Emitter<ProducerOrdersState> emit,
+  ) async {
     emit(ProducerOrdersLoading(_activeTab));
     try {
       final orders = await _getProducerOrders(status: _activeTab);

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -22,8 +22,9 @@ class ProducerOrderDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getIt<ProducerOrderDetailBloc>()
-        ..add(ProducerOrderDetailStarted(orderId)),
+      create: (_) =>
+          getIt<ProducerOrderDetailBloc>()
+            ..add(ProducerOrderDetailStarted(orderId)),
       child: BlocConsumer<ProducerOrderDetailBloc, ProducerOrderDetailState>(
         listener: (context, state) {
           if (state is ProducerOrderDetailSuccess) {
@@ -54,13 +55,12 @@ class ProducerOrderDetailPage extends StatelessWidget {
               state is ProducerOrderDetailInitial) {
             return const Scaffold(
               body: Center(
-                  child: CircularProgressIndicator(color: AppColors.darkGreen)),
+                child: CircularProgressIndicator(color: AppColors.darkGreen),
+              ),
             );
           }
           if (state is ProducerOrderDetailFailure) {
-            return Scaffold(
-              body: Center(child: Text(state.message)),
-            );
+            return Scaffold(body: Center(child: Text(state.message)));
           }
 
           final ProducerOrder? order = switch (state) {
@@ -74,7 +74,8 @@ class ProducerOrderDetailPage extends StatelessWidget {
 
           if (order == null) return const Scaffold();
 
-          final isProcessing = state is ProducerOrderDetailConfirming ||
+          final isProcessing =
+              state is ProducerOrderDetailConfirming ||
               state is ProducerOrderDetailRefusing ||
               state is ProducerOrderDetailUpdatingStatus;
 
@@ -101,12 +102,12 @@ class _ProducerOrderDetailView extends StatelessWidget {
       'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
 
   Color _statusColor(ProducerOrderStatus status) => switch (status) {
-        ProducerOrderStatus.pending => const Color(0xFFFFC107),
-        ProducerOrderStatus.accepted => AppColors.lightGreen,
-        ProducerOrderStatus.inDelivery => const Color(0xFF2196F3),
-        ProducerOrderStatus.delivered => AppColors.darkGreen,
-        ProducerOrderStatus.cancelled => AppColors.red,
-      };
+    ProducerOrderStatus.pending => const Color(0xFFFFC107),
+    ProducerOrderStatus.accepted => AppColors.lightGreen,
+    ProducerOrderStatus.inDelivery => const Color(0xFF2196F3),
+    ProducerOrderStatus.delivered => AppColors.darkGreen,
+    ProducerOrderStatus.cancelled => AppColors.red,
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -146,7 +147,9 @@ class _ProducerOrderDetailView extends StatelessWidget {
                         ),
                         Container(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 4),
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
                           decoration: BoxDecoration(
                             color: _statusColor(order.status).withOpacity(0.15),
                             borderRadius: BorderRadius.circular(8),
@@ -248,7 +251,8 @@ class _ProducerOrderDetailView extends StatelessWidget {
                       color: AppColors.white,
                       borderRadius: BorderRadius.circular(24),
                       border: Border.all(
-                          color: AppColors.lightGreen.withOpacity(0.1)),
+                        color: AppColors.lightGreen.withOpacity(0.1),
+                      ),
                       boxShadow: const [
                         BoxShadow(
                           color: Color(0x0D000000),
@@ -261,8 +265,7 @@ class _ProducerOrderDetailView extends StatelessWidget {
                       children: [
                         ...order.items.asMap().entries.map((entry) {
                           final item = entry.value;
-                          final isLast =
-                              entry.key == order.items.length - 1;
+                          final isLast = entry.key == order.items.length - 1;
                           return Column(
                             children: [
                               Padding(
@@ -273,10 +276,10 @@ class _ProducerOrderDetailView extends StatelessWidget {
                                       width: 64,
                                       height: 64,
                                       decoration: BoxDecoration(
-                                        color: AppColors.darkGreen
-                                            .withOpacity(0.05),
-                                        borderRadius:
-                                            BorderRadius.circular(12),
+                                        color: AppColors.darkGreen.withOpacity(
+                                          0.05,
+                                        ),
+                                        borderRadius: BorderRadius.circular(12),
                                       ),
                                       child: const Icon(
                                         Icons.eco_outlined,
@@ -324,8 +327,7 @@ class _ProducerOrderDetailView extends StatelessWidget {
                               ),
                               if (!isLast)
                                 Divider(
-                                  color:
-                                      AppColors.lightGreen.withOpacity(0.1),
+                                  color: AppColors.lightGreen.withOpacity(0.1),
                                   height: 1,
                                 ),
                             ],
@@ -396,7 +398,8 @@ class _ProducerOrderDetailView extends StatelessWidget {
                       color: AppColors.white,
                       borderRadius: BorderRadius.circular(16),
                       border: Border.all(
-                          color: AppColors.lightGreen.withOpacity(0.1)),
+                        color: AppColors.lightGreen.withOpacity(0.1),
+                      ),
                       boxShadow: const [
                         BoxShadow(
                           color: Color(0x0D000000),
@@ -408,8 +411,11 @@ class _ProducerOrderDetailView extends StatelessWidget {
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Icon(Icons.location_on_outlined,
-                            size: 20, color: AppColors.darkGreen),
+                        const Icon(
+                          Icons.location_on_outlined,
+                          size: 20,
+                          color: AppColors.darkGreen,
+                        ),
                         const SizedBox(width: 12),
                         Expanded(
                           child: Column(
@@ -501,8 +507,7 @@ class _BottomActions extends StatelessWidget {
                     style: ElevatedButton.styleFrom(
                       backgroundColor: AppColors.red,
                       foregroundColor: AppColors.white,
-                      disabledBackgroundColor:
-                          AppColors.red.withOpacity(0.5),
+                      disabledBackgroundColor: AppColors.red.withOpacity(0.5),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(24),
                       ),
@@ -524,12 +529,13 @@ class _BottomActions extends StatelessWidget {
                     onPressed: isProcessing
                         ? null
                         : () =>
-                            bloc.add(ProducerOrderDetailConfirmed(order.id)),
+                              bloc.add(ProducerOrderDetailConfirmed(order.id)),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: AppColors.darkGreen,
                       foregroundColor: AppColors.white,
-                      disabledBackgroundColor:
-                          AppColors.darkGreen.withOpacity(0.5),
+                      disabledBackgroundColor: AppColors.darkGreen.withOpacity(
+                        0.5,
+                      ),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(24),
                       ),
@@ -562,10 +568,12 @@ class _BottomActions extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: isProcessing
                     ? null
-                    : () => bloc.add(ProducerOrderDetailStatusUpdated(
+                    : () => bloc.add(
+                        ProducerOrderDetailStatusUpdated(
                           order.id,
                           ProducerOrderStatus.inDelivery,
-                        )),
+                        ),
+                      ),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppColors.darkGreen,
                   foregroundColor: AppColors.white,
@@ -599,10 +607,12 @@ class _BottomActions extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: isProcessing
                     ? null
-                    : () => bloc.add(ProducerOrderDetailStatusUpdated(
+                    : () => bloc.add(
+                        ProducerOrderDetailStatusUpdated(
                           order.id,
                           ProducerOrderStatus.delivered,
-                        )),
+                        ),
+                      ),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppColors.darkGreen,
                   foregroundColor: AppColors.white,

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -20,8 +20,9 @@ class ProducerOrdersPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getIt<ProducerOrdersBloc>()
-        ..add(const ProducerOrdersStarted(ProducerOrderStatus.pending)),
+      create: (_) =>
+          getIt<ProducerOrdersBloc>()
+            ..add(const ProducerOrdersStarted(ProducerOrderStatus.pending)),
       child: const _ProducerOrdersView(),
     );
   }
@@ -40,8 +41,18 @@ class _ProducerOrdersView extends StatelessWidget {
   String get _todayLabel {
     final now = DateTime.now();
     final months = [
-      'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho',
-      'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro',
+      'janeiro',
+      'fevereiro',
+      'março',
+      'abril',
+      'maio',
+      'junho',
+      'julho',
+      'agosto',
+      'setembro',
+      'outubro',
+      'novembro',
+      'dezembro',
     ];
     return 'Hoje, ${now.day} de ${months[now.month - 1]}';
   }
@@ -87,8 +98,8 @@ class _ProducerOrdersView extends StatelessWidget {
                 final activeTab = state is ProducerOrdersLoading
                     ? state.activeTab
                     : state is ProducerOrdersLoaded
-                        ? state.activeTab
-                        : ProducerOrderStatus.pending;
+                    ? state.activeTab
+                    : ProducerOrderStatus.pending;
                 return SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   padding: const EdgeInsets.only(left: 16),
@@ -96,9 +107,9 @@ class _ProducerOrdersView extends StatelessWidget {
                     children: _tabs.map((tab) {
                       final isActive = activeTab == tab.$1;
                       return GestureDetector(
-                        onTap: () => context
-                            .read<ProducerOrdersBloc>()
-                            .add(ProducerOrdersTabChanged(tab.$1)),
+                        onTap: () => context.read<ProducerOrdersBloc>().add(
+                          ProducerOrdersTabChanged(tab.$1),
+                        ),
                         child: Container(
                           padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
                           decoration: BoxDecoration(
@@ -115,8 +126,9 @@ class _ProducerOrdersView extends StatelessWidget {
                             tab.$2,
                             style: TextStyle(
                               fontFamily: 'Manrope',
-                              fontWeight:
-                                  isActive ? FontWeight.w700 : FontWeight.w500,
+                              fontWeight: isActive
+                                  ? FontWeight.w700
+                                  : FontWeight.w500,
                               fontSize: 14,
                               color: isActive
                                   ? AppColors.darkGreen
@@ -138,7 +150,8 @@ class _ProducerOrdersView extends StatelessWidget {
                   if (state is ProducerOrdersLoading) {
                     return const Center(
                       child: CircularProgressIndicator(
-                          color: AppColors.darkGreen),
+                        color: AppColors.darkGreen,
+                      ),
                     );
                   }
                   if (state is ProducerOrdersFailure) {
@@ -170,8 +183,7 @@ class _ProducerOrdersView extends StatelessWidget {
                       ),
                     );
                   }
-                  final newCount =
-                      state.orders.where((o) => o.isNew).length;
+                  final newCount = state.orders.where((o) => o.isNew).length;
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -179,8 +191,7 @@ class _ProducerOrdersView extends StatelessWidget {
                         Padding(
                           padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
                           child: GestureDetector(
-                            onTap: () =>
-                                context.push('/producer/home/route'),
+                            onTap: () => context.push('/producer/home/route'),
                             child: Container(
                               height: 44,
                               decoration: BoxDecoration(
@@ -233,20 +244,23 @@ class _ProducerOrdersView extends StatelessWidget {
                             final order = state.orders[index];
                             return ProducerOrderCard(
                               order: order,
-                              onDetailTap: () => context
-                                  .push('/producer/home/orders/${order.id}'),
+                              onDetailTap: () => context.push(
+                                '/producer/home/orders/${order.id}',
+                              ),
                               onActionTap: () {
                                 if (order.status ==
                                         ProducerOrderStatus.delivered ||
                                     order.status ==
                                         ProducerOrderStatus.cancelled) {
                                   context.push(
-                                      '/producer/home/orders/${order.id}');
+                                    '/producer/home/orders/${order.id}',
+                                  );
                                   return;
                                 }
                                 // Quick action via detail BLoC
                                 context.push(
-                                    '/producer/home/orders/${order.id}');
+                                  '/producer/home/orders/${order.id}',
+                                );
                               },
                             );
                           },

--- a/lib/features/producer_orders/presentation/pages/route_calculation_page.dart
+++ b/lib/features/producer_orders/presentation/pages/route_calculation_page.dart
@@ -215,18 +215,14 @@ class RouteCalculationPage extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
               decoration: BoxDecoration(
                 color: Colors.white.withOpacity(0.97),
-                border: const Border(
-                  top: BorderSide(color: Color(0x1A2E5729)),
-                ),
+                border: const Border(top: BorderSide(color: Color(0x1A2E5729))),
               ),
               child: GestureDetector(
                 onTap: () {
                   // TODO: Open Google Maps or in-app navigation when Maps SDK is integrated
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(
-                      content: Text(
-                        'Navegação por mapa disponível em breve',
-                      ),
+                      content: Text('Navegação por mapa disponível em breve'),
                     ),
                   );
                 },
@@ -285,10 +281,7 @@ class _RouteStatCard extends StatelessWidget {
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [
-            AppColors.darkGreen,
-            AppColors.darkGreen.withOpacity(0.8),
-          ],
+          colors: [AppColors.darkGreen, AppColors.darkGreen.withOpacity(0.8)],
         ),
         borderRadius: BorderRadius.circular(16),
       ),

--- a/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
+++ b/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
@@ -16,20 +16,20 @@ class ProducerOrderCard extends StatelessWidget {
   final VoidCallback onActionTap;
 
   String get _actionLabel => switch (order.status) {
-        ProducerOrderStatus.pending => 'Aceitar',
-        ProducerOrderStatus.accepted => 'A caminho',
-        ProducerOrderStatus.inDelivery => 'Entregue',
-        ProducerOrderStatus.delivered => 'Ver',
-        ProducerOrderStatus.cancelled => 'Ver',
-      };
+    ProducerOrderStatus.pending => 'Aceitar',
+    ProducerOrderStatus.accepted => 'A caminho',
+    ProducerOrderStatus.inDelivery => 'Entregue',
+    ProducerOrderStatus.delivered => 'Ver',
+    ProducerOrderStatus.cancelled => 'Ver',
+  };
 
   String get _subtitleLabel => switch (order.status) {
-        ProducerOrderStatus.pending => 'Pedido pendente',
-        ProducerOrderStatus.accepted => 'Pedido aceito',
-        ProducerOrderStatus.inDelivery => 'Pedido a caminho',
-        ProducerOrderStatus.delivered => 'Pedido entregue',
-        ProducerOrderStatus.cancelled => 'Pedido cancelado',
-      };
+    ProducerOrderStatus.pending => 'Pedido pendente',
+    ProducerOrderStatus.accepted => 'Pedido aceito',
+    ProducerOrderStatus.inDelivery => 'Pedido a caminho',
+    ProducerOrderStatus.delivered => 'Pedido entregue',
+    ProducerOrderStatus.cancelled => 'Pedido cancelado',
+  };
 
   String _formatPrice(double price) =>
       'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
@@ -98,7 +98,10 @@ class ProducerOrderCard extends StatelessWidget {
               // NOVO badge
               if (order.isNew)
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
                   decoration: BoxDecoration(
                     color: AppColors.darkGreen.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(6),

--- a/lib/features/producer_profile/data/models/public_producer_model.dart
+++ b/lib/features/producer_profile/data/models/public_producer_model.dart
@@ -35,20 +35,22 @@ class PublicProducerModel extends PublicProducer {
       totalReviews: json['total_reviews'] as int? ?? 0,
       totalOrders: json['total_orders'] as int? ?? 0,
       phone: user['phone'] as String? ?? '',
-      products: ((json['products'] as List?)?.map(
-                (p) => HomeProductModel.fromJson(p as Map<String, dynamic>),
-              ) ??
-              [])
-          .toList(),
-      availability: ((json['availability'] as List?)?.map(
-                (a) => AvailabilitySlot(
-                  weekday: a['weekday'] as int,
-                  opensAt: a['opens_at'] as String,
-                  closesAt: a['closes_at'] as String,
-                ),
-              ) ??
-              [])
-          .toList(),
+      products:
+          ((json['products'] as List?)?.map(
+                    (p) => HomeProductModel.fromJson(p as Map<String, dynamic>),
+                  ) ??
+                  [])
+              .toList(),
+      availability:
+          ((json['availability'] as List?)?.map(
+                    (a) => AvailabilitySlot(
+                      weekday: a['weekday'] as int,
+                      opensAt: a['opens_at'] as String,
+                      closesAt: a['closes_at'] as String,
+                    ),
+                  ) ??
+                  [])
+              .toList(),
       memberSince: json['created_at'] != null
           ? DateTime.parse(json['created_at'] as String)
           : DateTime(2016),

--- a/lib/features/producer_profile/domain/usecases/get_producer_profile.dart
+++ b/lib/features/producer_profile/domain/usecases/get_producer_profile.dart
@@ -8,5 +8,6 @@ class GetProducerProfile {
 
   final ProducerProfileRepository _repository;
 
-  Future<PublicProducer> call(String producerId) => _repository.getProducer(producerId);
+  Future<PublicProducer> call(String producerId) =>
+      _repository.getProducer(producerId);
 }

--- a/lib/features/producer_profile/presentation/bloc/producer_profile_bloc.dart
+++ b/lib/features/producer_profile/presentation/bloc/producer_profile_bloc.dart
@@ -8,7 +8,8 @@ import 'package:ragro_mobile/features/producer_profile/presentation/bloc/produce
 @injectable
 class ProducerProfileBloc
     extends Bloc<ProducerProfileEvent, ProducerProfileState> {
-  ProducerProfileBloc(this._getProducer) : super(const ProducerProfileInitial()) {
+  ProducerProfileBloc(this._getProducer)
+    : super(const ProducerProfileInitial()) {
     on<ProducerProfileStarted>(_onStarted);
   }
 
@@ -25,7 +26,9 @@ class ProducerProfileBloc
     } on ApiException catch (e) {
       emit(ProducerProfileFailure(e.message));
     } catch (_) {
-      emit(const ProducerProfileFailure('Erro ao carregar perfil do produtor.'));
+      emit(
+        const ProducerProfileFailure('Erro ao carregar perfil do produtor.'),
+      );
     }
   }
 }

--- a/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
+++ b/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
@@ -24,8 +24,8 @@ class ProducerPublicProfilePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getIt<ProducerProfileBloc>()
-        ..add(ProducerProfileStarted(producerId)),
+      create: (_) =>
+          getIt<ProducerProfileBloc>()..add(ProducerProfileStarted(producerId)),
       child: const _ProducerPublicProfileView(),
     );
   }
@@ -41,187 +41,196 @@ class _ProducerPublicProfileView extends StatelessWidget {
       body: BlocBuilder<ProducerProfileBloc, ProducerProfileState>(
         builder: (context, state) {
           return switch (state) {
-            ProducerProfileLoading() || ProducerProfileInitial() => const Center(
-                child: CircularProgressIndicator(color: AppColors.darkGreen),
-              ),
-            ProducerProfileFailure(:final message) => Center(child: Text(message)),
+            ProducerProfileLoading() ||
+            ProducerProfileInitial() => const Center(
+              child: CircularProgressIndicator(color: AppColors.darkGreen),
+            ),
+            ProducerProfileFailure(:final message) => Center(
+              child: Text(message),
+            ),
             ProducerProfileLoaded(:final producer) => CustomScrollView(
-                slivers: [
-                  // Header with blur background
-                  SliverAppBar(
-                    backgroundColor: Colors.white.withOpacity(0.85),
-                    leading: GestureDetector(
-                      onTap: () => context.pop(),
-                      child: const Icon(Icons.arrow_back, color: AppColors.black),
-                    ),
-                    title: const Text(
-                      'Perfil do Produtor',
-                      style: TextStyle(
-                        fontFamily: 'Figtree',
-                        fontWeight: FontWeight.w700,
-                        fontSize: 18,
-                        color: AppColors.black,
-                      ),
-                    ),
-                    pinned: true,
-                    expandedHeight: 256.0,
-                    flexibleSpace: FlexibleSpaceBar(
-                      background: _CoverPhoto(coverUrl: producer.coverUrl),
+              slivers: [
+                // Header with blur background
+                SliverAppBar(
+                  backgroundColor: Colors.white.withOpacity(0.85),
+                  leading: GestureDetector(
+                    onTap: () => context.pop(),
+                    child: const Icon(Icons.arrow_back, color: AppColors.black),
+                  ),
+                  title: const Text(
+                    'Perfil do Produtor',
+                    style: TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w700,
+                      fontSize: 18,
+                      color: AppColors.black,
                     ),
                   ),
-                  // Producer info
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
-                      child: Column(
-                        children: [
-                          // Avatar — overlapping cover
-                          Transform.translate(
-                            offset: const Offset(0, -64),
+                  pinned: true,
+                  expandedHeight: 256.0,
+                  flexibleSpace: FlexibleSpaceBar(
+                    background: _CoverPhoto(coverUrl: producer.coverUrl),
+                  ),
+                ),
+                // Producer info
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+                    child: Column(
+                      children: [
+                        // Avatar — overlapping cover
+                        Transform.translate(
+                          offset: const Offset(0, -64),
+                          child: CircleAvatar(
+                            radius: 64,
+                            backgroundColor: AppColors.white,
                             child: CircleAvatar(
-                              radius: 64,
-                              backgroundColor: AppColors.white,
-                              child: CircleAvatar(
-                                radius: 60,
-                                backgroundColor: AppColors.mintGreen.withOpacity(0.3),
-                                backgroundImage: producer.avatarUrl.isNotEmpty
-                                    ? NetworkImage(producer.avatarUrl)
-                                    : null,
-                                child: producer.avatarUrl.isEmpty
-                                    ? const Icon(
-                                        Icons.person,
-                                        size: 48,
-                                        color: AppColors.darkGreen,
-                                      )
-                                    : null,
+                              radius: 60,
+                              backgroundColor: AppColors.mintGreen.withOpacity(
+                                0.3,
                               ),
+                              backgroundImage: producer.avatarUrl.isNotEmpty
+                                  ? NetworkImage(producer.avatarUrl)
+                                  : null,
+                              child: producer.avatarUrl.isEmpty
+                                  ? const Icon(
+                                      Icons.person,
+                                      size: 48,
+                                      color: AppColors.darkGreen,
+                                    )
+                                  : null,
                             ),
                           ),
-                          Transform.translate(
-                            offset: const Offset(0, -48),
-                            child: Column(
-                              children: [
-                                Text(
-                                  producer.name,
-                                  style: const TextStyle(
-                                    fontFamily: 'Figtree',
-                                    fontWeight: FontWeight.w500,
-                                    fontSize: 24,
-                                    color: AppColors.darkGreen,
-                                  ),
-                                  textAlign: TextAlign.center,
+                        ),
+                        Transform.translate(
+                          offset: const Offset(0, -48),
+                          child: Column(
+                            children: [
+                              Text(
+                                producer.name,
+                                style: const TextStyle(
+                                  fontFamily: 'Figtree',
+                                  fontWeight: FontWeight.w500,
+                                  fontSize: 24,
+                                  color: AppColors.darkGreen,
                                 ),
-                                const SizedBox(height: 4),
-                                Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    const Icon(
-                                      Icons.location_on,
-                                      size: 14,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 4),
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  const Icon(
+                                    Icons.location_on,
+                                    size: 14,
+                                    color: Color(0xFF64748B),
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    producer.location,
+                                    style: const TextStyle(
+                                      fontFamily: 'Figtree',
+                                      fontWeight: FontWeight.w500,
+                                      fontSize: 14,
                                       color: Color(0xFF64748B),
                                     ),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      producer.location,
-                                      style: const TextStyle(
-                                        fontFamily: 'Figtree',
-                                        fontWeight: FontWeight.w500,
-                                        fontSize: 14,
-                                        color: Color(0xFF64748B),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 24),
-                                // Contact button
-                                SizedBox(
-                                  width: double.infinity,
-                                  child: ElevatedButton.icon(
-                                    onPressed: () {},
-                                    icon: const Icon(
-                                      Icons.phone_outlined,
-                                      color: AppColors.white,
-                                    ),
-                                    label: const Text(
-                                      'Contato',
-                                      style: TextStyle(
-                                        fontFamily: 'Figtree',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 16,
-                                        color: AppColors.white,
-                                      ),
-                                    ),
-                                    style: ElevatedButton.styleFrom(
-                                      backgroundColor: AppColors.darkGreen,
-                                      padding: const EdgeInsets.symmetric(vertical: 14),
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(24),
-                                      ),
-                                    ),
                                   ),
-                                ),
-                                const SizedBox(height: 16),
-                                // Story
-                                Text(
-                                  producer.story,
-                                  style: const TextStyle(
-                                    fontFamily: 'Figtree',
-                                    fontWeight: FontWeight.w500,
-                                    fontSize: 16,
-                                    color: Color(0xFF334155),
-                                    fontStyle: FontStyle.italic,
+                                ],
+                              ),
+                              const SizedBox(height: 24),
+                              // Contact button
+                              SizedBox(
+                                width: double.infinity,
+                                child: ElevatedButton.icon(
+                                  onPressed: () {},
+                                  icon: const Icon(
+                                    Icons.phone_outlined,
+                                    color: AppColors.white,
                                   ),
-                                  textAlign: TextAlign.center,
-                                ),
-                                const SizedBox(height: 24),
-                                // Stats
-                                ProducerStatsRow(
-                                  productCount: producer.products.length,
-                                  rating: producer.averageRating,
-                                  yearsOnPlatform: producer.yearsOnPlatform,
-                                ),
-                                const SizedBox(height: 32),
-                                // Products section header
-                                const Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: Text(
-                                    'Produtos',
+                                  label: const Text(
+                                    'Contato',
                                     style: TextStyle(
                                       fontFamily: 'Figtree',
                                       fontWeight: FontWeight.w700,
-                                      fontSize: 22,
-                                      color: AppColors.black,
+                                      fontSize: 16,
+                                      color: AppColors.white,
+                                    ),
+                                  ),
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: AppColors.darkGreen,
+                                    padding: const EdgeInsets.symmetric(
+                                      vertical: 14,
+                                    ),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(24),
                                     ),
                                   ),
                                 ),
-                                const SizedBox(height: 16),
-                                // Products grid
-                                GridView.builder(
-                                  shrinkWrap: true,
-                                  physics: const NeverScrollableScrollPhysics(),
-                                  gridDelegate:
-                                      const SliverGridDelegateWithFixedCrossAxisCount(
-                                    crossAxisCount: 2,
-                                    crossAxisSpacing: 12,
-                                    mainAxisSpacing: 12,
-                                    childAspectRatio: 0.55,
-                                  ),
-                                  itemCount: producer.products.length,
-                                  itemBuilder: (_, i) => HomeProductCard(
-                                    product: producer.products[i],
-                                    onTap: () => context.push('/consumer/home/product/${producer.products[i].id}'),
-                                    onAddToCart: () {},
+                              ),
+                              const SizedBox(height: 16),
+                              // Story
+                              Text(
+                                producer.story,
+                                style: const TextStyle(
+                                  fontFamily: 'Figtree',
+                                  fontWeight: FontWeight.w500,
+                                  fontSize: 16,
+                                  color: Color(0xFF334155),
+                                  fontStyle: FontStyle.italic,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 24),
+                              // Stats
+                              ProducerStatsRow(
+                                productCount: producer.products.length,
+                                rating: producer.averageRating,
+                                yearsOnPlatform: producer.yearsOnPlatform,
+                              ),
+                              const SizedBox(height: 32),
+                              // Products section header
+                              const Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  'Produtos',
+                                  style: TextStyle(
+                                    fontFamily: 'Figtree',
+                                    fontWeight: FontWeight.w700,
+                                    fontSize: 22,
+                                    color: AppColors.black,
                                   ),
                                 ),
-                              ],
-                            ),
+                              ),
+                              const SizedBox(height: 16),
+                              // Products grid
+                              GridView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                gridDelegate:
+                                    const SliverGridDelegateWithFixedCrossAxisCount(
+                                      crossAxisCount: 2,
+                                      crossAxisSpacing: 12,
+                                      mainAxisSpacing: 12,
+                                      childAspectRatio: 0.55,
+                                    ),
+                                itemCount: producer.products.length,
+                                itemBuilder: (_, i) => HomeProductCard(
+                                  product: producer.products[i],
+                                  onTap: () => context.push(
+                                    '/consumer/home/product/${producer.products[i].id}',
+                                  ),
+                                  onAddToCart: () {},
+                                ),
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
+            ),
           };
         },
       ),

--- a/lib/features/product_detail/domain/usecases/get_product_detail.dart
+++ b/lib/features/product_detail/domain/usecases/get_product_detail.dart
@@ -8,5 +8,6 @@ class GetProductDetail {
 
   final ProductDetailRepository _repository;
 
-  Future<ProductDetail> call(String productId) => _repository.getProduct(productId);
+  Future<ProductDetail> call(String productId) =>
+      _repository.getProduct(productId);
 }

--- a/lib/features/product_detail/presentation/bloc/product_detail_state.dart
+++ b/lib/features/product_detail/presentation/bloc/product_detail_state.dart
@@ -22,8 +22,10 @@ class ProductDetailLoaded extends ProductDetailState {
   final ProductDetail product;
   final int quantity;
 
-  ProductDetailLoaded copyWith({int? quantity}) =>
-      ProductDetailLoaded(product: product, quantity: quantity ?? this.quantity);
+  ProductDetailLoaded copyWith({int? quantity}) => ProductDetailLoaded(
+    product: product,
+    quantity: quantity ?? this.quantity,
+  );
 
   @override
   List<Object?> get props => [product, quantity];

--- a/lib/features/product_detail/presentation/pages/product_detail_page.dart
+++ b/lib/features/product_detail/presentation/pages/product_detail_page.dart
@@ -23,7 +23,8 @@ class ProductDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getIt<ProductDetailBloc>()..add(ProductDetailStarted(productId)),
+      create: (_) =>
+          getIt<ProductDetailBloc>()..add(ProductDetailStarted(productId)),
       child: const _ProductDetailView(),
     );
   }
@@ -60,7 +61,10 @@ class _ProductDetailView extends StatelessWidget {
                     backgroundColor: Colors.white.withOpacity(0.9),
                     leading: GestureDetector(
                       onTap: () => context.pop(),
-                      child: const Icon(Icons.arrow_back, color: AppColors.black),
+                      child: const Icon(
+                        Icons.arrow_back,
+                        color: AppColors.black,
+                      ),
                     ),
                     title: const Text(
                       'Detalhe do Produto',
@@ -98,7 +102,9 @@ class _ProductDetailView extends StatelessWidget {
                                       fit: BoxFit.cover,
                                     )
                                   : Container(
-                                      color: AppColors.mintGreen.withOpacity(0.3),
+                                      color: AppColors.mintGreen.withOpacity(
+                                        0.3,
+                                      ),
                                       child: const Center(
                                         child: Icon(
                                           Icons.eco,
@@ -253,7 +259,8 @@ class _ProductDetailView extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
                             GestureDetector(
-                              onTap: () => context.read<ProductDetailBloc>().add(
+                              onTap: () =>
+                                  context.read<ProductDetailBloc>().add(
                                     const ProductDetailQuantityDecremented(),
                                   ),
                               child: const Icon(Icons.remove, size: 16),
@@ -267,7 +274,8 @@ class _ProductDetailView extends StatelessWidget {
                               ),
                             ),
                             GestureDetector(
-                              onTap: () => context.read<ProductDetailBloc>().add(
+                              onTap: () =>
+                                  context.read<ProductDetailBloc>().add(
                                     const ProductDetailQuantityIncremented(),
                                   ),
                               child: const Icon(Icons.add, size: 14),

--- a/lib/features/search/data/datasources/search_remote_datasource.dart
+++ b/lib/features/search/data/datasources/search_remote_datasource.dart
@@ -35,7 +35,10 @@ class SearchRemoteDataSource {
   /// === END REAL IMPLEMENTATION ===
   ///
   /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
-  Future<List<SearchResultModel>> search({required String query, String? category}) async {
+  Future<List<SearchResultModel>> search({
+    required String query,
+    String? category,
+  }) async {
     await Future.delayed(const Duration(milliseconds: 500));
     return SearchResultModel.mocks(query);
   }

--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -10,6 +10,8 @@ class SearchRepositoryImpl implements SearchRepository {
   final SearchRemoteDataSource _dataSource;
 
   @override
-  Future<List<SearchResult>> search({required String query, String? category}) =>
-      _dataSource.search(query: query, category: category);
+  Future<List<SearchResult>> search({
+    required String query,
+    String? category,
+  }) => _dataSource.search(query: query, category: category);
 }

--- a/lib/features/search/domain/entities/search_result.dart
+++ b/lib/features/search/domain/entities/search_result.dart
@@ -24,5 +24,14 @@ class SearchResult extends Equatable {
   final String? category;
 
   @override
-  List<Object?> get props => [id, type, name, subtitle, imageUrl, price, rating, category];
+  List<Object?> get props => [
+    id,
+    type,
+    name,
+    subtitle,
+    imageUrl,
+    price,
+    rating,
+    category,
+  ];
 }

--- a/lib/features/search/domain/repositories/search_repository.dart
+++ b/lib/features/search/domain/repositories/search_repository.dart
@@ -1,8 +1,5 @@
 import 'package:ragro_mobile/features/search/domain/entities/search_result.dart';
 
 abstract class SearchRepository {
-  Future<List<SearchResult>> search({
-    required String query,
-    String? category,
-  });
+  Future<List<SearchResult>> search({required String query, String? category});
 }

--- a/lib/features/search/presentation/bloc/search_bloc.dart
+++ b/lib/features/search/presentation/bloc/search_bloc.dart
@@ -21,7 +21,9 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     Emitter<SearchState> emit,
   ) async {
     if (event.query.trim().isEmpty) {
-      final recent = state is SearchIdle ? (state as SearchIdle).recentSearches : <String>[];
+      final recent = state is SearchIdle
+          ? (state as SearchIdle).recentSearches
+          : <String>[];
       emit(SearchIdle(recentSearches: recent));
       return;
     }
@@ -46,7 +48,10 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     _currentCategory = event.category ?? 'Tudo';
   }
 
-  void _onRecentRemoved(SearchRecentItemRemoved event, Emitter<SearchState> emit) {
+  void _onRecentRemoved(
+    SearchRecentItemRemoved event,
+    Emitter<SearchState> emit,
+  ) {
     if (state is SearchIdle) {
       final recent = List<String>.from((state as SearchIdle).recentSearches)
         ..remove(event.query);

--- a/lib/features/search/presentation/pages/search_page.dart
+++ b/lib/features/search/presentation/pages/search_page.dart
@@ -84,12 +84,18 @@ class _SearchViewState extends State<_SearchView> {
                 child: Row(
                   children: [
                     const SizedBox(width: 16),
-                    const Icon(Icons.search, color: AppColors.placeholder, size: 20),
+                    const Icon(
+                      Icons.search,
+                      color: AppColors.placeholder,
+                      size: 20,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: TextField(
                         controller: _controller,
-                        onChanged: (q) => context.read<SearchBloc>().add(SearchQueryChanged(q)),
+                        onChanged: (q) => context.read<SearchBloc>().add(
+                          SearchQueryChanged(q),
+                        ),
                         style: const TextStyle(
                           fontFamily: 'Figtree',
                           fontSize: 16,
@@ -158,26 +164,31 @@ class _SearchViewState extends State<_SearchView> {
                   return switch (state) {
                     SearchIdle() => _buildIdleContent(),
                     SearchLoading() => const Center(
-                        child: CircularProgressIndicator(color: AppColors.darkGreen),
+                      child: CircularProgressIndicator(
+                        color: AppColors.darkGreen,
                       ),
-                    SearchLoaded(:final results) => results.isEmpty
-                        ? const Center(
-                            child: Text(
-                              'Nenhum resultado encontrado.',
-                              style: TextStyle(color: AppColors.placeholder),
+                    ),
+                    SearchLoaded(:final results) =>
+                      results.isEmpty
+                          ? const Center(
+                              child: Text(
+                                'Nenhum resultado encontrado.',
+                                style: TextStyle(color: AppColors.placeholder),
+                              ),
+                            )
+                          : ListView.builder(
+                              padding: const EdgeInsets.only(top: 8),
+                              itemCount: results.length,
+                              itemBuilder: (_, i) => SearchResultTile(
+                                result: results[i],
+                                onTap: () {
+                                  // TODO: navigate to producer/product detail
+                                },
+                              ),
                             ),
-                          )
-                        : ListView.builder(
-                            padding: const EdgeInsets.only(top: 8),
-                            itemCount: results.length,
-                            itemBuilder: (_, i) => SearchResultTile(
-                              result: results[i],
-                              onTap: () {
-                                // TODO: navigate to producer/product detail
-                              },
-                            ),
-                          ),
-                    SearchFailure(:final message) => Center(child: Text(message)),
+                    SearchFailure(:final message) => Center(
+                      child: Text(message),
+                    ),
                   };
                 },
               ),
@@ -224,7 +235,11 @@ class _SearchViewState extends State<_SearchView> {
             ),
             child: Row(
               children: [
-                const Icon(Icons.location_on_outlined, size: 18, color: AppColors.darkGreen),
+                const Icon(
+                  Icons.location_on_outlined,
+                  size: 18,
+                  color: AppColors.darkGreen,
+                ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: Column(
@@ -287,7 +302,9 @@ class _SearchViewState extends State<_SearchView> {
                     _controller.text = q;
                     context.read<SearchBloc>().add(SearchQueryChanged(q));
                   },
-                  onRemove: () => context.read<SearchBloc>().add(SearchRecentItemRemoved(q)),
+                  onRemove: () => context.read<SearchBloc>().add(
+                    SearchRecentItemRemoved(q),
+                  ),
                 ),
                 const Divider(color: Color(0xFFF1F5F9), height: 1),
               ],
@@ -332,7 +349,11 @@ class _RecentSearchItem extends StatelessWidget {
             ),
             GestureDetector(
               onTap: onRemove,
-              child: const Icon(Icons.close, size: 14, color: AppColors.placeholder),
+              child: const Icon(
+                Icons.close,
+                size: 14,
+                color: AppColors.placeholder,
+              ),
             ),
           ],
         ),

--- a/lib/features/search/presentation/widgets/category_chip.dart
+++ b/lib/features/search/presentation/widgets/category_chip.dart
@@ -23,9 +23,7 @@ class CategoryChip extends StatelessWidget {
         decoration: BoxDecoration(
           color: isSelected ? AppColors.darkGreen : const Color(0xFFF1F5F9),
           borderRadius: BorderRadius.circular(24),
-          border: isSelected
-              ? null
-              : Border.all(color: AppColors.black),
+          border: isSelected ? null : Border.all(color: AppColors.black),
           boxShadow: isSelected
               ? [
                   const BoxShadow(

--- a/lib/shared/widgets/producer_shell.dart
+++ b/lib/shared/widgets/producer_shell.dart
@@ -91,8 +91,7 @@ class _NavItem extends StatelessWidget {
             Icon(
               isActive ? activeIcon : icon,
               size: 24,
-              color:
-                  isActive ? AppColors.darkGreen : AppColors.placeholder,
+              color: isActive ? AppColors.darkGreen : AppColors.placeholder,
             ),
             const SizedBox(height: 4),
             Text(
@@ -101,8 +100,7 @@ class _NavItem extends StatelessWidget {
                 fontFamily: 'Figtree',
                 fontWeight: FontWeight.w500,
                 fontSize: 12,
-                color:
-                    isActive ? AppColors.darkGreen : AppColors.placeholder,
+                color: isActive ? AppColors.darkGreen : AppColors.placeholder,
               ),
             ),
           ],

--- a/test/features/auth/domain/usecases/login_user_test.dart
+++ b/test/features/auth/domain/usecases/login_user_test.dart
@@ -26,37 +26,32 @@ void main() {
   );
 
   test('calls repository with correct params', () async {
-    when(() => mockRepo.loginUser(
-          email: any(named: 'email'),
-          password: any(named: 'password'),
-        )).thenAnswer((_) async => (user: tUser, token: 'tok'));
+    when(
+      () => mockRepo.loginUser(
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer((_) async => (user: tUser, token: 'tok'));
 
-    final result = await loginUser(
-      email: 'joao@test.com',
-      password: '123456',
-    );
+    final result = await loginUser(email: 'joao@test.com', password: '123456');
 
     expect(result.user, tUser);
     expect(result.token, 'tok');
-    verify(() => mockRepo.loginUser(
-          email: 'joao@test.com',
-          password: '123456',
-        )).called(1);
+    verify(
+      () => mockRepo.loginUser(email: 'joao@test.com', password: '123456'),
+    ).called(1);
   });
 
   test('propagates UnauthorizedException from repository', () async {
-    when(() => mockRepo.loginUser(
-          email: any(named: 'email'),
-          password: any(named: 'password'),
-        )).thenThrow(
-      const UnauthorizedException(),
-    );
+    when(
+      () => mockRepo.loginUser(
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenThrow(const UnauthorizedException());
 
     expect(
-      () => loginUser(
-        email: 'j@t.com',
-        password: 'wrong',
-      ),
+      () => loginUser(email: 'j@t.com', password: 'wrong'),
       throwsA(isA<UnauthorizedException>()),
     );
   });

--- a/test/features/auth/presentation/bloc/login_bloc_test.dart
+++ b/test/features/auth/presentation/bloc/login_bloc_test.dart
@@ -33,32 +33,31 @@ void main() {
   blocTest<LoginBloc, LoginState>(
     'emits [Loading, Success] on successful login',
     build: () {
-      when(() => mockLoginUser(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-          )).thenAnswer((_) async => (user: tUser, token: 'tok'));
+      when(
+        () => mockLoginUser(
+          email: any(named: 'email'),
+          password: any(named: 'password'),
+        ),
+      ).thenAnswer((_) async => (user: tUser, token: 'tok'));
       return bloc;
     },
-    act: (b) => b.add(const LoginSubmitted(
-      email: 'j@t.com',
-      password: '123',
-    )),
+    act: (b) => b.add(const LoginSubmitted(email: 'j@t.com', password: '123')),
     expect: () => [const LoginLoading(), const LoginSuccess(tUser)],
   );
 
   blocTest<LoginBloc, LoginState>(
     'emits [Loading, Failure] on UnauthorizedException',
     build: () {
-      when(() => mockLoginUser(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-          )).thenThrow(const UnauthorizedException());
+      when(
+        () => mockLoginUser(
+          email: any(named: 'email'),
+          password: any(named: 'password'),
+        ),
+      ).thenThrow(const UnauthorizedException());
       return bloc;
     },
-    act: (b) => b.add(const LoginSubmitted(
-      email: 'j@t.com',
-      password: 'wrong',
-    )),
+    act: (b) =>
+        b.add(const LoginSubmitted(email: 'j@t.com', password: 'wrong')),
     expect: () => [
       const LoginLoading(),
       const LoginFailure('Credenciais inválidas'),

--- a/test/features/auth/presentation/bloc/register_bloc_test.dart
+++ b/test/features/auth/presentation/bloc/register_bloc_test.dart
@@ -46,20 +46,22 @@ void main() {
   blocTest<RegisterBloc, RegisterState>(
     'emits [Loading, Success] on successful registration',
     build: () {
-      when(() => mockRegister(
-            name: any(named: 'name'),
-            phone: any(named: 'phone'),
-            email: any(named: 'email'),
-            fiscalNumber: any(named: 'fiscalNumber'),
-            password: any(named: 'password'),
-            zipCode: any(named: 'zipCode'),
-            street: any(named: 'street'),
-            number: any(named: 'number'),
-            city: any(named: 'city'),
-            state: any(named: 'state'),
-            complement: any(named: 'complement'),
-            neighborhood: any(named: 'neighborhood'),
-          )).thenAnswer((_) async => tUser);
+      when(
+        () => mockRegister(
+          name: any(named: 'name'),
+          phone: any(named: 'phone'),
+          email: any(named: 'email'),
+          fiscalNumber: any(named: 'fiscalNumber'),
+          password: any(named: 'password'),
+          zipCode: any(named: 'zipCode'),
+          street: any(named: 'street'),
+          number: any(named: 'number'),
+          city: any(named: 'city'),
+          state: any(named: 'state'),
+          complement: any(named: 'complement'),
+          neighborhood: any(named: 'neighborhood'),
+        ),
+      ).thenAnswer((_) async => tUser);
       return bloc;
     },
     act: (b) => b.add(tEvent),
@@ -69,26 +71,168 @@ void main() {
   blocTest<RegisterBloc, RegisterState>(
     'emits [Loading, Failure] on ConflictException (email already exists)',
     build: () {
-      when(() => mockRegister(
-            name: any(named: 'name'),
-            phone: any(named: 'phone'),
-            email: any(named: 'email'),
-            fiscalNumber: any(named: 'fiscalNumber'),
-            password: any(named: 'password'),
-            zipCode: any(named: 'zipCode'),
-            street: any(named: 'street'),
-            number: any(named: 'number'),
-            city: any(named: 'city'),
-            state: any(named: 'state'),
-            complement: any(named: 'complement'),
-            neighborhood: any(named: 'neighborhood'),
-          )).thenThrow(const ConflictException());
+      when(
+        () => mockRegister(
+          name: any(named: 'name'),
+          phone: any(named: 'phone'),
+          email: any(named: 'email'),
+          fiscalNumber: any(named: 'fiscalNumber'),
+          password: any(named: 'password'),
+          zipCode: any(named: 'zipCode'),
+          street: any(named: 'street'),
+          number: any(named: 'number'),
+          city: any(named: 'city'),
+          state: any(named: 'state'),
+          complement: any(named: 'complement'),
+          neighborhood: any(named: 'neighborhood'),
+        ),
+      ).thenThrow(const ConflictException('Este e-mail já está em uso.'));
       return bloc;
     },
     act: (b) => b.add(tEvent),
     expect: () => [
       const RegisterLoading(),
-      const RegisterFailure('Recurso já existe'),
+      const RegisterFailure('Este e-mail já está em uso.'),
+    ],
+  );
+
+  blocTest<RegisterBloc, RegisterState>(
+    'emits [Loading, Failure] on ConflictException (CPF already registered)',
+    build: () {
+      when(
+        () => mockRegister(
+          name: any(named: 'name'),
+          phone: any(named: 'phone'),
+          email: any(named: 'email'),
+          fiscalNumber: any(named: 'fiscalNumber'),
+          password: any(named: 'password'),
+          zipCode: any(named: 'zipCode'),
+          street: any(named: 'street'),
+          number: any(named: 'number'),
+          city: any(named: 'city'),
+          state: any(named: 'state'),
+          complement: any(named: 'complement'),
+          neighborhood: any(named: 'neighborhood'),
+        ),
+      ).thenThrow(const ConflictException('Este CPF já está cadastrado.'));
+      return bloc;
+    },
+    act: (b) => b.add(tEvent),
+    expect: () => [
+      const RegisterLoading(),
+      const RegisterFailure('Este CPF já está cadastrado.'),
+    ],
+  );
+
+  blocTest<RegisterBloc, RegisterState>(
+    'emits [Loading, Failure] on ConflictException (generic 409)',
+    build: () {
+      when(
+        () => mockRegister(
+          name: any(named: 'name'),
+          phone: any(named: 'phone'),
+          email: any(named: 'email'),
+          fiscalNumber: any(named: 'fiscalNumber'),
+          password: any(named: 'password'),
+          zipCode: any(named: 'zipCode'),
+          street: any(named: 'street'),
+          number: any(named: 'number'),
+          city: any(named: 'city'),
+          state: any(named: 'state'),
+          complement: any(named: 'complement'),
+          neighborhood: any(named: 'neighborhood'),
+        ),
+      ).thenThrow(const ConflictException('E-mail ou CPF já cadastrado.'));
+      return bloc;
+    },
+    act: (b) => b.add(tEvent),
+    expect: () => [
+      const RegisterLoading(),
+      const RegisterFailure('E-mail ou CPF já cadastrado.'),
+    ],
+  );
+
+  blocTest<RegisterBloc, RegisterState>(
+    'emits [Loading, Failure] on UnknownApiException (400)',
+    build: () {
+      when(
+        () => mockRegister(
+          name: any(named: 'name'),
+          phone: any(named: 'phone'),
+          email: any(named: 'email'),
+          fiscalNumber: any(named: 'fiscalNumber'),
+          password: any(named: 'password'),
+          zipCode: any(named: 'zipCode'),
+          street: any(named: 'street'),
+          number: any(named: 'number'),
+          city: any(named: 'city'),
+          state: any(named: 'state'),
+          complement: any(named: 'complement'),
+          neighborhood: any(named: 'neighborhood'),
+        ),
+      ).thenThrow(const UnknownApiException('Campo inválido'));
+      return bloc;
+    },
+    act: (b) => b.add(tEvent),
+    expect: () => [
+      const RegisterLoading(),
+      const RegisterFailure('Campo inválido'),
+    ],
+  );
+
+  blocTest<RegisterBloc, RegisterState>(
+    'emits [Loading, Failure] on ServerException (500)',
+    build: () {
+      when(
+        () => mockRegister(
+          name: any(named: 'name'),
+          phone: any(named: 'phone'),
+          email: any(named: 'email'),
+          fiscalNumber: any(named: 'fiscalNumber'),
+          password: any(named: 'password'),
+          zipCode: any(named: 'zipCode'),
+          street: any(named: 'street'),
+          number: any(named: 'number'),
+          city: any(named: 'city'),
+          state: any(named: 'state'),
+          complement: any(named: 'complement'),
+          neighborhood: any(named: 'neighborhood'),
+        ),
+      ).thenThrow(const ServerException());
+      return bloc;
+    },
+    act: (b) => b.add(tEvent),
+    expect: () => [
+      const RegisterLoading(),
+      const RegisterFailure('Erro interno do servidor'),
+    ],
+  );
+
+  blocTest<RegisterBloc, RegisterState>(
+    'emits [Loading, Failure] on NetworkException',
+    build: () {
+      when(
+        () => mockRegister(
+          name: any(named: 'name'),
+          phone: any(named: 'phone'),
+          email: any(named: 'email'),
+          fiscalNumber: any(named: 'fiscalNumber'),
+          password: any(named: 'password'),
+          zipCode: any(named: 'zipCode'),
+          street: any(named: 'street'),
+          number: any(named: 'number'),
+          city: any(named: 'city'),
+          state: any(named: 'state'),
+          complement: any(named: 'complement'),
+          neighborhood: any(named: 'neighborhood'),
+        ),
+      ).thenThrow(const NetworkException());
+      return bloc;
+    },
+    act: (b) => b.add(tEvent),
+    expect: () => [
+      const RegisterLoading(),
+      const RegisterFailure('Sem conexão com a internet'),
     ],
   );
 }


### PR DESCRIPTION
## O que mudou?
- ApiClient passa a ler o body do erro para montar mensagens específicas por status
- 409 com email → "Este e-mail já está em uso."
- 409 com cpf/fiscal → "Este CPF já está cadastrado."
- 400 → mensagem do backend ou fallback genérico
- 500, sem internet e outros → mensagens amigáveis
- Novos testes cobrindo todos os cenários de erro no RegisterBloc


## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

flutter test

## Screenshots / Gravações
<img width="461" height="55" alt="Captura de Tela 2026-04-11 às 13 16 25" src="https://github.com/user-attachments/assets/01ce8a63-ba08-4098-bd80-073e8b6bcc22" />

<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
