### PR TITLE
feat(inventory): add currency input mask to product price field

### DIFF
--- a/lib/core/formatters/input_masks.dart
+++ b/lib/core/formatters/input_masks.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 
 // Máscaras dinâmicas para campos de entrada. Aplicadas via `inputFormatters`
 // para autoformatar enquanto o usuário digita, mantendo apenas dígitos no
@@ -163,5 +164,40 @@ class BankAccountInputFormatter extends TextInputFormatter {
   String _formatAccount(String digits) {
     if (digits.length <= 1) return digits;
     return '${digits.substring(0, digits.length - 1)}-${digits.substring(digits.length - 1)}';
+  }
+}
+
+class CurrencyInputFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    if (newValue.text.isEmpty) {
+      return newValue.copyWith(text: '');
+    }
+
+    String digitsOnly = newValue.text.replaceAll(RegExp(r'[^\d]'), '');
+    if (digitsOnly.isEmpty) {
+      return const TextEditingValue(
+        text: '0,00',
+        selection: TextSelection.collapsed(offset: 4),
+      );
+    }
+
+    double value = double.parse(digitsOnly) / 100;
+    
+    final format = NumberFormat.currency(
+      locale: 'pt_BR',
+      symbol: '',
+      decimalDigits: 2,
+    );
+    
+    String formatted = format.format(value).trim();
+    
+    return TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
+    );
   }
 }

--- a/lib/features/inventory/presentation/pages/product_form_page.dart
+++ b/lib/features/inventory/presentation/pages/product_form_page.dart
@@ -4,9 +4,12 @@
 // Routes: POST /products | PUT /products/:id
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/core/formatters/input_masks.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/inventory/presentation/bloc/product_form_bloc.dart';
 import 'package:ragro_mobile/features/inventory/presentation/bloc/product_form_event.dart';
@@ -60,7 +63,12 @@ class _ProductFormViewState extends State<_ProductFormView> {
     if (state.product != null) {
       _nameController.text = state.product!.name;
       _descriptionController.text = state.product!.description;
-      _priceController.text = state.product!.price.toStringAsFixed(2);
+      final format = NumberFormat.currency(
+        locale: 'pt_BR',
+        symbol: '',
+        decimalDigits: 2,
+      );
+      _priceController.text = format.format(state.product!.price).trim();
       _selectedUnit = state.product!.unit;
       _stockCount = state.product!.stock;
     }
@@ -69,7 +77,10 @@ class _ProductFormViewState extends State<_ProductFormView> {
   void _submit() {
     final name = _nameController.text.trim();
     final description = _descriptionController.text.trim();
-    final priceText = _priceController.text.trim().replaceAll(',', '.');
+    final priceText = _priceController.text
+        .trim()
+        .replaceAll('.', '')
+        .replaceAll(',', '.');
     if (name.isEmpty || priceText.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -247,6 +258,7 @@ class _ProductFormViewState extends State<_ProductFormView> {
                               decimal: true,
                             ),
                             enabled: !isLoading,
+                            inputFormatters: [CurrencyInputFormatter()],
                           ),
                         ],
                       ),
@@ -385,6 +397,7 @@ class _TextField extends StatelessWidget {
     this.maxLines = 1,
     this.keyboardType = TextInputType.text,
     this.enabled = true,
+    this.inputFormatters,
   });
 
   final TextEditingController controller;
@@ -392,6 +405,7 @@ class _TextField extends StatelessWidget {
   final int maxLines;
   final TextInputType keyboardType;
   final bool enabled;
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   Widget build(BuildContext context) {
@@ -400,6 +414,7 @@ class _TextField extends StatelessWidget {
       maxLines: maxLines,
       keyboardType: keyboardType,
       enabled: enabled,
+      inputFormatters: inputFormatters,
       decoration: InputDecoration(
         hintText: hint,
         hintStyle: const TextStyle(


### PR DESCRIPTION
## O que mudou?
- Criação do `CurrencyInputFormatter` em `input_masks.dart` usando a biblioteca `intl` para formatação de moeda automática em Reais (pt_BR).
- Aplicação da nova máscara no campo de "Preço" na `product_form_page.dart`.
- Ajuste na lógica de conversão (`_initFromProduct` e `_submit`) da página de formulário do produto para exibir os valores recuperados no formato de tela, além de remover a máscara antes de salvar como `double`.

## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?
1. Faça login no app com uma conta de Produtor.
2. Acesse a tela de criar um "Novo Produto" ou de "Editar Produto".
3. Digite números no campo numérico de "Preço (R$)".
4. Verifique se o valor é formatado adequadamente enquanto digita (ex: `1.234,50`).
5. Salve o produto e certifique-se de que o preço foi registrado e salvo corretamente no sistema e é recarregado sem erros na edição.

## Screenshots / Gravações

<img width="499" height="816" alt="image" src="https://github.com/user-attachments/assets/ad1100af-d51f-47fc-a768-bb44a71aee8b" />

<img width="495" height="798" alt="image" src="https://github.com/user-attachments/assets/e89db761-1195-4945-9f03-7e838d9b4101" />


## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
