### PR TITLE
Feat/password reset flow

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -346,9 +346,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i1.ProducerOrdersBloc>(
       () => _i1.ProducerOrdersBloc(gh<_i935.GetProducerOrders>()),
     );
-    gh.lazySingleton<_i894.SearchProducersAndProducts>(
-      () => _i894.SearchProducersAndProducts(gh<_i38.SearchRepository>()),
-    );
     gh.lazySingleton<_i70.AddToCart>(
       () => _i70.AddToCart(gh<_i830.CartRepository>()),
     );
@@ -425,6 +422,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i38.SearchRepository>(
       () => _i563.SearchRepositoryImpl(gh<_i987.SearchRemoteDataSource>()),
     );
+    gh.lazySingleton<_i191.ForgotPassword>(
+      () => _i191.ForgotPassword(gh<_i43.AuthRepository>()),
+    );
     gh.lazySingleton<_i846.GetCurrentUser>(
       () => _i846.GetCurrentUser(gh<_i43.AuthRepository>()),
     );
@@ -460,6 +460,9 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i192.RegisterBloc>(
       () => _i192.RegisterBloc(gh<_i948.RegisterCustomer>()),
+    );
+    gh.lazySingleton<_i894.SearchProducersAndProducts>(
+      () => _i894.SearchProducersAndProducts(gh<_i38.SearchRepository>()),
     );
     gh.lazySingleton<_i671.ActivateAdminProducer>(
       () => _i671.ActivateAdminProducer(gh<_i759.AdminRepository>()),
@@ -514,7 +517,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i436.UpdateCustomerProfile>(
       () => _i436.UpdateCustomerProfile(gh<_i788.CustomerProfileRepository>()),
     );
-    gh.factory<_i713.LoginBloc>(() => _i713.LoginBloc(gh<_i1047.LoginUser>()));
     gh.factory<_i151.HomeBloc>(
       () => _i151.HomeBloc(gh<_i159.GetHomeData>(), gh<_i298.GetProducers>()),
     );

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -56,6 +56,8 @@ import 'package:ragro_mobile/features/auth/domain/usecases/logout.dart'
     as _i418;
 import 'package:ragro_mobile/features/auth/domain/usecases/register_customer.dart'
     as _i948;
+import 'package:ragro_mobile/features/auth/domain/usecases/request_password_reset.dart'
+    as _i485;
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_bloc.dart'
     as _i475;
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_bloc.dart'
@@ -100,6 +102,8 @@ import 'package:ragro_mobile/features/home/domain/repositories/home_repository.d
     as _i285;
 import 'package:ragro_mobile/features/home/domain/usecases/get_home_data.dart'
     as _i159;
+import 'package:ragro_mobile/features/home/domain/usecases/get_producers.dart'
+    as _i298;
 import 'package:ragro_mobile/features/home/presentation/bloc/home_bloc.dart'
     as _i151;
 import 'package:ragro_mobile/features/inventory/data/datasources/inventory_remote_datasource.dart'
@@ -216,8 +220,6 @@ import 'package:ragro_mobile/features/search/domain/usecases/search_producers_an
     as _i894;
 import 'package:ragro_mobile/features/search/presentation/bloc/search_bloc.dart'
     as _i856;
-import 'package:ragro_mobile/features/home/domain/usecases/get_producers.dart'
-    as _i2000;
 import 'package:shared_preferences/shared_preferences.dart' as _i460;
 
 extension GetItInjectableX on _i174.GetIt {
@@ -252,6 +254,12 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i608.ProducerOrdersRemoteDataSource>(
       () => _i608.ProducerOrdersRemoteDataSource(),
     );
+    gh.lazySingleton<_i127.ProductDetailRemoteDataSource>(
+      () => const _i127.ProductDetailRemoteDataSource(),
+    );
+    gh.lazySingleton<_i987.SearchRemoteDataSource>(
+      () => const _i987.SearchRemoteDataSource(),
+    );
     gh.lazySingleton<_i165.OrdersRepository>(
       () => _i962.OrdersRepositoryImpl(gh<_i384.OrdersRemoteDatasource>()),
     );
@@ -272,6 +280,11 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i20.GetProducts>(
       () => _i20.GetProducts(gh<_i414.ProductRepository>()),
+    );
+    gh.lazySingleton<_i818.ProductDetailRepository>(
+      () => _i43.ProductDetailRepositoryImpl(
+        gh<_i127.ProductDetailRemoteDataSource>(),
+      ),
     );
     gh.lazySingleton<_i570.ProducerManagementRepository>(
       () => _i715.ProducerManagementRepositoryImpl(
@@ -304,6 +317,12 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i209.AuthLocalDataSource>(
       () => _i209.AuthLocalDataSource(gh<_i460.SharedPreferences>()),
     );
+    gh.lazySingleton<_i38.SearchRepository>(
+      () => _i563.SearchRepositoryImpl(gh<_i987.SearchRemoteDataSource>()),
+    );
+    gh.lazySingleton<_i680.GetProductDetail>(
+      () => _i680.GetProductDetail(gh<_i818.ProductDetailRepository>()),
+    );
     gh.factory<_i463.CheckoutBloc>(
       () => _i463.CheckoutBloc(gh<_i680.ConfirmOrder>()),
     );
@@ -325,8 +344,14 @@ extension GetItInjectableX on _i174.GetIt {
       ),
     );
     gh.factory<_i226.OrdersBloc>(() => _i226.OrdersBloc(gh<_i52.GetOrders>()));
+    gh.factory<_i740.ProductDetailBloc>(
+      () => _i740.ProductDetailBloc(gh<_i680.GetProductDetail>()),
+    );
     gh.factory<_i1.ProducerOrdersBloc>(
       () => _i1.ProducerOrdersBloc(gh<_i935.GetProducerOrders>()),
+    );
+    gh.lazySingleton<_i894.SearchProducersAndProducts>(
+      () => _i894.SearchProducersAndProducts(gh<_i38.SearchRepository>()),
     );
     gh.lazySingleton<_i70.AddToCart>(
       () => _i70.AddToCart(gh<_i830.CartRepository>()),
@@ -380,12 +405,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i889.ProducerProfileRemoteDataSource>(
       () => _i889.ProducerProfileRemoteDataSource(gh<_i873.ApiClient>()),
     );
-    gh.lazySingleton<_i127.ProductDetailRemoteDataSource>(
-      () => _i127.ProductDetailRemoteDataSource(),
-    );
-    gh.lazySingleton<_i987.SearchRemoteDataSource>(
-      () => _i987.SearchRemoteDataSource(),
-    );
     gh.factory<_i767.ProducerManagementBloc>(
       () => _i767.ProducerManagementBloc(gh<_i805.GetProducerDashboard>()),
     );
@@ -397,10 +416,8 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i1038.UpdateProducerOrderStatus>(),
       ),
     );
-    gh.lazySingleton<_i818.ProductDetailRepository>(
-      () => _i43.ProductDetailRepositoryImpl(
-        gh<_i127.ProductDetailRemoteDataSource>(),
-      ),
+    gh.factory<_i856.SearchBloc>(
+      () => _i856.SearchBloc(gh<_i894.SearchProducersAndProducts>()),
     );
     gh.lazySingleton<_i43.AuthRepository>(
       () => _i579.AuthRepositoryImpl(
@@ -408,12 +425,6 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i209.AuthLocalDataSource>(),
         gh<_i873.ApiClient>(),
       ),
-    );
-    gh.lazySingleton<_i38.SearchRepository>(
-      () => _i563.SearchRepositoryImpl(gh<_i987.SearchRemoteDataSource>()),
-    );
-    gh.lazySingleton<_i680.GetProductDetail>(
-      () => _i680.GetProductDetail(gh<_i818.ProductDetailRepository>()),
     );
     gh.lazySingleton<_i846.GetCurrentUser>(
       () => _i846.GetCurrentUser(gh<_i43.AuthRepository>()),
@@ -427,14 +438,14 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i948.RegisterCustomer>(
       () => _i948.RegisterCustomer(gh<_i43.AuthRepository>()),
     );
+    gh.lazySingleton<_i485.RequestPasswordReset>(
+      () => _i485.RequestPasswordReset(gh<_i43.AuthRepository>()),
+    );
     gh.factory<_i205.InventoryBloc>(
       () => _i205.InventoryBloc(
         gh<_i252.GetInventoryProducts>(),
         gh<_i481.DeleteInventoryProduct>(),
       ),
-    );
-    gh.factory<_i740.ProductDetailBloc>(
-      () => _i740.ProductDetailBloc(gh<_i680.GetProductDetail>()),
     );
     gh.lazySingleton<_i759.AdminRepository>(
       () => _i780.AdminRepositoryImpl(gh<_i16.AdminRemoteDataSource>()),
@@ -450,9 +461,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i192.RegisterBloc>(
       () => _i192.RegisterBloc(gh<_i948.RegisterCustomer>()),
-    );
-    gh.lazySingleton<_i894.SearchProducersAndProducts>(
-      () => _i894.SearchProducersAndProducts(gh<_i38.SearchRepository>()),
     );
     gh.lazySingleton<_i671.ActivateAdminProducer>(
       () => _i671.ActivateAdminProducer(gh<_i759.AdminRepository>()),
@@ -477,11 +485,15 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i889.ProducerProfileRemoteDataSource>(),
       ),
     );
-    gh.lazySingleton<_i475.AuthBloc>(
-      () => _i475.AuthBloc(gh<_i846.GetCurrentUser>(), gh<_i418.Logout>()),
-    );
     gh.lazySingleton<_i285.HomeRepository>(
       () => _i1055.HomeRepositoryImpl(gh<_i904.HomeRemoteDataSource>()),
+    );
+    gh.lazySingleton<_i475.AuthBloc>(
+      () => _i475.AuthBloc(
+        gh<_i846.GetCurrentUser>(),
+        gh<_i418.Logout>(),
+        gh<_i485.RequestPasswordReset>(),
+      ),
     );
     gh.lazySingleton<_i788.CustomerProfileRepository>(
       () => _i866.CustomerProfileRepositoryImpl(
@@ -491,8 +503,8 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i159.GetHomeData>(
       () => _i159.GetHomeData(gh<_i285.HomeRepository>()),
     );
-    gh.lazySingleton<_i2000.GetProducers>(
-      () => _i2000.GetProducers(gh<_i285.HomeRepository>()),
+    gh.lazySingleton<_i298.GetProducers>(
+      () => _i298.GetProducers(gh<_i285.HomeRepository>()),
     );
     gh.lazySingleton<_i626.GetCustomerProfile>(
       () => _i626.GetCustomerProfile(gh<_i788.CustomerProfileRepository>()),
@@ -501,13 +513,9 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i436.UpdateCustomerProfile(gh<_i788.CustomerProfileRepository>()),
     );
     gh.factory<_i713.LoginBloc>(() => _i713.LoginBloc(gh<_i1047.LoginUser>()));
-    gh.factory<_i856.SearchBloc>(
-      () => _i856.SearchBloc(gh<_i894.SearchProducersAndProducts>()),
+    gh.factory<_i151.HomeBloc>(
+      () => _i151.HomeBloc(gh<_i159.GetHomeData>(), gh<_i298.GetProducers>()),
     );
-    gh.factory<_i151.HomeBloc>(() => _i151.HomeBloc(
-          gh<_i159.GetHomeData>(),
-          gh<_i2000.GetProducers>(),
-        ));
     gh.factory<_i914.AdminEditProducerBloc>(
       () => _i914.AdminEditProducerBloc(
         gh<_i852.GetAdminProducerById>(),

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -48,6 +48,8 @@ import 'package:ragro_mobile/features/auth/data/repositories/auth_repository_imp
     as _i579;
 import 'package:ragro_mobile/features/auth/domain/repositories/auth_repository.dart'
     as _i43;
+import 'package:ragro_mobile/features/auth/domain/usecases/forgot_password.dart'
+    as _i191;
 import 'package:ragro_mobile/features/auth/domain/usecases/get_current_user.dart'
     as _i846;
 import 'package:ragro_mobile/features/auth/domain/usecases/login_user.dart'
@@ -426,6 +428,9 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i873.ApiClient>(),
       ),
     );
+    gh.lazySingleton<_i191.ForgotPassword>(
+      () => _i191.ForgotPassword(gh<_i43.AuthRepository>()),
+    );
     gh.lazySingleton<_i846.GetCurrentUser>(
       () => _i846.GetCurrentUser(gh<_i43.AuthRepository>()),
     );
@@ -485,6 +490,9 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i889.ProducerProfileRemoteDataSource>(),
       ),
     );
+    gh.factory<_i713.LoginBloc>(
+      () => _i713.LoginBloc(gh<_i1047.LoginUser>(), gh<_i191.ForgotPassword>()),
+    );
     gh.lazySingleton<_i285.HomeRepository>(
       () => _i1055.HomeRepositoryImpl(gh<_i904.HomeRemoteDataSource>()),
     );
@@ -512,7 +520,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i436.UpdateCustomerProfile>(
       () => _i436.UpdateCustomerProfile(gh<_i788.CustomerProfileRepository>()),
     );
-    gh.factory<_i713.LoginBloc>(() => _i713.LoginBloc(gh<_i1047.LoginUser>()));
     gh.factory<_i151.HomeBloc>(
       () => _i151.HomeBloc(gh<_i159.GetHomeData>(), gh<_i298.GetProducers>()),
     );

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -29,7 +29,8 @@ abstract final class ApiEndpoints {
   static String get authConfig => '$_base/auth/config';
   static String get authSession => '$_base/auth/session';
   static String get registerCustomer => '$_base/auth/register/customer';
-  static String get resetPasswordEmail => '$_base/auth/password/reset-email';
+  static String get resetPasswordEmail => '$_base/auth/password/reset';
+  static String get forgotPassword => '$_base/auth/password/forgot';
 
   // Customers
   static String get customers => '$_base/customers';

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -29,6 +29,7 @@ abstract final class ApiEndpoints {
   static String get authConfig => '$_base/auth/config';
   static String get authSession => '$_base/auth/session';
   static String get registerCustomer => '$_base/auth/register/customer';
+  static String get resetPasswordEmail => '$_base/auth/password/reset-email';
 
   // Customers
   static String get customers => '$_base/customers';

--- a/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -163,4 +163,16 @@ class AuthRemoteDataSource {
       throw e.error as ApiException? ?? const UnknownApiException();
     }
   }
+
+  /// Esqueceu a senha — POST /auth/password/forgot (204 No Content).
+  Future<void> forgotPassword(String email) async {
+    try {
+      await _apiClient.dio.post(
+        ApiEndpoints.forgotPassword,
+        data: {'email': email},
+      );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
 }

--- a/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -154,4 +154,13 @@ class AuthRemoteDataSource {
       throw e.error as ApiException? ?? const UnknownApiException();
     }
   }
+
+  /// Solicita redefinição de senha via e-mail — POST /auth/password/reset-email (204 No Content).
+  Future<void> requestPasswordReset() async {
+    try {
+      await _apiClient.dio.post(ApiEndpoints.resetPasswordEmail);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -91,6 +91,11 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<void> forgotPassword(String email) {
+    return _remote.forgotPassword(email);
+  }
+
+  @override
   Future<User?> getCurrentUser() async {
     // DEMO_MODE: bypass auth — used for Playwright visual testing only.
     // Run with: flutter run -d chrome --dart-define=DEMO_MODE=true

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -86,6 +86,11 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<void> requestPasswordReset() {
+    return _remote.requestPasswordReset();
+  }
+
+  @override
   Future<User?> getCurrentUser() async {
     // DEMO_MODE: bypass auth — used for Playwright visual testing only.
     // Run with: flutter run -d chrome --dart-define=DEMO_MODE=true

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -23,5 +23,7 @@ abstract class AuthRepository {
 
   Future<void> logout();
 
+  Future<void> requestPasswordReset();
+
   Future<User?> getCurrentUser();
 }

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -24,6 +24,8 @@ abstract class AuthRepository {
   Future<void> logout();
 
   Future<void> requestPasswordReset();
+  
+  Future<void> forgotPassword(String email);
 
   Future<User?> getCurrentUser();
 }

--- a/lib/features/auth/domain/usecases/forgot_password.dart
+++ b/lib/features/auth/domain/usecases/forgot_password.dart
@@ -1,0 +1,12 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/auth/domain/repositories/auth_repository.dart';
+
+@lazySingleton
+class ForgotPassword {
+  const ForgotPassword(this._repository);
+  final AuthRepository _repository;
+
+  Future<void> call(String email) {
+    return _repository.forgotPassword(email);
+  }
+}

--- a/lib/features/auth/domain/usecases/request_password_reset.dart
+++ b/lib/features/auth/domain/usecases/request_password_reset.dart
@@ -1,0 +1,12 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/auth/domain/repositories/auth_repository.dart';
+
+@lazySingleton
+class RequestPasswordReset {
+  const RequestPasswordReset(this._repository);
+  final AuthRepository _repository;
+
+  Future<void> call() {
+    return _repository.requestPasswordReset();
+  }
+}

--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,20 +1,25 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/get_current_user.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/logout.dart';
+import 'package:ragro_mobile/features/auth/domain/usecases/request_password_reset.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_state.dart';
 
 @lazySingleton
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
-  AuthBloc(this._getCurrentUser, this._logout) : super(const AuthInitial()) {
+  AuthBloc(this._getCurrentUser, this._logout, this._requestPasswordReset)
+    : super(const AuthInitial()) {
     on<AuthStarted>(_onStarted);
     on<AuthLoggedIn>((event, emit) => emit(AuthAuthenticated(event.user)));
     on<AuthLogoutRequested>(_onLogout);
+    on<AuthPasswordResetRequested>(_onPasswordResetRequested);
   }
 
   final GetCurrentUser _getCurrentUser;
   final Logout _logout;
+  final RequestPasswordReset _requestPasswordReset;
 
   Future<void> _onStarted(AuthStarted event, Emitter<AuthState> emit) async {
     emit(const AuthLoading());
@@ -37,5 +42,25 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       // and unauthenticate the user in-memory.
     }
     emit(const AuthUnauthenticated());
+  }
+
+  Future<void> _onPasswordResetRequested(
+    AuthPasswordResetRequested event,
+    Emitter<AuthState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! AuthAuthenticated) return;
+
+    final user = currentState.user;
+    emit(AuthPasswordResetInProgress(user));
+
+    try {
+      await _requestPasswordReset();
+      emit(AuthPasswordResetSuccess(user));
+    } on ApiException catch (e) {
+      emit(AuthPasswordResetFailure(user, e.message));
+    } on Exception catch (e) {
+      emit(AuthPasswordResetFailure(user, e.toString()));
+    }
   }
 }

--- a/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/lib/features/auth/presentation/bloc/auth_event.dart
@@ -21,3 +21,7 @@ class AuthLoggedIn extends AuthEvent {
 class AuthLogoutRequested extends AuthEvent {
   const AuthLogoutRequested();
 }
+
+class AuthPasswordResetRequested extends AuthEvent {
+  const AuthPasswordResetRequested();
+}

--- a/lib/features/auth/presentation/bloc/auth_state.dart
+++ b/lib/features/auth/presentation/bloc/auth_state.dart
@@ -22,6 +22,21 @@ class AuthAuthenticated extends AuthState {
   List<Object?> get props => [user];
 }
 
+class AuthPasswordResetInProgress extends AuthAuthenticated {
+  const AuthPasswordResetInProgress(super.user);
+}
+
+class AuthPasswordResetSuccess extends AuthAuthenticated {
+  const AuthPasswordResetSuccess(super.user);
+}
+
+class AuthPasswordResetFailure extends AuthAuthenticated {
+  const AuthPasswordResetFailure(super.user, this.message);
+  final String message;
+  @override
+  List<Object?> get props => [user, message];
+}
+
 class AuthUnauthenticated extends AuthState {
   const AuthUnauthenticated();
 }

--- a/lib/features/auth/presentation/bloc/login_bloc.dart
+++ b/lib/features/auth/presentation/bloc/login_bloc.dart
@@ -1,17 +1,20 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/auth/domain/usecases/forgot_password.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/login_user.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_state.dart';
 
 @injectable
 class LoginBloc extends Bloc<LoginEvent, LoginState> {
-  LoginBloc(this._loginUser) : super(const LoginInitial()) {
+  LoginBloc(this._loginUser, this._forgotPassword) : super(const LoginInitial()) {
     on<LoginSubmitted>(_onSubmitted);
+    on<LoginForgotPasswordRequested>(_onForgotPasswordRequested);
   }
 
   final LoginUser _loginUser;
+  final ForgotPassword _forgotPassword;
 
   Future<void> _onSubmitted(
     LoginSubmitted event,
@@ -28,6 +31,21 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       emit(LoginFailure(e.message));
     } on Object catch (_) {
       emit(const LoginFailure('Unexpected error. Please try again.'));
+    }
+  }
+
+  Future<void> _onForgotPasswordRequested(
+    LoginForgotPasswordRequested event,
+    Emitter<LoginState> emit,
+  ) async {
+    emit(const LoginForgotPasswordInProgress());
+    try {
+      await _forgotPassword(event.email);
+      emit(const LoginForgotPasswordSuccess());
+    } on ApiException catch (e) {
+      emit(LoginForgotPasswordFailure(e.message));
+    } on Object catch (_) {
+      emit(const LoginForgotPasswordFailure('Erro ao solicitar redefinição.'));
     }
   }
 }

--- a/lib/features/auth/presentation/bloc/login_event.dart
+++ b/lib/features/auth/presentation/bloc/login_event.dart
@@ -15,3 +15,11 @@ class LoginSubmitted extends LoginEvent {
   @override
   List<Object?> get props => [email, password];
 }
+
+class LoginForgotPasswordRequested extends LoginEvent {
+  const LoginForgotPasswordRequested(this.email);
+  final String email;
+
+  @override
+  List<Object?> get props => [email];
+}

--- a/lib/features/auth/presentation/bloc/login_state.dart
+++ b/lib/features/auth/presentation/bloc/login_state.dart
@@ -28,3 +28,18 @@ class LoginFailure extends LoginState {
   @override
   List<Object?> get props => [message];
 }
+
+class LoginForgotPasswordInProgress extends LoginState {
+  const LoginForgotPasswordInProgress();
+}
+
+class LoginForgotPasswordSuccess extends LoginState {
+  const LoginForgotPasswordSuccess();
+}
+
+class LoginForgotPasswordFailure extends LoginState {
+  const LoginForgotPasswordFailure(this.message);
+  final String message;
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -8,13 +8,18 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/core/theme/app_text_styles.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_bloc.dart';
 
+import 'package:ragro_mobile/features/auth/presentation/bloc/login_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_state.dart';
+import 'package:ragro_mobile/features/auth/presentation/widgets/auth_submit_button.dart';
+import 'package:ragro_mobile/features/auth/presentation/widgets/auth_text_field.dart';
 import 'package:ragro_mobile/features/auth/presentation/widgets/login_form.dart';
 import 'package:ragro_mobile/features/auth/presentation/widgets/ragro_logo.dart';
+import 'package:ragro_mobile/shared/widgets/app_notification.dart';
 
 class LoginPage extends StatelessWidget {
   const LoginPage({super.key});
@@ -34,10 +39,18 @@ class LoginPage extends StatelessWidget {
                 backgroundColor: AppColors.red,
               ),
             );
+          } else if (state is LoginForgotPasswordSuccess) {
+            AppNotification.showSuccess(
+              context,
+              'E-mail de recuperação enviado com sucesso!',
+            );
+          } else if (state is LoginForgotPasswordFailure) {
+            AppNotification.showError(context, state.message);
           }
         },
-        child: Scaffold(
-          backgroundColor: AppColors.white,
+        child: Builder(
+          builder: (context) => Scaffold(
+            backgroundColor: AppColors.white,
           body: SafeArea(
             child: SingleChildScrollView(
               padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -53,7 +66,10 @@ class LoginPage extends StatelessWidget {
                       const Spacer(flex: 3),
                       const RagroLogo(),
                       const Spacer(flex: 1),
-                      LoginForm(onRegisterTap: () => context.push('/register')),
+                      LoginForm(
+                        onRegisterTap: () => context.push('/register'),
+                        onForgotPasswordTap: () => _showForgotPasswordModal(context),
+                      ),
                       const Spacer(),
                     ],
                   ),
@@ -61,8 +77,108 @@ class LoginPage extends StatelessWidget {
               ),
             ),
           ),
+          ),
         ),
       ),
+    );
+  }
+
+  void _showForgotPasswordModal(BuildContext context) {
+    final emailController = TextEditingController();
+    final formKey = GlobalKey<FormState>();
+    final loginBloc = context.read<LoginBloc>();
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) {
+        return BlocProvider.value(
+          value: loginBloc,
+          child: BlocListener<LoginBloc, LoginState>(
+            listener: (context, state) {
+              if (state is LoginForgotPasswordSuccess) {
+                Navigator.pop(context); // Close modal on success
+              }
+            },
+            child: Padding(
+              padding: EdgeInsets.only(
+                bottom: MediaQuery.of(context).viewInsets.bottom,
+              ),
+              child: Container(
+                padding: const EdgeInsets.all(24),
+                decoration: const BoxDecoration(
+                  color: AppColors.white,
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+                ),
+                child: Form(
+                  key: formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            'Recuperar Senha',
+                            style: AppTextStyles.title2.copyWith(
+                              color: AppColors.darkGreen,
+                            ),
+                          ),
+                          IconButton(
+                            onPressed: () => Navigator.pop(context),
+                            icon: const Icon(Icons.close),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Informe seu e-mail cadastrado e enviaremos um link para você definir uma nova senha.',
+                        style: AppTextStyles.body.copyWith(
+                          color: AppColors.black.withOpacity(0.7),
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      AuthTextField(
+                        label: 'E-mail',
+                        icon: Icons.email_outlined,
+                        controller: emailController,
+                        keyboardType: TextInputType.emailAddress,
+                        validator: (v) {
+                          if (v == null || v.isEmpty) return 'E-mail obrigatório';
+                          final emailRegex =
+                              RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+                          if (!emailRegex.hasMatch(v)) return 'E-mail inválido';
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 24),
+                      BlocBuilder<LoginBloc, LoginState>(
+                        builder: (context, state) {
+                          return AuthSubmitButton(
+                            label: 'Enviar link',
+                            isLoading: state is LoginForgotPasswordInProgress,
+                            onPressed: () {
+                              if (formKey.currentState?.validate() ?? false) {
+                                loginBloc.add(
+                                  LoginForgotPasswordRequested(
+                                    emailController.text.trim(),
+                                  ),
+                                );
+                              }
+                            },
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/auth/presentation/widgets/login_form.dart
+++ b/lib/features/auth/presentation/widgets/login_form.dart
@@ -93,13 +93,14 @@ class _LoginFormState extends State<LoginForm> {
           if (widget.onForgotPasswordTap != null) ...[
             const SizedBox(height: 12),
             Align(
-              alignment: Alignment.centerRight,
+              alignment: Alignment.centerLeft,
               child: GestureDetector(
                 onTap: widget.onForgotPasswordTap,
                 child: Text(
                   'Esqueceu sua senha?',
                   style: AppTextStyles.caption.copyWith(
                     color: AppColors.darkGreen,
+                    fontWeight: FontWeight.w700,
                   ),
                 ),
               ),
@@ -110,7 +111,8 @@ class _LoginFormState extends State<LoginForm> {
             builder: (context, state) {
               return AuthSubmitButton(
                 label: 'Entrar',
-                isLoading: state is LoginLoading,
+                isLoading: state is LoginLoading ||
+                    state is LoginForgotPasswordInProgress,
                 onPressed: _submit,
               );
             },

--- a/lib/features/customer_profile/presentation/pages/customer_profile_page.dart
+++ b/lib/features/customer_profile/presentation/pages/customer_profile_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_event.dart';
+import 'package:ragro_mobile/features/auth/presentation/bloc/auth_state.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_bloc.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_state.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/widgets/profile_info_row.dart';
@@ -23,17 +24,43 @@ class _CustomerProfileView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<CustomerProfileBloc, CustomerProfileState>(
-      listener: (context, state) {
-        if (state is CustomerProfileFailure) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(state.message),
-              backgroundColor: AppColors.red,
-            ),
-          );
-        }
-      },
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<CustomerProfileBloc, CustomerProfileState>(
+          listener: (context, state) {
+            if (state is CustomerProfileFailure) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(state.message),
+                  backgroundColor: AppColors.red,
+                ),
+              );
+            }
+          },
+        ),
+        BlocListener<AuthBloc, AuthState>(
+          listener: (context, state) {
+            if (state is AuthPasswordResetSuccess) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text(
+                    'Enviamos um e-mail para você com as instruções para definir sua nova senha. Verifique sua caixa de entrada.',
+                  ),
+                  backgroundColor: AppColors.lightGreen,
+                  duration: Duration(seconds: 5),
+                ),
+              );
+            } else if (state is AuthPasswordResetFailure) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Erro: ${state.message}'),
+                  backgroundColor: AppColors.red,
+                ),
+              );
+            }
+          },
+        ),
+      ],
       child: Scaffold(
         backgroundColor: AppColors.white,
         body: SafeArea(
@@ -130,6 +157,28 @@ class _CustomerProfileView extends StatelessWidget {
                       icon: Icons.edit_outlined,
                       label: 'Editar perfil',
                       onTap: () => context.push('/customer/profile/edit'),
+                    ),
+                    const SizedBox(height: 16),
+                    BlocBuilder<AuthBloc, AuthState>(
+                      builder: (context, authState) {
+                        final isLoading =
+                            authState is AuthPasswordResetInProgress;
+                        return ProfileMenuItem(
+                          icon:
+                              isLoading
+                                  ? Icons.hourglass_empty
+                                  : Icons.lock_outline,
+                          label: isLoading ? 'Solicitando...' : 'Alterar senha',
+                          onTap:
+                              isLoading
+                                  ? null
+                                  : () {
+                                    context.read<AuthBloc>().add(
+                                      const AuthPasswordResetRequested(),
+                                    );
+                                  },
+                        );
+                      },
                     ),
                     const SizedBox(height: 16),
                     ProfileMenuItem(

--- a/lib/features/customer_profile/presentation/pages/customer_profile_page.dart
+++ b/lib/features/customer_profile/presentation/pages/customer_profile_page.dart
@@ -9,6 +9,7 @@ import 'package:ragro_mobile/features/customer_profile/presentation/bloc/custome
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_state.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/widgets/profile_info_row.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/widgets/profile_menu_item.dart';
+import 'package:ragro_mobile/shared/widgets/app_notification.dart';
 
 class CustomerProfilePage extends StatelessWidget {
   const CustomerProfilePage({super.key});
@@ -41,22 +42,12 @@ class _CustomerProfileView extends StatelessWidget {
         BlocListener<AuthBloc, AuthState>(
           listener: (context, state) {
             if (state is AuthPasswordResetSuccess) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text(
-                    'Enviamos um e-mail para você com as instruções para definir sua nova senha. Verifique sua caixa de entrada.',
-                  ),
-                  backgroundColor: AppColors.lightGreen,
-                  duration: Duration(seconds: 5),
-                ),
+              AppNotification.showSuccess(
+                context,
+                'Enviamos um e-mail para você com as instruções para definir sua nova senha. Verifique sua caixa de entrada.',
               );
             } else if (state is AuthPasswordResetFailure) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('Erro: ${state.message}'),
-                  backgroundColor: AppColors.red,
-                ),
-              );
+              AppNotification.showError(context, 'Erro: ${state.message}');
             }
           },
         ),

--- a/lib/features/customer_profile/presentation/widgets/profile_menu_item.dart
+++ b/lib/features/customer_profile/presentation/widgets/profile_menu_item.dart
@@ -5,7 +5,7 @@ class ProfileMenuItem extends StatelessWidget {
   const ProfileMenuItem({
     required this.icon,
     required this.label,
-    required this.onTap,
+    this.onTap,
     this.iconBackgroundColor,
     this.iconColor,
     this.labelColor,
@@ -16,7 +16,7 @@ class ProfileMenuItem extends StatelessWidget {
 
   final IconData icon;
   final String label;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final Color? iconBackgroundColor;
   final Color? iconColor;
   final Color? labelColor;

--- a/lib/features/producer_management/presentation/pages/producer_settings_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_settings_page.dart
@@ -10,6 +10,7 @@ import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_state.dart';
+import 'package:ragro_mobile/shared/widgets/app_notification.dart';
 
 class ProducerSettingsPage extends StatelessWidget {
   const ProducerSettingsPage({super.key});
@@ -19,22 +20,12 @@ class ProducerSettingsPage extends StatelessWidget {
     return BlocListener<AuthBloc, AuthState>(
       listener: (context, state) {
         if (state is AuthPasswordResetSuccess) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text(
-                'Enviamos um e-mail para você com as instruções para definir sua nova senha. Verifique sua caixa de entrada.',
-              ),
-              backgroundColor: AppColors.lightGreen,
-              duration: Duration(seconds: 5),
-            ),
+          AppNotification.showSuccess(
+            context,
+            'Enviamos um e-mail para você com as instruções para definir sua nova senha. Verifique sua caixa de entrada.',
           );
         } else if (state is AuthPasswordResetFailure) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('Erro: ${state.message}'),
-              backgroundColor: AppColors.red,
-            ),
-          );
+          AppNotification.showError(context, 'Erro: ${state.message}');
         }
       },
       child: Scaffold(

--- a/lib/features/producer_management/presentation/pages/producer_settings_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_settings_page.dart
@@ -4,103 +4,140 @@
 // Routes: (settings page, no dedicated API route)
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
-import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_event.dart';
+import 'package:ragro_mobile/features/auth/presentation/bloc/auth_state.dart';
 
 class ProducerSettingsPage extends StatelessWidget {
   const ProducerSettingsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFFF6F7F6),
-      appBar: AppBar(
-        backgroundColor: AppColors.white,
-        elevation: 0,
-        leading: GestureDetector(
-          onTap: () => context.pop(),
-          child: const Icon(Icons.arrow_back, color: AppColors.black),
-        ),
-        title: const Text(
-          'Perfil do Produtor',
-          style: TextStyle(
-            fontFamily: 'Figtree',
-            fontWeight: FontWeight.w700,
-            fontSize: 18,
-            color: AppColors.black,
-          ),
-        ),
-        centerTitle: true,
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(1),
-          child: Container(color: const Color(0x1A2E5729), height: 1),
-        ),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
-        child: Container(
-          decoration: BoxDecoration(
-            color: AppColors.white,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: const Color(0xFFE2E8F0)),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              // Alterar senha
-              ListTile(
-                onTap: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Alteração de senha em breve'),
-                    ),
-                  );
-                },
-                leading: const Icon(
-                  Icons.edit_outlined,
-                  color: AppColors.black,
-                  size: 20,
-                ),
-                title: const Text(
-                  'Alterar senha',
-                  style: TextStyle(
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w500,
-                    fontSize: 16,
-                    color: AppColors.black,
-                  ),
-                ),
-                trailing: const Icon(
-                  Icons.chevron_right,
-                  color: AppColors.placeholder,
-                  size: 20,
-                ),
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthPasswordResetSuccess) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                'Enviamos um e-mail para você com as instruções para definir sua nova senha. Verifique sua caixa de entrada.',
               ),
-              const Divider(height: 1, color: Color(0xFFE2E8F0)),
-              // Sair
-              ListTile(
-                onTap: () {
-                  getIt<AuthBloc>().add(const AuthLogoutRequested());
-                },
-                leading: const Icon(
-                  Icons.close,
-                  color: AppColors.red,
-                  size: 20,
+              backgroundColor: AppColors.lightGreen,
+              duration: Duration(seconds: 5),
+            ),
+          );
+        } else if (state is AuthPasswordResetFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Erro: ${state.message}'),
+              backgroundColor: AppColors.red,
+            ),
+          );
+        }
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF6F7F6),
+        appBar: AppBar(
+          backgroundColor: AppColors.white,
+          elevation: 0,
+          leading: GestureDetector(
+            onTap: () => context.pop(),
+            child: const Icon(Icons.arrow_back, color: AppColors.black),
+          ),
+          title: const Text(
+            'Perfil do Produtor',
+            style: TextStyle(
+              fontFamily: 'Figtree',
+              fontWeight: FontWeight.w700,
+              fontSize: 18,
+              color: AppColors.black,
+            ),
+          ),
+          centerTitle: true,
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(1),
+            child: Container(color: const Color(0x1A2E5729), height: 1),
+          ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
+          child: Container(
+            decoration: BoxDecoration(
+              color: AppColors.white,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: const Color(0xFFE2E8F0)),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Alterar senha
+                BlocBuilder<AuthBloc, AuthState>(
+                  builder: (context, state) {
+                    final isLoading = state is AuthPasswordResetInProgress;
+                    return ListTile(
+                      onTap: isLoading
+                          ? null
+                          : () {
+                              context.read<AuthBloc>().add(
+                                const AuthPasswordResetRequested(),
+                              );
+                            },
+                      leading: isLoading
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: AppColors.darkGreen,
+                              ),
+                            )
+                          : const Icon(
+                              Icons.edit_outlined,
+                              color: AppColors.black,
+                              size: 20,
+                            ),
+                      title: const Text(
+                        'Alterar senha',
+                        style: TextStyle(
+                          fontFamily: 'Figtree',
+                          fontWeight: FontWeight.w500,
+                          fontSize: 16,
+                          color: AppColors.black,
+                        ),
+                      ),
+                      trailing: const Icon(
+                        Icons.chevron_right,
+                        color: AppColors.placeholder,
+                        size: 20,
+                      ),
+                    );
+                  },
                 ),
-                title: const Text(
-                  'Sair',
-                  style: TextStyle(
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w500,
-                    fontSize: 16,
+                const Divider(height: 1, color: Color(0xFFE2E8F0)),
+                // Sair
+                ListTile(
+                  onTap: () {
+                    context.read<AuthBloc>().add(const AuthLogoutRequested());
+                  },
+                  leading: const Icon(
+                    Icons.close,
                     color: AppColors.red,
+                    size: 20,
+                  ),
+                  title: const Text(
+                    'Sair',
+                    style: TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w500,
+                      fontSize: 16,
+                      color: AppColors.red,
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/producer_profile/data/models/public_producer_model.dart
+++ b/lib/features/producer_profile/data/models/public_producer_model.dart
@@ -1,4 +1,3 @@
-import 'package:ragro_mobile/features/home/data/models/home_product_model.dart';
 import 'package:ragro_mobile/features/producer_profile/domain/entities/public_producer.dart';
 
 class PublicProducerModel extends PublicProducer {

--- a/lib/shared/widgets/app_notification.dart
+++ b/lib/shared/widgets/app_notification.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:ragro_mobile/core/theme/app_colors.dart';
+
+class AppNotification {
+  static void showSuccess(BuildContext context, String message) {
+    _show(context, message, isError: false);
+  }
+
+  static void showError(BuildContext context, String message) {
+    _show(context, message, isError: true);
+  }
+
+  static void _show(
+    BuildContext context,
+    String message, {
+    required bool isError,
+  }) {
+    final overlay = Overlay.of(context);
+    late OverlayEntry entry;
+
+    entry = OverlayEntry(
+      builder:
+          (context) => _NotificationWidget(
+            message: message,
+            isError: isError,
+            onDismiss: () {
+              entry.remove();
+            },
+          ),
+    );
+
+    overlay.insert(entry);
+  }
+}
+
+class _NotificationWidget extends StatefulWidget {
+  const _NotificationWidget({
+    required this.message,
+    required this.isError,
+    required this.onDismiss,
+  });
+
+  final String message;
+  final bool isError;
+  final VoidCallback onDismiss;
+
+  @override
+  State<_NotificationWidget> createState() => _NotificationWidgetState();
+}
+
+class _NotificationWidgetState extends State<_NotificationWidget>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<Offset> _offsetAnimation;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+
+    _offsetAnimation = Tween<Offset>(
+      begin: const Offset(0, -1.5),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutBack));
+
+    _controller.forward();
+
+    _timer = Timer(const Duration(seconds: 4), () {
+      _hide();
+    });
+  }
+
+  void _hide() async {
+    if (!mounted) return;
+    await _controller.reverse();
+    widget.onDismiss();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final safeAreaTop = MediaQuery.of(context).padding.top;
+
+    return Positioned(
+      top: safeAreaTop + 10,
+      left: 16,
+      right: 16,
+      child: SlideTransition(
+        position: _offsetAnimation,
+        child: Material(
+          color: Colors.transparent,
+          child: GestureDetector(
+            onVerticalDragUpdate: (details) {
+              if (details.primaryDelta! < -10) {
+                _hide();
+              }
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: widget.isError ? AppColors.red : AppColors.darkGreen,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.15),
+                    blurRadius: 10,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    widget.isError ? Icons.error_outline : Icons.check_circle_outline,
+                    color: Colors.white,
+                    size: 24,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          widget.isError ? 'Ops!' : 'Sucesso',
+                          style: const TextStyle(
+                            fontFamily: 'Figtree',
+                            fontWeight: FontWeight.w800,
+                            fontSize: 14,
+                            color: Colors.white,
+                          ),
+                        ),
+                        Text(
+                          widget.message,
+                          style: const TextStyle(
+                            fontFamily: 'Manrope',
+                            fontWeight: FontWeight.w500,
+                            fontSize: 13,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/auth/presentation/bloc/auth_bloc_test.dart
+++ b/test/features/auth/presentation/bloc/auth_bloc_test.dart
@@ -5,6 +5,7 @@ import 'package:ragro_mobile/features/auth/domain/entities/user.dart';
 import 'package:ragro_mobile/features/auth/domain/entities/user_type.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/get_current_user.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/logout.dart';
+import 'package:ragro_mobile/features/auth/domain/usecases/request_password_reset.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_state.dart';
@@ -13,15 +14,19 @@ class MockGetCurrentUser extends Mock implements GetCurrentUser {}
 
 class MockLogout extends Mock implements Logout {}
 
+class MockRequestPasswordReset extends Mock implements RequestPasswordReset {}
+
 void main() {
   late AuthBloc bloc;
   late MockGetCurrentUser mockGetCurrentUser;
   late MockLogout mockLogout;
+  late MockRequestPasswordReset mockRequestPasswordReset;
 
   setUp(() {
     mockGetCurrentUser = MockGetCurrentUser();
     mockLogout = MockLogout();
-    bloc = AuthBloc(mockGetCurrentUser, mockLogout);
+    mockRequestPasswordReset = MockRequestPasswordReset();
+    bloc = AuthBloc(mockGetCurrentUser, mockLogout, mockRequestPasswordReset);
   });
 
   tearDown(() => bloc.close());
@@ -63,5 +68,37 @@ void main() {
     seed: () => const AuthAuthenticated(tUser),
     act: (b) => b.add(const AuthLogoutRequested()),
     expect: () => [const AuthUnauthenticated()],
+  );
+
+  blocTest<AuthBloc, AuthState>(
+    'emits [InProgress, Success] when password reset succeeds',
+    build: () {
+      when(() => mockRequestPasswordReset()).thenAnswer((_) async {});
+      return bloc;
+    },
+    seed: () => const AuthAuthenticated(tUser),
+    act: (b) => b.add(const AuthPasswordResetRequested()),
+    expect:
+        () => [
+          const AuthPasswordResetInProgress(tUser),
+          const AuthPasswordResetSuccess(tUser),
+        ],
+  );
+
+  blocTest<AuthBloc, AuthState>(
+    'emits [InProgress, Failure] when password reset fails',
+    build: () {
+      when(
+        () => mockRequestPasswordReset(),
+      ).thenThrow(Exception('Erro ao enviar e-mail'));
+      return bloc;
+    },
+    seed: () => const AuthAuthenticated(tUser),
+    act: (b) => b.add(const AuthPasswordResetRequested()),
+    expect:
+        () => [
+          const AuthPasswordResetInProgress(tUser),
+          const AuthPasswordResetFailure(tUser, 'Exception: Erro ao enviar e-mail'),
+        ],
   );
 }

--- a/test/features/auth/presentation/bloc/login_bloc_test.dart
+++ b/test/features/auth/presentation/bloc/login_bloc_test.dart
@@ -4,6 +4,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/auth/domain/entities/user.dart';
 import 'package:ragro_mobile/features/auth/domain/entities/user_type.dart';
+import 'package:ragro_mobile/features/auth/domain/usecases/forgot_password.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/login_user.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_bloc.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_event.dart';
@@ -11,13 +12,17 @@ import 'package:ragro_mobile/features/auth/presentation/bloc/login_state.dart';
 
 class MockLoginUser extends Mock implements LoginUser {}
 
+class MockForgotPassword extends Mock implements ForgotPassword {}
+
 void main() {
   late LoginBloc bloc;
   late MockLoginUser mockLoginUser;
+  late MockForgotPassword mockForgotPassword;
 
   setUp(() {
     mockLoginUser = MockLoginUser();
-    bloc = LoginBloc(mockLoginUser);
+    mockForgotPassword = MockForgotPassword();
+    bloc = LoginBloc(mockLoginUser, mockForgotPassword);
   });
 
   tearDown(() => bloc.close());
@@ -63,4 +68,33 @@ void main() {
       const LoginFailure('Credenciais inválidas'),
     ],
   );
+
+  group('ForgotPassword', () {
+    blocTest<LoginBloc, LoginState>(
+      'emits [InProgress, Success] when forgot password succeeds',
+      build: () {
+        when(() => mockForgotPassword(any())).thenAnswer((_) async {});
+        return bloc;
+      },
+      act: (b) => b.add(const LoginForgotPasswordRequested('test@test.com')),
+      expect: () => [
+        const LoginForgotPasswordInProgress(),
+        const LoginForgotPasswordSuccess(),
+      ],
+    );
+
+    blocTest<LoginBloc, LoginState>(
+      'emits [InProgress, Failure] when forgot password fails',
+      build: () {
+        when(() => mockForgotPassword(any()))
+            .thenThrow(const UnknownApiException('Error'));
+        return bloc;
+      },
+      act: (b) => b.add(const LoginForgotPasswordRequested('test@test.com')),
+      expect: () => [
+        const LoginForgotPasswordInProgress(),
+        const LoginForgotPasswordFailure('Error'),
+      ],
+    );
+  });
 }


### PR DESCRIPTION
## O que mudou?
- **Fluxo de Recuperação de Senha**: Implementada a integração completa com o backend para disparar e-mails de redefinição de senha via Keycloak.
- **Novo Modal "Esqueci minha senha"**: Adicionado um `BottomSheet` na tela de login para captura de e-mail de usuários não autenticados.
- **Notificações Premium**: Criado o componente `AppNotification` que desliza do topo da tela (estilo nativo iOS/Android) para feedbacks de sucesso e erro no fluxo de senha.
- **Ajustes de UI**: O link "Esqueceu sua senha?" foi movido para a **esquerda** e o componente de formulário foi atualizado.
- **Sincronização com Backend**: Atualizadas as constantes de rede (`ApiEndpoints`) para refletir as mudanças nas rotas de autenticação (`/auth/password/reset` e `/auth/password/forgot`).
- **Correção de Testes e Lints**: Atualizados os testes unitários do `LoginBloc` e resolvidos avisos de análise do Dart.

## Tipo de mudança

- [x] Nova feature
- [x] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [x] Chore (dependências, configs, etc.)

## Como testar?
1. **Recuperação Logado**: Vá ao Perfil (Consumidor ou Produtor) e clique em "Alterar Senha". Verifique se a notificação surge no topo e se o e-mail chega na caixa de entrada.
2. **Esqueci minha Senha (Login)**: Na tela de login, clique em "Esqueceu sua senha?". Informe um e-mail válido no modal que abrirá e confirme. Verifique o feedback visual e o recebimento do e-mail.
3. **Casos de Erro**: Tente enviar o modal de recuperação com o campo de e-mail vazio ou inválido e verifique as validações.

## Screenshots / Gravações

Modal esqueci a senha:
<img width="500" height="993" alt="image" src="https://github.com/user-attachments/assets/7d5df815-fc39-4cb3-963b-9af3119a1c77" />
Notificação estilo celular no topo da tela (tanto para alterar senha quanto para resetar):
<img width="501" height="100" alt="image" src="https://github.com/user-attachments/assets/21afa96e-6d8c-4cc0-9a6c-0decc580e007" />


## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
