### PR TITLE
Fix/ajusta perfil produtor

### DIFF
--- a/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -55,10 +55,21 @@ class AuthRemoteDataSource {
     required String password,
   }) async {
     // Step 1: Get Keycloak configuration from our backend
-    final configResponse = await _apiClient.dio.get<Map<String, dynamic>>(
-      ApiEndpoints.authConfig,
-    );
-    final config = AuthConfigModel.fromJson(configResponse.data!);
+    final AuthConfigModel config;
+    try {
+      final configResponse = await _apiClient.dio.get<Map<String, dynamic>>(
+        ApiEndpoints.authConfig,
+      );
+      final data = configResponse.data;
+      if (data == null) {
+        throw const UnknownApiException(
+          'Resposta inválida ao carregar configuração de autenticação.',
+        );
+      }
+      config = AuthConfigModel.fromJson(data);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
 
     // Step 2: Authenticate directly with Keycloak (form-urlencoded)
     // Uses a separate Dio instance because Keycloak expects

--- a/lib/features/auth/presentation/bloc/login_bloc.dart
+++ b/lib/features/auth/presentation/bloc/login_bloc.dart
@@ -26,7 +26,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       emit(LoginSuccess(result.user));
     } on ApiException catch (e) {
       emit(LoginFailure(e.message));
-    } on Exception catch (_) {
+    } on Object catch (_) {
       emit(const LoginFailure('Unexpected error. Please try again.'));
     }
   }

--- a/lib/features/producer_management/data/datasources/producer_management_remote_datasource.dart
+++ b/lib/features/producer_management/data/datasources/producer_management_remote_datasource.dart
@@ -1,40 +1,51 @@
+import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/core/network/api_client.dart';
+import 'package:ragro_mobile/core/network/api_endpoints.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/auth/data/datasources/auth_local_datasource.dart';
 import 'package:ragro_mobile/features/producer_management/domain/entities/producer_dashboard.dart';
 
 @lazySingleton
 class ProducerManagementRemoteDataSource {
+  final ApiClient _apiClient = getIt<ApiClient>();
+  final AuthLocalDataSource _authLocal = getIt<AuthLocalDataSource>();
+
   /// Gets dashboard data for the authenticated producer.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future<ProducerDashboard> getDashboard() async {
-  ///   try {
-  ///     final response = await _apiClient.dio.get<Map<String, dynamic>>(
-  ///       ApiEndpoints.producerDashboard,
-  ///     );
-  ///     return ProducerDashboard.fromJson(response.data!);
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<ProducerDashboard> getDashboard() async {
-    await Future.delayed(const Duration(milliseconds: 400));
-    return const ProducerDashboard(
-      producerName: 'João Silva',
-      producerTitle: 'Produtor Orgânico Certificado',
-      avatarUrl: '',
-      totalSales: 42850.0,
-      salesGrowthPercent: 18.5,
-      totalOrders: 128,
-      ordersGrowthPercent: 12.0,
-      stockPercentage: 85.0,
-      stockChangePercent: -2.0,
-      weeklyChartData: [3200, 4100, 2800, 5600, 4800, 3900, 2200],
-      currentMonth: 'Março/26',
-    );
+    final producerId = _authLocal.getUserId();
+    if (producerId == null || producerId.isEmpty) {
+      throw const UnauthorizedException('Sessão expirada. Faça login novamente.');
+    }
+
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        ApiEndpoints.producer(producerId),
+      );
+
+      final data = response.data ?? const <String, dynamic>{};
+      final farmName =
+          (data['farmName'] as String? ?? data['farm_name'] as String? ?? '')
+              .trim();
+
+      return ProducerDashboard(
+        producerName: (data['name'] as String? ?? '').trim(),
+        producerTitle: farmName.isNotEmpty ? farmName : 'Produtor',
+        avatarUrl: data['avatarS3'] as String? ??
+            data['avatar_s3'] as String? ??
+            '',
+        totalSales: 0,
+        salesGrowthPercent: 0,
+        totalOrders: (data['totalOrders'] as num?)?.toInt() ?? 0,
+        ordersGrowthPercent: 0,
+        stockPercentage: 0,
+        stockChangePercent: 0,
+        weeklyChartData: const [0, 0, 0, 0, 0, 0, 0],
+        currentMonth: 'Atual',
+      );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
   }
 }

--- a/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
@@ -1,36 +1,43 @@
 // Screen: Producer Edit Profile (Editar Perfil do Produtor)
 // User Story: US-25 — Edit Producer Profile
 // Epic: EPIC 4 — Producer Features
