### PR TITLE
feat(customer): make neighborhood and complement mandatory in registration 

### DIFF
--- a/lib/features/auth/presentation/pages/customer_register_page.dart
+++ b/lib/features/auth/presentation/pages/customer_register_page.dart
@@ -130,12 +130,8 @@ class _CustomerRegisterViewState extends State<_CustomerRegisterView> {
         number: _numberController.text.trim(),
         city: _cityController.text.trim(),
         state: _selectedState!,
-        complement: _complementController.text.trim().isEmpty
-            ? null
-            : _complementController.text.trim(),
-        neighborhood: _neighborhoodController.text.trim().isEmpty
-            ? null
-            : _neighborhoodController.text.trim(),
+        complement: _complementController.text.trim(),
+        neighborhood: _neighborhoodController.text.trim(),
       ),
     );
   }
@@ -301,15 +297,27 @@ class _CustomerRegisterViewState extends State<_CustomerRegisterView> {
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
-                  label: 'Complemento (opcional)',
+                  label: 'Complemento',
                   icon: Icons.apartment_outlined,
                   controller: _complementController,
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) {
+                      return 'Informe o complemento';
+                    }
+                    return null;
+                  },
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
-                  label: 'Bairro (opcional)',
+                  label: 'Bairro',
                   icon: Icons.signpost_outlined,
                   controller: _neighborhoodController,
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) {
+                      return 'Informe o bairro';
+                    }
+                    return null;
+                  },
                 ),
                 const SizedBox(height: 16),
                 Row(

--- a/lib/features/customer_profile/presentation/pages/customer_edit_profile_page.dart
+++ b/lib/features/customer_profile/presentation/pages/customer_edit_profile_page.dart
@@ -203,6 +203,7 @@ class _CustomerEditProfilePageState extends State<CustomerEditProfilePage> {
                           controller: _complementController,
                           icon: Icons.apartment_outlined,
                           hint: 'Apto 42',
+                          validator: _requiredValidator,
                         ),
                         const SizedBox(height: 24),
                         _buildField(
@@ -210,6 +211,7 @@ class _CustomerEditProfilePageState extends State<CustomerEditProfilePage> {
                           controller: _neighborhoodController,
                           icon: Icons.location_city_outlined,
                           hint: 'Centro',
+                          validator: _requiredValidator,
                         ),
                         const SizedBox(height: 24),
                         _buildField(
@@ -423,12 +425,8 @@ class _CustomerEditProfilePageState extends State<CustomerEditProfilePage> {
         city: _cityController.text.trim(),
         state: _stateController.text.trim().toUpperCase(),
         zipCode: _zipCodeController.text.trim(),
-        complement: _complementController.text.trim().isEmpty
-            ? null
-            : _complementController.text.trim(),
-        neighborhood: _neighborhoodController.text.trim().isEmpty
-            ? null
-            : _neighborhoodController.text.trim(),
+        complement: _complementController.text.trim(),
+        neighborhood: _neighborhoodController.text.trim(),
       ),
     );
   }


### PR DESCRIPTION
## O que mudou?
- Os campos de **Bairro** e **Complemento** agora são obrigatórios tanto no cadastro de novos consumidores quanto na edição de perfil.
- Adicionadas validações de formulário para garantir que esses campos não sejam enviados vazios.
- Removida a indicação de `(opcional)` nos rótulos desses campos para clareza do usuário.

## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?
1. Acesse a tela de **Cadastro de Consumidor**.
2. Tente criar uma conta deixando o campo de "Bairro" ou "Complemento" vazio e verifique se a validação impede o envio.
3. Repita o processo na tela de **Editar Perfil** do consumidor.
4. Verifique se, após preencher todos os campos corretamente, os dados são salvos com sucesso.

## Screenshots / Gravações

Cadastrar novo:
<img width="498" height="370" alt="WhatsApp Image 2026-05-03 at 11 09 44 PM" src="https://github.com/user-attachments/assets/3e2e12db-7a34-4af2-9f3e-9489f58bb659" />
<img width="501" height="382" alt="WhatsApp Image 2026-05-03 at 11 10 04 PM" src="https://github.com/user-attachments/assets/b26ddbba-0443-471a-bc1c-62f3dca38349" />
Editar perfil sem opcional:
<img width="501" height="227" alt="WhatsApp Image 2026-05-03 at 11 10 41 PM" src="https://github.com/user-attachments/assets/fb323779-8ce2-4399-82ae-94cd7a9234d7" />



## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
