### PR TITLE
feat: implement horizontal infinite scroll for producers

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -216,6 +216,8 @@ import 'package:ragro_mobile/features/search/domain/usecases/search_producers_an
     as _i894;
 import 'package:ragro_mobile/features/search/presentation/bloc/search_bloc.dart'
     as _i856;
+import 'package:ragro_mobile/features/home/domain/usecases/get_producers.dart'
+    as _i2000;
 import 'package:shared_preferences/shared_preferences.dart' as _i460;
 
 extension GetItInjectableX on _i174.GetIt {
@@ -489,6 +491,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i159.GetHomeData>(
       () => _i159.GetHomeData(gh<_i285.HomeRepository>()),
     );
+    gh.lazySingleton<_i2000.GetProducers>(
+      () => _i2000.GetProducers(gh<_i285.HomeRepository>()),
+    );
     gh.lazySingleton<_i626.GetCustomerProfile>(
       () => _i626.GetCustomerProfile(gh<_i788.CustomerProfileRepository>()),
     );
@@ -499,7 +504,10 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i856.SearchBloc>(
       () => _i856.SearchBloc(gh<_i894.SearchProducersAndProducts>()),
     );
-    gh.factory<_i151.HomeBloc>(() => _i151.HomeBloc(gh<_i159.GetHomeData>()));
+    gh.factory<_i151.HomeBloc>(() => _i151.HomeBloc(
+          gh<_i159.GetHomeData>(),
+          gh<_i2000.GetProducers>(),
+        ));
     gh.factory<_i914.AdminEditProducerBloc>(
       () => _i914.AdminEditProducerBloc(
         gh<_i852.GetAdminProducerById>(),

--- a/lib/core/network/paginated_response.dart
+++ b/lib/core/network/paginated_response.dart
@@ -15,6 +15,8 @@ class PaginatedResponse<T> {
   final int totalElements;
   final int totalPages;
 
+  bool get isLast => page + 1 >= totalPages;
+
   factory PaginatedResponse.fromJson(
     Map<String, dynamic> json,
     T Function(Map<String, dynamic>) fromJsonT,

--- a/lib/features/home/domain/usecases/get_home_data.dart
+++ b/lib/features/home/domain/usecases/get_home_data.dart
@@ -10,7 +10,7 @@ class GetHomeData {
 
   final HomeRepository _repository;
 
-  Future<({List<Producer> producers, List<HomeProduct> products})> call() async {
+  Future<({PaginatedResponse<Producer> producers, List<HomeProduct> products})> call() async {
     final results = await Future.wait([
       _repository.getProducers(),
       _repository.getRecommendedProducts(),
@@ -20,7 +20,7 @@ class GetHomeData {
     final products = results[1] as List<HomeProduct>;
 
     return (
-      producers: producersResponse.content,
+      producers: producersResponse,
       products: products,
     );
   }

--- a/lib/features/home/domain/usecases/get_producers.dart
+++ b/lib/features/home/domain/usecases/get_producers.dart
@@ -1,0 +1,15 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/network/paginated_response.dart';
+import 'package:ragro_mobile/features/home/domain/entities/producer.dart';
+import 'package:ragro_mobile/features/home/domain/repositories/home_repository.dart';
+
+@lazySingleton
+class GetProducers {
+  const GetProducers(this._repository);
+
+  final HomeRepository _repository;
+
+  Future<PaginatedResponse<Producer>> call({int page = 0, int size = 10}) {
+    return _repository.getProducers(page: page, size: size);
+  }
+}

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -2,27 +2,68 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/home/domain/usecases/get_home_data.dart';
+import 'package:ragro_mobile/features/home/domain/usecases/get_producers.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_event.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_state.dart';
 
 @injectable
 class HomeBloc extends Bloc<HomeEvent, HomeState> {
-  HomeBloc(this._getHomeData) : super(const HomeInitial()) {
+  HomeBloc(this._getHomeData, this._getProducers) : super(const HomeInitial()) {
     on<HomeStarted>(_onStarted);
     on<HomeRefreshed>(_onStarted);
+    on<HomeLoadMoreProducers>(_onLoadMoreProducers);
   }
 
   final GetHomeData _getHomeData;
+  final GetProducers _getProducers;
 
   Future<void> _onStarted(HomeEvent event, Emitter<HomeState> emit) async {
     emit(const HomeLoading());
     try {
       final data = await _getHomeData();
-      emit(HomeLoaded(producers: data.producers, products: data.products));
+      emit(
+        HomeLoaded(
+          producers: data.producers.content,
+          products: data.products,
+          currentProducersPage: data.producers.page,
+          hasMoreProducers: !data.producers.isLast,
+        ),
+      );
     } on ApiException catch (e) {
       emit(HomeFailure(e.message));
     } catch (_) {
       emit(const HomeFailure('Erro ao carregar dados. Tente novamente.'));
+    }
+  }
+
+  Future<void> _onLoadMoreProducers(
+    HomeLoadMoreProducers event,
+    Emitter<HomeState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! HomeLoaded ||
+        !currentState.hasMoreProducers ||
+        currentState.isFetchingMoreProducers) {
+      return;
+    }
+
+    emit(currentState.copyWith(isFetchingMoreProducers: true));
+
+    try {
+      final response = await _getProducers(
+        page: currentState.currentProducersPage + 1,
+      );
+
+      emit(
+        currentState.copyWith(
+          producers: [...currentState.producers, ...response.content],
+          currentProducersPage: response.page,
+          hasMoreProducers: !response.isLast,
+          isFetchingMoreProducers: false,
+        ),
+      );
+    } catch (_) {
+      emit(currentState.copyWith(isFetchingMoreProducers: false));
     }
   }
 }

--- a/lib/features/home/presentation/bloc/home_event.dart
+++ b/lib/features/home/presentation/bloc/home_event.dart
@@ -14,3 +14,7 @@ class HomeStarted extends HomeEvent {
 class HomeRefreshed extends HomeEvent {
   const HomeRefreshed();
 }
+
+class HomeLoadMoreProducers extends HomeEvent {
+  const HomeLoadMoreProducers();
+}

--- a/lib/features/home/presentation/bloc/home_state.dart
+++ b/lib/features/home/presentation/bloc/home_state.dart
@@ -18,13 +18,44 @@ class HomeLoading extends HomeState {
 }
 
 class HomeLoaded extends HomeState {
-  const HomeLoaded({required this.producers, required this.products});
+  const HomeLoaded({
+    required this.producers,
+    required this.products,
+    this.currentProducersPage = 0,
+    this.hasMoreProducers = true,
+    this.isFetchingMoreProducers = false,
+  });
 
   final List<Producer> producers;
   final List<HomeProduct> products;
+  final int currentProducersPage;
+  final bool hasMoreProducers;
+  final bool isFetchingMoreProducers;
+
+  HomeLoaded copyWith({
+    List<Producer>? producers,
+    List<HomeProduct>? products,
+    int? currentProducersPage,
+    bool? hasMoreProducers,
+    bool? isFetchingMoreProducers,
+  }) {
+    return HomeLoaded(
+      producers: producers ?? this.producers,
+      products: products ?? this.products,
+      currentProducersPage: currentProducersPage ?? this.currentProducersPage,
+      hasMoreProducers: hasMoreProducers ?? this.hasMoreProducers,
+      isFetchingMoreProducers: isFetchingMoreProducers ?? this.isFetchingMoreProducers,
+    );
+  }
 
   @override
-  List<Object?> get props => [producers, products];
+  List<Object?> get props => [
+    producers,
+    products,
+    currentProducersPage,
+    hasMoreProducers,
+    isFetchingMoreProducers,
+  ];
 }
 
 class HomeFailure extends HomeState {

--- a/lib/features/home/presentation/pages/customer_home_page.dart
+++ b/lib/features/home/presentation/pages/customer_home_page.dart
@@ -64,6 +64,7 @@ class _CustomerHomeView extends StatelessWidget {
                       child: ProducersSection(
                         producers: producers,
                         onProducerTap: (p) => _onProducerTap(context, p),
+                        isLoadingMore: state is HomeLoaded && state.isFetchingMoreProducers,
                       ),
                     ),
                     const SliverToBoxAdapter(child: SizedBox(height: 32)),

--- a/lib/features/home/presentation/widgets/producers_section.dart
+++ b/lib/features/home/presentation/widgets/producers_section.dart
@@ -1,17 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/home/domain/entities/producer.dart';
+import 'package:ragro_mobile/features/home/presentation/bloc/home_bloc.dart';
+import 'package:ragro_mobile/features/home/presentation/bloc/home_event.dart';
 import 'package:ragro_mobile/features/home/presentation/widgets/producer_card.dart';
 
-class ProducersSection extends StatelessWidget {
+class ProducersSection extends StatefulWidget {
   const ProducersSection({
     super.key,
     required this.producers,
     required this.onProducerTap,
+    this.isLoadingMore = false,
   });
 
   final List<Producer> producers;
   final void Function(Producer) onProducerTap;
+  final bool isLoadingMore;
+
+  @override
+  State<ProducersSection> createState() => _ProducersSectionState();
+}
+
+class _ProducersSectionState extends State<ProducersSection> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      context.read<HomeBloc>().add(const HomeLoadMoreProducers());
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,14 +64,27 @@ class ProducersSection extends StatelessWidget {
         SizedBox(
           height: 282,
           child: ListView.separated(
+            controller: _scrollController,
             scrollDirection: Axis.horizontal,
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: producers.length,
+            itemCount: widget.isLoadingMore
+                ? widget.producers.length + 1
+                : widget.producers.length,
             separatorBuilder: (_, __) => const SizedBox(width: 16),
-            itemBuilder: (context, index) => ProducerCard(
-              producer: producers[index],
-              onTap: () => onProducerTap(producers[index]),
-            ),
+            itemBuilder: (context, index) {
+              if (index < widget.producers.length) {
+                return ProducerCard(
+                  producer: widget.producers[index],
+                  onTap: () => widget.onProducerTap(widget.producers[index]),
+                );
+              }
+              return const Center(
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: CircularProgressIndicator(color: AppColors.darkGreen),
+                ),
+              );
+            },
           ),
         ),
       ],


### PR DESCRIPTION
## O que mudou?
Ajuste de Scroll: Implementado o scroll da tela de marketplace (Início) (barra de rolagem horizontal para os produtores.)

## Tipo de mudança
- [x] Nova feature
- [ ] Bug fix 
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (configurações de scroll e DI)

## Como testar?
1. Abra o app no navegador Chrome.
2. Na seção de **Produtores**, arraste a tela (no chrome use shift + scroll do mouse)
3. É necessário ter produtores suficientes para conseguir utilizar essa feature

## Screenshots / Gravações

Pré scroll:
<img width="1916" height="363" alt="image" src="https://github.com/user-attachments/assets/5b662d10-aacc-4a0f-85a3-1f17bdddda6e" />
Pós scroll:
<img width="1915" height="375" alt="image" src="https://github.com/user-attachments/assets/6d475b51-8c89-4f73-84ce-37a2fe5161c8" />
Testes:
<img width="229" height="46" alt="image" src="https://github.com/user-attachments/assets/6a3d8f99-7cdf-47a8-be9c-34da7a6eb859" />


## Checklist
- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (Lints pré-existentes ignorados, novos arquivos limpos)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto (Clean Architecture)