### PR TITLE
fix(search): move search icon inside the input field for better alig

### DIFF
--- a/lib/features/search/presentation/pages/search_page.dart
+++ b/lib/features/search/presentation/pages/search_page.dart
@@ -88,7 +88,6 @@ class _SearchViewState extends State<_SearchView> {
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
                 child: Container(
-                  height: 56,
                   decoration: BoxDecoration(
                     color: const Color(0xFFF1F5F9),
                     borderRadius: BorderRadius.circular(24),
@@ -100,36 +99,31 @@ class _SearchViewState extends State<_SearchView> {
                       ),
                     ],
                   ),
-                  child: Row(
-                    children: [
-                      const SizedBox(width: 16),
-                      const Icon(
+                  child: TextField(
+                    controller: _controller,
+                    textInputAction: TextInputAction.search,
+                    onSubmitted: (q) => _goToResults(context, q),
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontSize: 16,
+                      color: AppColors.black,
+                    ),
+                    decoration: const InputDecoration(
+                      hintText: 'O que você procura hoje?',
+                      hintStyle: TextStyle(
+                        color: Color(0xFF64748B),
+                        fontSize: 16,
+                      ),
+                      prefixIcon: Icon(
                         Icons.search,
                         color: AppColors.placeholder,
                         size: 20,
                       ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: TextField(
-                          controller: _controller,
-                          textInputAction: TextInputAction.search,
-                          onSubmitted: (q) => _goToResults(context, q),
-                          style: const TextStyle(
-                            fontFamily: 'Figtree',
-                            fontSize: 16,
-                            color: AppColors.black,
-                          ),
-                          decoration: const InputDecoration(
-                            hintText: 'O que você procura hoje?',
-                            hintStyle: TextStyle(
-                              color: Color(0xFF64748B),
-                              fontSize: 16,
-                            ),
-                            border: InputBorder.none,
-                          ),
-                        ),
+                      border: InputBorder.none,
+                      contentPadding: EdgeInsets.symmetric(
+                        vertical: 18,
                       ),
-                    ],
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## O que mudou?
- Refatorada a barra de pesquisa na tela de busca para posicionar corretamente o ícone de lupa.
- O ícone foi movido de uma `Row` externa para a propriedade `prefixIcon` do `TextField`, garantindo que ele permaneça dentro dos limites do container arredondado e com o alinhamento correto em qualquer resolução.

## Tipo de mudança

- [ ] Nova feature
- [x] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?
1. Abra o aplicativo e navegue até a tela de **Pesquisa**.
2. Verifique se o ícone de lupa está devidamente posicionado dentro da barra cinza arredondada.
3. Verifique se o texto "O que você procura hoje?" está alinhado corretamente em relação ao ícone.

## Screenshots / Gravações

<img width="503" height="143" alt="image" src="https://github.com/user-attachments/assets/717ccc7c-2803-4dbe-adb9-02bb00784146" />

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
