### PR TITLE
feat: products from producers being shown in the profile screen

### DIFF
--- a/lib/core/formatters/input_masks.dart
+++ b/lib/core/formatters/input_masks.dart
@@ -152,7 +152,7 @@ class BankAccountInputFormatter extends TextInputFormatter {
   ) {
     final digits = _digits(newValue.text, max: 7);
     if (digits.isEmpty) return TextEditingValue.empty;
-    
+
     final formatted = _formatAccount(digits);
     return TextEditingValue(
       text: formatted,

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -1,4 +1,3 @@
-// lib/core/network/api_endpoints.dart
 abstract final class ApiEndpoints {
   static const String _defaultBase = 'http://localhost:8080';
 
@@ -38,7 +37,9 @@ abstract final class ApiEndpoints {
   static String get producers => '$_base/producers';
   static String get recommendations => '$_base/recommendations';
   static String producer(String id) => '$_base/producers/$id';
-  static String producerPublicProfile(String id) => '$_base/producers/$id/profile';
+  static String producerPublicProfile(String id) =>
+      '$_base/producers/$id/profile';
+  static String producerProducts(String id) => '$_base/producers/$id/products';
   static String producerAvatar(String id) => '$_base/producers/$id/avatar';
   static String producerCover(String id) => '$_base/producers/$id/cover';
 

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -38,7 +38,6 @@ import 'package:ragro_mobile/features/search/presentation/pages/search_result_pa
 import 'package:ragro_mobile/shared/widgets/customer_shell.dart';
 import 'package:ragro_mobile/shared/widgets/producer_shell.dart';
 
-
 @lazySingleton
 class AppRouter {
   AppRouter(this._authBloc) {
@@ -159,11 +158,10 @@ class AppRouter {
                   routes: [
                     GoRoute(
                       path: 'results',
-                      builder: (_, state) => SearchResultsPage(
-                        query: state.extra as String,
-                      ),
-                    )
-                  ]
+                      builder: (_, state) =>
+                          SearchResultsPage(query: state.extra! as String),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
@@ -180,10 +180,16 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
     _nameController.text = producer.name;
     _phoneController.text = _applyMask(producer.phone, PhoneInputFormatter());
     _emailController.text = producer.email;
-    _cpfCnpjController.text = _applyMask(producer.fiscalNumber, FiscalNumberInputFormatter());
+    _cpfCnpjController.text = _applyMask(
+      producer.fiscalNumber,
+      FiscalNumberInputFormatter(),
+    );
     _farmNameController.text = producer.farmName;
     _descriptionController.text = producer.description;
-    _cepController.text = _applyMask(producer.producerAddress?.zipCode ?? '', CepInputFormatter());
+    _cepController.text = _applyMask(
+      producer.producerAddress?.zipCode ?? '',
+      CepInputFormatter(),
+    );
     _addressController.text = producer.producerAddress?.street ?? '';
     _numberController.text = producer.producerAddress?.number ?? '';
     _neighborhoodController.text = producer.producerAddress?.neighborhood ?? '';
@@ -197,9 +203,15 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
     if (pix != null) {
       _pixKeyType = pix.pixKeyType;
       if (_pixKeyType == 'cpf' || _pixKeyType == 'cnpj') {
-        _pixKeyController.text = _applyMask(pix.pixKey ?? '', FiscalNumberInputFormatter());
+        _pixKeyController.text = _applyMask(
+          pix.pixKey ?? '',
+          FiscalNumberInputFormatter(),
+        );
       } else if (_pixKeyType == 'phone') {
-        _pixKeyController.text = _applyMask(pix.pixKey ?? '', PhoneInputFormatter());
+        _pixKeyController.text = _applyMask(
+          pix.pixKey ?? '',
+          PhoneInputFormatter(),
+        );
       } else {
         _pixKeyController.text = pix.pixKey ?? '';
       }
@@ -213,9 +225,15 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
       _bankNameController.text = bank.bankName ?? '';
       _bankCodeController.text = bank.bankCode ?? '';
       _agencyController.text = bank.agency ?? '';
-      _accountController.text = _applyMask(bank.accountNumber ?? '', BankAccountInputFormatter());
+      _accountController.text = _applyMask(
+        bank.accountNumber ?? '',
+        BankAccountInputFormatter(),
+      );
       _holderController.text = bank.holderName ?? '';
-      _bankFiscalController.text = _applyMask(bank.fiscalNumber ?? '', FiscalNumberInputFormatter());
+      _bankFiscalController.text = _applyMask(
+        bank.fiscalNumber ?? '',
+        FiscalNumberInputFormatter(),
+      );
     }
 
     // Pre-fill horário

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -43,7 +43,8 @@ class LoginPage extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: ConstrainedBox(
                 constraints: BoxConstraints(
-                  minHeight: MediaQuery.of(context).size.height -
+                  minHeight:
+                      MediaQuery.of(context).size.height -
                       MediaQuery.of(context).padding.top -
                       MediaQuery.of(context).padding.bottom,
                 ),
@@ -52,7 +53,7 @@ class LoginPage extends StatelessWidget {
                     children: [
                       const Spacer(flex: 3),
                       const RagroLogo(),
-                      const Spacer(flex: 1),
+                      const Spacer(),
                       LoginForm(onRegisterTap: () => context.push('/register')),
                       const Spacer(),
                     ],

--- a/lib/features/auth/presentation/widgets/ragro_logo.dart
+++ b/lib/features/auth/presentation/widgets/ragro_logo.dart
@@ -12,11 +12,7 @@ class RagroLogo extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SvgPicture.asset(
-          'assets/images/logo_ragro.svg',
-          height: 300,
-          fit: BoxFit.contain,
-        ),
+        SvgPicture.asset('assets/images/logo_ragro.svg', height: 300),
         const SizedBox(height: 8),
         Text(
           'Do campo à mesa',

--- a/lib/features/home/data/models/home_product_model.dart
+++ b/lib/features/home/data/models/home_product_model.dart
@@ -11,17 +11,37 @@ class HomeProductModel extends HomeProduct {
     required super.producerId,
   });
 
-  factory HomeProductModel.fromJson(Map<String, dynamic> json) {
+  factory HomeProductModel.fromJson(
+    Map<String, dynamic> json, {
+    String fallbackFarmName = '',
+  }) {
+    final categories = json['categories'];
+    final primaryCategory = categories is List && categories.isNotEmpty
+        ? categories.first as Map<String, dynamic>
+        : null;
+
     return HomeProductModel(
-      id: json['id'] as String,
-      name: json['name'] as String,
-      category: json['category'] as String? ?? '',
-      price: (json['price'] as num).toDouble(),
+      id: (json['id'] ?? '').toString(),
+      name: json['name'] as String? ?? '',
+      category:
+          json['category'] as String? ??
+          primaryCategory?['name'] as String? ??
+          '',
+      price: (json['price'] as num?)?.toDouble() ?? 0,
       imageUrl:
-          json['image_s3'] as String? ?? json['imageUrl'] as String? ?? '',
-      farmName: json['farm_name'] as String? ?? '',
+          json['imageS3'] as String? ??
+          json['image_s3'] as String? ??
+          json['imageUrl'] as String? ??
+          '',
+      farmName:
+          json['farmName'] as String? ??
+          json['farm_name'] as String? ??
+          fallbackFarmName,
       producerId:
-          json['farmer_id'] as String? ?? json['producerId'] as String? ?? '',
+          json['farmerId'] as String? ??
+          json['farmer_id'] as String? ??
+          json['producerId'] as String? ??
+          '',
     );
   }
 

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -62,7 +62,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
           isFetchingMoreProducers: false,
         ),
       );
-    } catch (_) {
+    } on Object {
       emit(currentState.copyWith(isFetchingMoreProducers: false));
     }
   }

--- a/lib/features/home/presentation/bloc/home_state.dart
+++ b/lib/features/home/presentation/bloc/home_state.dart
@@ -44,7 +44,8 @@ class HomeLoaded extends HomeState {
       products: products ?? this.products,
       currentProducersPage: currentProducersPage ?? this.currentProducersPage,
       hasMoreProducers: hasMoreProducers ?? this.hasMoreProducers,
-      isFetchingMoreProducers: isFetchingMoreProducers ?? this.isFetchingMoreProducers,
+      isFetchingMoreProducers:
+          isFetchingMoreProducers ?? this.isFetchingMoreProducers,
     );
   }
 

--- a/lib/features/home/presentation/pages/customer_home_page.dart
+++ b/lib/features/home/presentation/pages/customer_home_page.dart
@@ -64,7 +64,7 @@ class _CustomerHomeView extends StatelessWidget {
                       child: ProducersSection(
                         producers: producers,
                         onProducerTap: (p) => _onProducerTap(context, p),
-                        isLoadingMore: state is HomeLoaded && state.isFetchingMoreProducers,
+                        isLoadingMore: state.isFetchingMoreProducers,
                       ),
                     ),
                     const SliverToBoxAdapter(child: SizedBox(height: 32)),

--- a/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
@@ -187,7 +187,6 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
     _phoneController.text = _applyMask(producer.phone, PhoneInputFormatter());
     _farmNameController.text = producer.farmName;
 
-    // Address
     if (producer.producerAddress != null) {
       final addr = producer.producerAddress!;
       _cepController.text = _applyMask(addr.zipCode, CepInputFormatter());
@@ -243,12 +242,14 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
     if (producer.availability.isNotEmpty) {
       _scheduleStartController.text = producer.availability.first.opensAt;
       _scheduleEndController.text = producer.availability.first.closesAt;
-      for (int i = 0; i < 7; i++) {
+      for (var i = 0; i < 7; i++) {
         _weekdays[i] = false;
       }
       for (final slot in producer.availability) {
         final uiIndex = slot.weekday == 0 ? 6 : slot.weekday - 1;
-        if (uiIndex >= 0 && uiIndex < 7) _weekdays[uiIndex] = true;
+        if (uiIndex >= 0 && uiIndex < 7) {
+          _weekdays[uiIndex] = true;
+        }
       }
     } else {
       _scheduleStartController.text = '08:00';
@@ -261,7 +262,6 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
   void _submit() {
     if (!(_formKey.currentState?.validate() ?? false)) return;
 
-    // Address
     Map<String, dynamic>? addressPayload;
     if (_addressController.text.trim().isNotEmpty) {
       addressPayload = {
@@ -324,10 +324,10 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
     final availability = <Map<String, dynamic>>[];
     final sStart = _scheduleStartController.text.trim();
     final sEnd = _scheduleEndController.text.trim();
-    for (int i = 0; i < 7; i++) {
+    for (var i = 0; i < 7; i++) {
       if (_weekdays[i]) {
         // UI weekday: 0=Mon..6=Sun. API weekday: 0=Sun, 1=Mon..
-        int apiWeekday = (i == 6) ? 0 : i + 1;
+        final apiWeekday = (i == 6) ? 0 : i + 1;
         availability.add({
           'weekday': apiWeekday,
           'opensAt': sStart,
@@ -618,8 +618,9 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
                           validator: (value) {
                             final trimmed = value?.trim() ?? '';
                             if (trimmed.isEmpty) return 'Informe seu nome';
-                            if (trimmed.length < 3)
+                            if (trimmed.length < 3) {
                               return 'Nome deve ter ao menos 3 caracteres';
+                            }
                             return null;
                           },
                         ),
@@ -638,8 +639,9 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
                               '',
                             );
                             if (digits.isEmpty) return 'Informe um telefone';
-                            if (digits.length < 10)
+                            if (digits.length < 10) {
                               return 'Telefone deve ter ao menos 10 dígitos';
+                            }
                             return null;
                           },
                         ),
@@ -651,8 +653,9 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
                           hint: 'Nome da sua propriedade rural',
                           prefixIcon: Icons.home_outlined,
                           validator: (value) {
-                            if (value?.trim().isEmpty ?? true)
+                            if (value?.trim().isEmpty ?? true) {
                               return 'Informe o nome da fazenda';
+                            }
                             return null;
                           },
                         ),
@@ -666,8 +669,9 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
                           minLines: 1,
                           maxLines: null,
                           validator: (value) {
-                            if (value?.trim().isEmpty ?? true)
+                            if (value?.trim().isEmpty ?? true) {
                               return 'Conte um pouco sobre você';
+                            }
                             return null;
                           },
                         ),
@@ -687,8 +691,9 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
                           validator: (value) {
                             if (value == null || value.isEmpty) return null;
                             final digits = _digitsOnly(value);
-                            if (digits.length != 8)
+                            if (digits.length != 8) {
                               return 'CEP deve ter 8 dígitos';
+                            }
                             return null;
                           },
                         ),
@@ -805,7 +810,8 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
                                 const _FieldLabel('Tipo da chave (opcional)'),
                                 const SizedBox(height: 8),
                                 DropdownButtonFormField<String>(
-                                  value: _pixKeyTypes.contains(_pixKeyType)
+                                  initialValue:
+                                      _pixKeyTypes.contains(_pixKeyType)
                                       ? _pixKeyType
                                       : null,
                                   decoration: _dropdownDecoration(),
@@ -1172,9 +1178,7 @@ class _FormField extends StatelessWidget {
     this.prefixIcon,
     this.maxLines = 1,
     this.minLines,
-    this.maxLength,
     this.keyboardType = TextInputType.text,
-    this.enabled = true,
     this.inputFormatters,
     this.validator,
     super.key,
@@ -1185,9 +1189,7 @@ class _FormField extends StatelessWidget {
   final IconData? prefixIcon;
   final int? maxLines;
   final int? minLines;
-  final int? maxLength;
   final TextInputType keyboardType;
-  final bool enabled;
   final List<TextInputFormatter>? inputFormatters;
   final String? Function(String?)? validator;
 
@@ -1197,9 +1199,7 @@ class _FormField extends StatelessWidget {
       controller: controller,
       maxLines: maxLines,
       minLines: minLines,
-      maxLength: maxLength,
       keyboardType: keyboardType,
-      enabled: enabled,
       inputFormatters: inputFormatters,
       validator: validator,
       autovalidateMode: AutovalidateMode.onUserInteraction,
@@ -1250,7 +1250,7 @@ class _UppercaseFormatter extends TextInputFormatter {
 }
 
 class _UfAutocomplete extends StatelessWidget {
-  const _UfAutocomplete({this.initialValue, required this.onSelected});
+  const _UfAutocomplete({required this.onSelected, this.initialValue});
   final String? initialValue;
   final ValueChanged<String> onSelected;
 

--- a/lib/features/producer_profile/data/datasources/producer_profile_remote_datasource.dart
+++ b/lib/features/producer_profile/data/datasources/producer_profile_remote_datasource.dart
@@ -5,6 +5,7 @@ import 'package:ragro_mobile/core/network/api_client.dart';
 import 'package:ragro_mobile/core/network/api_endpoints.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/core/utils/multipart_file_builder.dart';
+import 'package:ragro_mobile/features/home/data/models/home_product_model.dart';
 import 'package:ragro_mobile/features/producer_profile/data/models/producer_update_request.dart';
 import 'package:ragro_mobile/features/producer_profile/data/models/public_producer_model.dart';
 
@@ -14,14 +15,44 @@ class ProducerProfileRemoteDataSource {
 
   final ApiClient _apiClient;
 
-  // Public profile endpoint for customers to view producer details
-  // GET /producers/{id}/profile - requires @PreAuthorize("hasRole('CUSTOMER')")
   Future<PublicProducerModel> getProducer(String producerId) async {
     try {
-      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+      final profileResponse = await _apiClient.dio.get<Map<String, dynamic>>(
         ApiEndpoints.producerPublicProfile(producerId),
       );
-      return PublicProducerModel.fromJson(response.data!);
+      final producer = PublicProducerModel.fromJson(profileResponse.data!);
+
+      final productsResponse = await _apiClient.dio.get<List<dynamic>>(
+        ApiEndpoints.producerProducts(producerId),
+      );
+
+      final products = (productsResponse.data ?? const [])
+          .map(
+            (item) => HomeProductModel.fromJson(
+              item as Map<String, dynamic>,
+              fallbackFarmName: producer.farmName,
+            ),
+          )
+          .toList();
+
+      return PublicProducerModel(
+        id: producer.id,
+        name: producer.name,
+        farmName: producer.farmName,
+        location: producer.location,
+        description: producer.description,
+        story: producer.story,
+        avatarUrl: producer.avatarUrl,
+        coverUrl: producer.coverUrl,
+        averageRating: producer.averageRating,
+        totalReviews: producer.totalReviews,
+        phone: producer.phone,
+        availability: producer.availability,
+        memberSince: producer.memberSince,
+        photoUrl: producer.photoUrl,
+        producerAddress: producer.producerAddress,
+        products: products,
+      );
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();
     }

--- a/lib/features/producer_profile/data/models/public_producer_model.dart
+++ b/lib/features/producer_profile/data/models/public_producer_model.dart
@@ -1,4 +1,3 @@
-import 'package:ragro_mobile/features/home/data/models/home_product_model.dart';
 import 'package:ragro_mobile/features/producer_profile/domain/entities/public_producer.dart';
 
 class PublicProducerModel extends PublicProducer {
@@ -18,11 +17,9 @@ class PublicProducerModel extends PublicProducer {
     required super.memberSince,
     super.photoUrl,
     super.producerAddress,
+    super.products,
   });
 
-  /// Parses ProducerPublicProfileResponse from backend
-  /// Aligns with: GET /producers/{id}/profile
-  /// @PreAuthorize("hasRole('CUSTOMER')")
   factory PublicProducerModel.fromJson(Map<String, dynamic> json) {
     final address = json['address'] as Map<String, dynamic>?;
     final location = _deriveLocation(json, address);
@@ -62,6 +59,7 @@ class PublicProducerModel extends PublicProducer {
           : DateTime(2016),
       photoUrl: json['photoUrl'] as String?,
       producerAddress: producerAddress,
+      products: const [],
     );
   }
 

--- a/lib/features/producer_profile/data/models/review_model.dart
+++ b/lib/features/producer_profile/data/models/review_model.dart
@@ -16,7 +16,8 @@ class ReviewModel extends Review {
 
     return ReviewModel(
       id: json['id'] as String? ?? '',
-      authorName: json['authorName'] as String? ??
+      authorName:
+          json['authorName'] as String? ??
           json['author_name'] as String? ??
           'Anônimo',
       rating: (json['rating'] as num?)?.toDouble() ?? 0.0,
@@ -31,11 +32,11 @@ class ReviewModel extends Review {
   }
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'authorName': authorName,
-        'rating': rating,
-        'comment': comment,
-        'createdAt': createdAt.toIso8601String(),
-        'authorAvatarUrl': authorAvatarUrl,
-      };
+    'id': id,
+    'authorName': authorName,
+    'rating': rating,
+    'comment': comment,
+    'createdAt': createdAt.toIso8601String(),
+    'authorAvatarUrl': authorAvatarUrl,
+  };
 }

--- a/lib/features/producer_profile/domain/entities/public_producer.dart
+++ b/lib/features/producer_profile/domain/entities/public_producer.dart
@@ -41,7 +41,17 @@ class ProducerAddress extends Equatable {
   final double? longitude;
 
   @override
-  List<Object?> get props => [street, number, city, state, zipCode, complement, neighborhood, latitude, longitude];
+  List<Object?> get props => [
+    street,
+    number,
+    city,
+    state,
+    zipCode,
+    complement,
+    neighborhood,
+    latitude,
+    longitude,
+  ];
 }
 
 class ProducerPaymentMethod extends Equatable {
@@ -71,17 +81,17 @@ class ProducerPaymentMethod extends Equatable {
 
   @override
   List<Object?> get props => [
-        type,
-        pixKeyType,
-        pixKey,
-        bankCode,
-        bankName,
-        agency,
-        accountNumber,
-        accountType,
-        holderName,
-        fiscalNumber,
-      ];
+    type,
+    pixKeyType,
+    pixKey,
+    bankCode,
+    bankName,
+    agency,
+    accountNumber,
+    accountType,
+    holderName,
+    fiscalNumber,
+  ];
 }
 
 class PublicProducer extends Equatable {
@@ -120,10 +130,7 @@ class PublicProducer extends Equatable {
   final List<AvailabilitySlot> availability;
   final DateTime memberSince;
 
-  /// Optional: from ProducerPublicProfileResponse
   final String? photoUrl;
-
-  /// Optional: fetched from separate endpoints or profile editing
   final ProducerAddress? producerAddress;
   final List<ProducerPaymentMethod>? paymentMethods;
   final List<HomeProduct>? products;
@@ -134,5 +141,24 @@ class PublicProducer extends Equatable {
   }
 
   @override
-  List<Object?> get props => [id, farmName, averageRating, phone, memberSince];
+  List<Object?> get props => [
+    id,
+    name,
+    farmName,
+    location,
+    description,
+    story,
+    avatarUrl,
+    coverUrl,
+    averageRating,
+    totalReviews,
+    phone,
+    availability,
+    memberSince,
+    photoUrl,
+    producerAddress,
+    paymentMethods,
+    products,
+    reviews,
+  ];
 }

--- a/lib/features/producer_profile/domain/entities/review.dart
+++ b/lib/features/producer_profile/domain/entities/review.dart
@@ -18,5 +18,12 @@ class Review extends Equatable {
   final String? authorAvatarUrl;
 
   @override
-  List<Object?> get props => [id, authorName, rating, comment, createdAt, authorAvatarUrl];
+  List<Object?> get props => [
+    id,
+    authorName,
+    rating,
+    comment,
+    createdAt,
+    authorAvatarUrl,
+  ];
 }

--- a/lib/features/producer_profile/presentation/bloc/producer_profile_event.dart
+++ b/lib/features/producer_profile/presentation/bloc/producer_profile_event.dart
@@ -39,15 +39,15 @@ class ProducerProfileUpdateSubmitted extends ProducerProfileEvent {
 
   @override
   List<Object?> get props => [
-        producerId,
-        name,
-        story,
-        phone,
-        farmName,
-        address,
-        paymentMethods,
-        availability,
-      ];
+    producerId,
+    name,
+    story,
+    phone,
+    farmName,
+    address,
+    paymentMethods,
+    availability,
+  ];
 }
 
 class ProducerAvatarPicked extends ProducerProfileEvent {

--- a/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
+++ b/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
@@ -10,9 +10,9 @@ import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/home/presentation/widgets/home_product_card.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/bloc/producer_profile_bloc.dart';
-import 'package:ragro_mobile/features/producer_profile/presentation/widgets/availability_section.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/bloc/producer_profile_event.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/bloc/producer_profile_state.dart';
+import 'package:ragro_mobile/features/producer_profile/presentation/widgets/availability_section.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/widgets/producer_stats_row.dart';
 import 'package:ragro_mobile/features/producer_profile/presentation/widgets/review_card.dart';
 
@@ -146,7 +146,9 @@ class _ProducerPublicProfileView extends StatelessWidget {
                                 width: double.infinity,
                                 child: ElevatedButton.icon(
                                   onPressed: () {
-                                    debugPrint('Telefone do produtor: ${producer.phone}');
+                                    debugPrint(
+                                      'Telefone do produtor: ${producer.phone}',
+                                    );
                                   },
                                   icon: const Icon(
                                     Icons.phone_outlined,
@@ -242,7 +244,8 @@ class _ProducerPublicProfileView extends StatelessWidget {
                                         mainAxisSpacing: 12,
                                         childAspectRatio: 0.55,
                                       ),
-                                  itemCount: (producer.products ?? const []).length,
+                                  itemCount:
+                                      (producer.products ?? const []).length,
                                   itemBuilder: (_, i) => HomeProductCard(
                                     product: (producer.products ?? const [])[i],
                                     onTap: () => context.push(
@@ -270,15 +273,17 @@ class _ProducerPublicProfileView extends StatelessWidget {
                               if ((producer.reviews ?? const []).isEmpty)
                                 Center(
                                   child: Padding(
-                                    padding:
-                                        const EdgeInsets.symmetric(vertical: 24),
+                                    padding: const EdgeInsets.symmetric(
+                                      vertical: 24,
+                                    ),
                                     child: Column(
                                       children: [
                                         Icon(
                                           Icons.rate_review_outlined,
                                           size: 48,
-                                          color: AppColors.darkGreen
-                                              .withValues(alpha: 0.3),
+                                          color: AppColors.darkGreen.withValues(
+                                            alpha: 0.3,
+                                          ),
                                         ),
                                         const SizedBox(height: 12),
                                         Text(
@@ -299,7 +304,8 @@ class _ProducerPublicProfileView extends StatelessWidget {
                                 ListView.builder(
                                   shrinkWrap: true,
                                   physics: const NeverScrollableScrollPhysics(),
-                                  itemCount: (producer.reviews ?? const []).length,
+                                  itemCount:
+                                      (producer.reviews ?? const []).length,
                                   itemBuilder: (_, i) => ReviewCard(
                                     review: (producer.reviews ?? const [])[i],
                                   ),

--- a/lib/features/producer_profile/presentation/widgets/availability_section.dart
+++ b/lib/features/producer_profile/presentation/widgets/availability_section.dart
@@ -3,10 +3,7 @@ import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/producer_profile/domain/entities/public_producer.dart';
 
 class AvailabilitySection extends StatelessWidget {
-  const AvailabilitySection({
-    required this.availability,
-    super.key,
-  });
+  const AvailabilitySection({required this.availability, super.key});
 
   final List<AvailabilitySlot> availability;
 
@@ -61,70 +58,73 @@ class AvailabilitySection extends StatelessWidget {
     // Ordena os dias para exibição (Seg -> Dom) e filtra apenas os dias
     // que realmente possuem um slot de disponibilidade.
     final orderedWeekdays = [1, 2, 3, 4, 5, 6, 0]; // Seg..Dom
-    final shownWeekdays = orderedWeekdays.where((d) => availability.any((s) => s.weekday == d)).toList();
+    final shownWeekdays = orderedWeekdays
+        .where((d) => availability.any((s) => s.weekday == d))
+        .toList();
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         const SizedBox(height: 4),
-        LayoutBuilder(builder: (context, constraints) {
-          return Row(
-            children: shownWeekdays.map((weekday) {
-              final matches = availability.where((s) => s.weekday == weekday);
-              final slot = matches.first;
+        LayoutBuilder(
+          builder: (context, constraints) {
+            return Row(
+              children: shownWeekdays.map((weekday) {
+                final matches = availability.where((s) => s.weekday == weekday);
+                final slot = matches.first;
 
-              return Expanded(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      _getWeekdayShortName(weekday),
-                      style: TextStyle(
-                        fontFamily: 'Figtree',
-                        fontWeight: FontWeight.w600,
-                        fontSize: 16,
-                        color: AppColors.darkGreen,
+                return Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        _getWeekdayShortName(weekday),
+                        style: const TextStyle(
+                          fontFamily: 'Figtree',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                          color: AppColors.darkGreen,
+                        ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      slot.opensAt,
-                      style: TextStyle(
-                        fontFamily: 'Figtree',
-                        fontWeight: FontWeight.w500,
-                        fontSize: 14,
-                        color: const Color(0xFF64748B),
+                      const SizedBox(height: 6),
+                      Text(
+                        slot.opensAt,
+                        style: const TextStyle(
+                          fontFamily: 'Figtree',
+                          fontWeight: FontWeight.w500,
+                          fontSize: 14,
+                          color: Color(0xFF64748B),
+                        ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 4),
-                    // separador vertical pequeno conforme o Figma
-                    Container(
-                      width: 2,
-                      height: 12,
-                      decoration: BoxDecoration(
-                        color: AppColors.darkGreen.withValues(alpha: 0.25),
-                        borderRadius: BorderRadius.circular(1),
+                      const SizedBox(height: 4),
+                      // separador vertical pequeno conforme o Figma
+                      Container(
+                        width: 2,
+                        height: 12,
+                        decoration: BoxDecoration(
+                          color: AppColors.darkGreen.withValues(alpha: 0.25),
+                          borderRadius: BorderRadius.circular(1),
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      slot.closesAt,
-                      style: TextStyle(
-                        fontFamily: 'Figtree',
-                        fontWeight: FontWeight.w500,
-                        fontSize: 14,
-                        color: const Color(0xFF64748B),
+                      const SizedBox(height: 4),
+                      Text(
+                        slot.closesAt,
+                        style: const TextStyle(
+                          fontFamily: 'Figtree',
+                          fontWeight: FontWeight.w500,
+                          fontSize: 14,
+                          color: Color(0xFF64748B),
+                        ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                ),
-              );
-            }).toList(),
-          );
-        }),
+                    ],
+                  ),
+                );
+              }).toList(),
+            );
+          },
+        ),
       ],
     );
   }

--- a/lib/features/producer_profile/presentation/widgets/review_card.dart
+++ b/lib/features/producer_profile/presentation/widgets/review_card.dart
@@ -37,10 +37,7 @@ class ReviewCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.white,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: const Color(0xFFE2E8F0),
-          width: 1,
-        ),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -56,7 +53,9 @@ class ReviewCard extends StatelessWidget {
                     // Avatar
                     CircleAvatar(
                       radius: 20,
-                      backgroundColor: AppColors.mintGreen.withValues(alpha: 0.3),
+                      backgroundColor: AppColors.mintGreen.withValues(
+                        alpha: 0.3,
+                      ),
                       backgroundImage: review.authorAvatarUrl != null
                           ? NetworkImage(review.authorAvatarUrl!)
                           : null,

--- a/lib/features/search/data/datasources/search_remote_datasource.dart
+++ b/lib/features/search/data/datasources/search_remote_datasource.dart
@@ -16,7 +16,7 @@ class SearchRemoteDataSource {
     String? category,
   }) async {
     try {
-      final response = await _apiClient.dio.get<dynamic>(
+      final response = await _apiClient.dio.get<Object?>(
         ApiEndpoints.producers,
         queryParameters: {
           'name': query,
@@ -27,10 +27,14 @@ class SearchRemoteDataSource {
       final data = response.data;
       if (data == null) throw const UnknownApiException();
 
-      final list = data is List ? data : (data['content'] as List);
+      final list = switch (data) {
+        final List<Object?> values => values,
+        final Map<String, dynamic> map => map['content'] as List<Object?>,
+        _ => throw const UnknownApiException(),
+      };
 
       return list
-          .map((e) => SearchResultModel.fromJson(e as Map<String, dynamic>))
+          .map((e) => SearchResultModel.fromJson(e! as Map<String, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();

--- a/lib/features/search/data/models/search_result_model.dart
+++ b/lib/features/search/data/models/search_result_model.dart
@@ -56,11 +56,6 @@ class SearchResultModel extends SearchResult {
       subtitle: json['farm_name'] as String? ?? '',
       imageUrl: json['avatar_s3'] as String? ?? '',
       rating: (json['average_rating'] as num?)?.toDouble(),
-      reviewCount: null,
-      price: null,
-      category: null,
-      distance: null,
-      unit: null,
     );
   }
 }

--- a/lib/features/search/presentation/pages/search_page.dart
+++ b/lib/features/search/presentation/pages/search_page.dart
@@ -143,9 +143,7 @@ class _SearchViewState extends State<_SearchView> {
                           label: _categories[i],
                           isSelected: _selectedCategory == _categories[i],
                           onTap: () {
-                            setState(
-                              () => _selectedCategory = _categories[i],
-                            );
+                            setState(() => _selectedCategory = _categories[i]);
                           },
                         ),
                       ),
@@ -255,10 +253,7 @@ class _SearchViewState extends State<_SearchView> {
                               SearchRecentItemRemoved(q),
                             ),
                           ),
-                          const Divider(
-                            color: Color(0xFFF1F5F9),
-                            height: 1,
-                          ),
+                          const Divider(color: Color(0xFFF1F5F9), height: 1),
                         ],
                       ),
                     ),

--- a/lib/features/search/presentation/pages/search_result_page.dart
+++ b/lib/features/search/presentation/pages/search_result_page.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
-import 'package:ragro_mobile/features/search/presentation/widgets/category_chip.dart';
 import 'package:ragro_mobile/features/search/domain/entities/search_result.dart';
 import 'package:ragro_mobile/features/search/presentation/bloc/search_bloc.dart';
 import 'package:ragro_mobile/features/search/presentation/bloc/search_event.dart';
 import 'package:ragro_mobile/features/search/presentation/bloc/search_state.dart';
+import 'package:ragro_mobile/features/search/presentation/widgets/category_chip.dart';
 import 'package:ragro_mobile/features/search/presentation/widgets/search_result_tile.dart';
 
 class SearchResultsPage extends StatelessWidget {
@@ -120,22 +120,23 @@ class _SearchResultsViewState extends State<_SearchResultsView> {
             return switch (state) {
               SearchIdle() => const SizedBox.shrink(),
               SearchLoading() => const Center(
-                  child: CircularProgressIndicator(color: AppColors.darkGreen),
-                ),
-              SearchLoaded(:final results) => results.isEmpty
-                  ? const Center(
-                      child: Text(
-                        'Nenhum resultado encontrado.',
-                        style: TextStyle(color: AppColors.placeholder),
-                      ),
-                    )
-                  : _buildTabs(results),
+                child: CircularProgressIndicator(color: AppColors.darkGreen),
+              ),
+              SearchLoaded(:final results) =>
+                results.isEmpty
+                    ? const Center(
+                        child: Text(
+                          'Nenhum resultado encontrado.',
+                          style: TextStyle(color: AppColors.placeholder),
+                        ),
+                      )
+                    : _buildTabs(results),
               SearchFailure(:final message) => Center(
-                  child: Text(
-                    message,
-                    style: const TextStyle(color: AppColors.placeholder),
-                  ),
+                child: Text(
+                  message,
+                  style: const TextStyle(color: AppColors.placeholder),
                 ),
+              ),
             };
           },
         ),
@@ -178,8 +179,9 @@ class _SearchResultsViewState extends State<_SearchResultsView> {
                     label: filter,
                     isSelected: _selectedFilter == filter,
                     onTap: () => setState(() {
-                      _selectedFilter =
-                          _selectedFilter == filter ? null : filter;
+                      _selectedFilter = _selectedFilter == filter
+                          ? null
+                          : filter;
                     }),
                   ),
                   if (!isLast) const SizedBox(width: 12),
@@ -221,7 +223,7 @@ class _SearchResultsViewState extends State<_SearchResultsView> {
       itemBuilder: (_, i) => SearchResultTile(
         result: items[i],
         onTap: () {
-          // TODO: navegar para detalhe
+          // TODO(codex): navegar para detalhe.
         },
       ),
     );

--- a/lib/features/search/presentation/widgets/producer_tile.dart
+++ b/lib/features/search/presentation/widgets/producer_tile.dart
@@ -4,11 +4,7 @@ import 'package:ragro_mobile/features/search/domain/entities/search_result.dart'
 import 'package:ragro_mobile/features/search/presentation/widgets/search_result_tile.dart';
 
 class ProducerTile extends StatelessWidget {
-  const ProducerTile({
-    required this.result,
-    required this.onTap,
-    super.key,
-  });
+  const ProducerTile({required this.result, required this.onTap, super.key});
 
   final SearchResult result;
   final VoidCallback onTap;
@@ -23,7 +19,9 @@ class ProducerTile extends StatelessWidget {
         decoration: BoxDecoration(
           color: AppColors.lightGreen.withValues(alpha: 0.05),
           borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: AppColors.lightGreen.withValues(alpha: 0.3)),
+          border: Border.all(
+            color: AppColors.lightGreen.withValues(alpha: 0.3),
+          ),
           boxShadow: const [
             BoxShadow(
               color: Color(0x08000000),
@@ -83,7 +81,7 @@ class ProducerTile extends StatelessWidget {
                       Text(
                         result.distance != null
                             ? '${result.distance!.toStringAsFixed(1)} km de você'
-                            : '0.5 km de você', //TODO: Ajustar para pegar distância real quando tiver
+                            : '0.5 km de você', // TODO(codex): usar distância real quando disponível.
                         style: const TextStyle(
                           fontFamily: 'Manrope',
                           fontSize: 12,

--- a/lib/features/search/presentation/widgets/product_tile.dart
+++ b/lib/features/search/presentation/widgets/product_tile.dart
@@ -3,11 +3,7 @@ import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/search/domain/entities/search_result.dart';
 
 class ProductTile extends StatelessWidget {
-  const ProductTile({
-    required this.result,
-    required this.onTap,
-    super.key,
-  });
+  const ProductTile({required this.result, required this.onTap, super.key});
 
   final SearchResult result;
   final VoidCallback onTap;
@@ -74,7 +70,6 @@ class ProductTile extends StatelessWidget {
                   ),
                   const SizedBox(height: 6),
                   Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       Text(
                         'R\$ ${result.price!.toStringAsFixed(2).replaceAll('.', ',')}',
@@ -95,7 +90,7 @@ class ProductTile extends StatelessWidget {
                           ),
                         ),
                       const Spacer(),
-                      _CartButton(),
+                      const _CartButton(),
                     ],
                   ),
                 ],
@@ -128,16 +123,11 @@ class _ProductImage extends StatelessWidget {
               child: Image.network(
                 imageUrl,
                 fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => const Icon(
-                  Icons.eco_outlined,
-                  color: AppColors.darkGreen,
-                ),
+                errorBuilder: (_, __, ___) =>
+                    const Icon(Icons.eco_outlined, color: AppColors.darkGreen),
               ),
             )
-          : const Icon(
-              Icons.eco_outlined,
-              color: AppColors.darkGreen,
-            ),
+          : const Icon(Icons.eco_outlined, color: AppColors.darkGreen),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -409,7 +409,7 @@ packages:
     source: hosted
     version: "3.2.2"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   image_picker: ^1.1.2
   flutter_svg: ^2.0.10
   intl: ^0.20.0
+  http_parser: ^4.1.2
 
 dev_dependencies:
   flutter_test:

--- a/test/features/producer_profile/data/models/public_producer_model_test.dart
+++ b/test/features/producer_profile/data/models/public_producer_model_test.dart
@@ -28,11 +28,7 @@ void main() {
           'zipCode': '90010120',
         },
         'availability': [
-          {
-            'weekday': 1,
-            'opensAt': '14:00',
-            'closesAt': '18:30',
-          }
+          {'weekday': 1, 'opensAt': '14:00', 'closesAt': '18:30'},
         ],
       };
 
@@ -94,10 +90,7 @@ void main() {
         'averageRating': 4.5,
         'totalReviews': 50,
         'memberSince': '2019-06-01',
-        'address': {
-          'city': 'Canela',
-          'state': 'RS',
-        },
+        'address': {'city': 'Canela', 'state': 'RS'},
       };
 
       final model = PublicProducerModel.fromJson(json);
@@ -109,7 +102,7 @@ void main() {
       expect(model.photoUrl, 'https://s3.example.com/photo.jpg');
       expect(model.averageRating, 4.5);
       expect(model.totalReviews, 50);
-      expect(model.memberSince, DateTime(2019, 6, 1));
+      expect(model.memberSince, DateTime(2019, 6));
       expect(model.location, 'Canela, RS');
     });
   });

--- a/test/features/search/presentation/search_bloc_test.dart
+++ b/test/features/search/presentation/search_bloc_test.dart
@@ -25,7 +25,7 @@ void main() {
     name: 'Farmer Test',
     subtitle: 'Sítio Boa Vista',
     imageUrl: '',
-    rating: 0.0,
+    rating: 0,
   );
 
   setUp(() {
@@ -55,7 +55,7 @@ void main() {
       'emite [SearchLoading, SearchLoaded] quando busca retorna resultados',
       build: () {
         when(
-          () => mockRepository.search(query: 'Farmer', category: null),
+          () => mockRepository.search(query: 'Farmer'),
         ).thenAnswer((_) async => [tProducer]);
         return bloc;
       },
@@ -65,8 +65,7 @@ void main() {
         const SearchLoaded(results: [tProducer], query: 'Farmer'),
       ],
       verify: (_) {
-        verify(() => mockRepository.search(query: 'Farmer', category: null))
-            .called(1);
+        verify(() => mockRepository.search(query: 'Farmer')).called(1);
       },
     );
 
@@ -74,7 +73,7 @@ void main() {
       'emite [SearchLoading, SearchLoaded] com lista vazia quando não há resultados',
       build: () {
         when(
-          () => mockRepository.search(query: 'xyzabc', category: null),
+          () => mockRepository.search(query: 'xyzabc'),
         ).thenAnswer((_) async => []);
         return bloc;
       },
@@ -89,22 +88,19 @@ void main() {
       'emite [SearchLoading, SearchFailure] quando ocorre ApiException',
       build: () {
         when(
-          () => mockRepository.search(query: 'erro', category: null),
+          () => mockRepository.search(query: 'erro'),
         ).thenThrow(const UnknownApiException());
         return bloc;
       },
       act: (b) => b.add(const SearchQueryChanged('erro')),
-      expect: () => [
-        const SearchLoading(),
-        isA<SearchFailure>(),
-      ],
+      expect: () => [const SearchLoading(), isA<SearchFailure>()],
     );
 
     blocTest<SearchBloc, SearchState>(
       'emite [SearchLoading, SearchFailure] quando ocorre Exception genérica',
       build: () {
         when(
-          () => mockRepository.search(query: 'erro', category: null),
+          () => mockRepository.search(query: 'erro'),
         ).thenThrow(Exception('erro genérico'));
         return bloc;
       },
@@ -121,7 +117,7 @@ void main() {
       'não emite estados ao trocar categoria',
       build: () => bloc,
       act: (b) => b.add(const SearchCategoryChanged('Horta')),
-      expect: () => [],
+      expect: () => <SearchState>[],
     );
 
     blocTest<SearchBloc, SearchState>(
@@ -152,7 +148,7 @@ void main() {
       'busca sem categoria quando categoria é Tudo',
       build: () {
         when(
-          () => mockRepository.search(query: 'tomate', category: null),
+          () => mockRepository.search(query: 'tomate'),
         ).thenAnswer((_) async => [tProducer]);
         return bloc;
       },
@@ -166,9 +162,7 @@ void main() {
         const SearchLoaded(results: [tProducer], query: 'tomate'),
       ],
       verify: (_) {
-        verify(
-          () => mockRepository.search(query: 'tomate', category: null),
-        ).called(1);
+        verify(() => mockRepository.search(query: 'tomate')).called(1);
       },
     );
   });
@@ -189,7 +183,7 @@ void main() {
       build: () => bloc,
       seed: () => const SearchLoading(),
       act: (b) => b.add(const SearchRecentItemRemoved('tomate')),
-      expect: () => [],
+      expect: () => <SearchState>[],
     );
   });
 }


### PR DESCRIPTION
## O que mudou?
Integração da tela pública de perfil do produtor com o backend para carregar corretamente os produtos do produtor. Foram realizados os seguintes ajustes:

- adicionada no mobile a rota de consumo dos produtos do produtor via GET /producers/{id}/products
- ajustado o fluxo da tela de perfil público para buscar:
- perfil público do produtor em GET /producers/{id}/profile
- produtos ativos do produtor em GET /producers/{id}/products
- adaptado o datasource para compor o estado da tela com os dados do perfil e a lista de produtos

## Tipo de mudança

- [X] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

1. Subir o backend com os endpoints de produtor disponíveis.
2. Garantir que exista um produtor com produtos ativos cadastrados.
3. Abrir o app no fluxo de cliente.
4. Ir para a home.
5. Clicar em um card de produtor.
6. Validar que a tela pública do produtor abre corretamente, carrega os dados do perfil público e exibe os produtos do produtor na grade

## Screenshots / Gravações

<img width="574" height="634" alt="Screenshot 2026-04-25 at 13 33 04" src="https://github.com/user-attachments/assets/932b59a5-f3d5-4515-803e-cf15fcea6422" />

## Checklist

- [X] Código formatado (`dart format .`)
- [X] Sem warnings no analyze (`dart analyze`)
- [X] Testes passando (`flutter test`)
- [X] Segue o padrão de arquitetura do projeto