-// Routes: PUT /producers/:id
+// Routes: GET /producers/:id, PUT /producers/:id
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/auth/data/datasources/auth_local_datasource.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/bloc/producer_profile_bloc.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/bloc/producer_profile_event.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/bloc/producer_profile_state.dart';
-
-/// ID do produtor autenticado. O backend resolve via JWT.
-const String _authenticatedProducerId = 'me';
 
 class ProducerEditProfilePage extends StatelessWidget {
   const ProducerEditProfilePage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final producerId = getIt<AuthLocalDataSource>().getUserId();
+    if (producerId == null || producerId.isEmpty) {
+      return const Scaffold(
+        body: Center(
+          child: Text('Sessão expirada. Faça login novamente.'),
+        ),
+      );
+    }
     return BlocProvider<ProducerProfileBloc>(
-      create: (_) =>
-          getIt<ProducerProfileBloc>()
-            ..add(const ProducerProfileStarted(_authenticatedProducerId)),
-      child: const _ProducerEditProfileView(),
+      create: (_) => getIt<ProducerProfileBloc>()
+        ..add(ProducerProfileStarted(producerId)),
+      child: _ProducerEditProfileView(producerId: producerId),
     );
   }
 }
 
 class _ProducerEditProfileView extends StatefulWidget {
-  const _ProducerEditProfileView();
+  const _ProducerEditProfileView({required this.producerId});
+
+  final String producerId;
 
   @override
   State<_ProducerEditProfileView> createState() =>
@@ -68,7 +75,7 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
     if (!(_formKey.currentState?.validate() ?? false)) return;
     context.read<ProducerProfileBloc>().add(
       ProducerProfileUpdateSubmitted(
-        producerId: _authenticatedProducerId,
+        producerId: widget.producerId,
         name: _nameController.text,
         story: _bioController.text,
         phone: _phoneController.text,
@@ -128,6 +135,22 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
               state is ProducerProfileInitial) {
             return const Center(
               child: CircularProgressIndicator(color: AppColors.darkGreen),
+            );
+          }
+          if (state is ProducerProfileFailure && !_hydrated) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  state.message,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 14,
+                    color: AppColors.black,
+                  ),
+                ),
+              ),
             );
           }
 

--- a/lib/features/producer_management/presentation/pages/producer_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_profile_page.dart
@@ -29,6 +29,14 @@ class ProducerProfilePage extends StatelessWidget {
 class _ProducerProfileView extends StatelessWidget {
   const _ProducerProfileView();
 
+  Future<void> _openEditProfile(BuildContext context) async {
+    await context.push('/producer/profile/edit');
+    if (!context.mounted) return;
+    context.read<ProducerManagementBloc>().add(
+      const ProducerManagementRefreshed(),
+    );
+  }
+
   String _formatPrice(double price) {
     final formatted = price.toStringAsFixed(2).replaceAll('.', ',');
     return 'R\$ $formatted';
@@ -147,7 +155,7 @@ class _ProducerProfileView extends StatelessWidget {
                   ),
                   const SizedBox(height: 12),
                   OutlinedButton.icon(
-                    onPressed: () => context.push('/producer/profile/edit'),
+                    onPressed: () => _openEditProfile(context),
                     icon: const Icon(Icons.edit_outlined, size: 16),
                     label: const Text('Editar Perfil'),
                     style: OutlinedButton.styleFrom(


### PR DESCRIPTION
## O que mudou?

Ajustado o carregamento dos dados do perfil do produtor para usar o endpoint novo GET /producers/{id} (com producerId da sessão autenticada).

Corrigido o fluxo de atualização da tela de perfil após edição: ao voltar da tela de editar perfil, agora ocorre refresh automático dos dados (sem depender de hot reload/hot restart).

Melhorado o tratamento de erro no login para evitar fallback genérico em falhas de configuração de autenticação e exibir mensagens mais úteis.

## Tipo de mudança

- [x] Nova feature
- [x] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

1. Fazer login com usuário produtor válido.
2. Acessar a tela de perfil do produtor.
3. Clicar em Editar Perfil.
4. Alterar nome/fazenda/telefone/bio e salvar.
5. Voltar para a tela de perfil.
6. Validar que os dados atualizam automaticamente ao retornar da edição (sem precisar usar R no terminal).
7. Validar também o fluxo de login:
8. Com backend ativo, login deve funcionar normalmente.
9. Em caso de falha de rede/configuração, a mensagem exibida deve ser específica (não apenas “Unexpected error”).


## Screenshots / Gravações

<img width="513" height="734" alt="image" src="https://github.com/user-attachments/assets/0a60151a-47ef-4896-b2fd-5ba03daa69c5" />

<img width="517" height="729" alt="image" src="https://github.com/user-attachments/assets/b5bf4f88-a2d3-4512-bf7c-8ad5e73ba3d8" />

<img width="520" height="667" alt="image" src="https://github.com/user-attachments/assets/4cfac74a-20e2-4c40-b87c-1021f4825d66" />


<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
