### PR TITLE
feat(orders): integração completa do fluxo de pedidos com o backend

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -51,7 +51,7 @@ import 'package:ragro_mobile/features/auth/domain/repositories/auth_repository.d
 import 'package:ragro_mobile/features/auth/domain/usecases/forgot_password.dart'
     as _i191;
 import 'package:ragro_mobile/features/auth/domain/usecases/get_current_user.dart'
-    as _i846;
+    as _i847;
 import 'package:ragro_mobile/features/auth/domain/usecases/login_user.dart'
     as _i1047;
 import 'package:ragro_mobile/features/auth/domain/usecases/logout.dart'
@@ -67,7 +67,7 @@ import 'package:ragro_mobile/features/auth/presentation/bloc/login_bloc.dart'
 import 'package:ragro_mobile/features/auth/presentation/bloc/register_bloc.dart'
     as _i192;
 import 'package:ragro_mobile/features/cart/data/datasources/cart_remote_datasource.dart'
-    as _i58;
+    as _i488;
 import 'package:ragro_mobile/features/cart/data/repositories/cart_repository_impl.dart'
     as _i939;
 import 'package:ragro_mobile/features/cart/domain/repositories/cart_repository.dart'
@@ -95,7 +95,7 @@ import 'package:ragro_mobile/features/customer_profile/domain/usecases/get_custo
 import 'package:ragro_mobile/features/customer_profile/domain/usecases/update_customer_profile.dart'
     as _i436;
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_bloc.dart'
-    as _i526;
+    as _i527;
 import 'package:ragro_mobile/features/home/data/datasources/home_remote_datasource.dart'
     as _i904;
 import 'package:ragro_mobile/features/home/data/repositories/home_repository_impl.dart'
@@ -121,7 +121,7 @@ import 'package:ragro_mobile/features/inventory/domain/usecases/delete_inventory
 import 'package:ragro_mobile/features/inventory/domain/usecases/get_inventory_products.dart'
     as _i252;
 import 'package:ragro_mobile/features/inventory/domain/usecases/update_inventory_product.dart'
-    as _i626;
+    as _i627;
 import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_bloc.dart'
     as _i205;
 import 'package:ragro_mobile/features/inventory/presentation/bloc/product_form_bloc.dart'
@@ -142,14 +142,28 @@ import 'package:ragro_mobile/features/orders/data/repositories/orders_repository
     as _i962;
 import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart'
     as _i165;
+import 'package:ragro_mobile/features/orders/domain/usecases/cancel_customer_order.dart'
+    as _i1105;
+import 'package:ragro_mobile/features/orders/domain/usecases/cancel_order.dart'
+    as _i1101;
+import 'package:ragro_mobile/features/orders/domain/usecases/confirm_customer_delivery.dart'
+    as _i1106;
+import 'package:ragro_mobile/features/orders/domain/usecases/confirm_existing_order.dart'
+    as _i1102;
 import 'package:ragro_mobile/features/orders/domain/usecases/confirm_order.dart'
     as _i680;
 import 'package:ragro_mobile/features/orders/domain/usecases/get_order_detail.dart'
     as _i884;
+import 'package:ragro_mobile/features/orders/domain/usecases/get_customer_order_by_id.dart'
+    as _i1107;
 import 'package:ragro_mobile/features/orders/domain/usecases/get_orders.dart'
     as _i52;
 import 'package:ragro_mobile/features/orders/domain/usecases/rate_producer.dart'
     as _i907;
+import 'package:ragro_mobile/features/orders/domain/usecases/repeat_order.dart'
+    as _i1103;
+import 'package:ragro_mobile/features/orders/domain/usecases/update_order_status.dart'
+    as _i1104;
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_bloc.dart'
     as _i463;
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_bloc.dart'
@@ -205,11 +219,11 @@ import 'package:ragro_mobile/features/producer_profile/presentation/bloc/produce
 import 'package:ragro_mobile/features/product_detail/data/datasources/product_detail_remote_datasource.dart'
     as _i127;
 import 'package:ragro_mobile/features/product_detail/data/repositories/product_detail_repository_impl.dart'
-    as _i43;
+    as _i44;
 import 'package:ragro_mobile/features/product_detail/domain/repositories/product_detail_repository.dart'
     as _i818;
 import 'package:ragro_mobile/features/product_detail/domain/usecases/get_product_detail.dart'
-    as _i680;
+    as _i681;
 import 'package:ragro_mobile/features/product_detail/presentation/bloc/product_detail_bloc.dart'
     as _i740;
 import 'package:ragro_mobile/features/search/data/datasources/search_remote_datasource.dart'
@@ -244,17 +258,8 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i368.ProductMockDataSource>(
       () => _i368.ProductMockDataSource(),
     );
-    gh.lazySingleton<_i384.OrdersRemoteDatasource>(
-      () => _i384.OrdersRemoteDatasource(),
-    );
     gh.lazySingleton<_i727.ProducerManagementRemoteDataSource>(
       () => _i727.ProducerManagementRemoteDataSource(),
-    );
-    gh.lazySingleton<_i608.ProducerOrdersRemoteDataSource>(
-      () => _i608.ProducerOrdersRemoteDataSource(),
-    );
-    gh.lazySingleton<_i165.OrdersRepository>(
-      () => _i962.OrdersRepositoryImpl(gh<_i384.OrdersRemoteDatasource>()),
     );
     gh.lazySingleton<_i276.InventoryRepository>(
       () =>
@@ -279,6 +284,21 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i680.ConfirmOrder>(
       () => _i680.ConfirmOrder(gh<_i165.OrdersRepository>()),
     );
+    gh.lazySingleton<_i1101.CancelOrder>(
+      () => _i1101.CancelOrder(gh<_i165.OrdersRepository>()),
+    );
+    gh.lazySingleton<_i1105.CancelCustomerOrder>(
+      () => _i1105.CancelCustomerOrder(gh<_i165.OrdersRepository>()),
+    );
+    gh.lazySingleton<_i1106.ConfirmCustomerDelivery>(
+      () => _i1106.ConfirmCustomerDelivery(gh<_i165.OrdersRepository>()),
+    );
+    gh.lazySingleton<_i1102.ConfirmExistingOrder>(
+      () => _i1102.ConfirmExistingOrder(gh<_i165.OrdersRepository>()),
+    );
+    gh.lazySingleton<_i1107.GetCustomerOrderById>(
+      () => _i1107.GetCustomerOrderById(gh<_i165.OrdersRepository>()),
+    );
     gh.lazySingleton<_i884.GetOrderDetail>(
       () => _i884.GetOrderDetail(gh<_i165.OrdersRepository>()),
     );
@@ -288,12 +308,37 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i907.RateProducer>(
       () => _i907.RateProducer(gh<_i165.OrdersRepository>()),
     );
+    gh.lazySingleton<_i1103.RepeatOrder>(
+      () => _i1103.RepeatOrder(gh<_i165.OrdersRepository>()),
+    );
+    gh.lazySingleton<_i1104.UpdateOrderStatus>(
+      () => _i1104.UpdateOrderStatus(gh<_i165.OrdersRepository>()),
+    );
     gh.lazySingleton<_i873.ApiClient>(() => _i873.ApiClient(gh<_i361.Dio>()));
+    gh.lazySingleton<_i608.ProducerOrdersRemoteDataSource>(
+      () => _i608.ProducerOrdersRemoteDataSource(gh<_i873.ApiClient>()),
+    );
+    gh.lazySingleton<_i384.OrdersRemoteDatasource>(
+      () => _i384.OrdersRemoteDatasource(gh<_i873.ApiClient>()),
+    );
+    gh.lazySingleton<_i165.OrdersRepository>(
+      () => _i962.OrdersRepositoryImpl(gh<_i384.OrdersRemoteDatasource>()),
+    );
+    gh.lazySingleton<_i488.CartRemoteDataSource>(
+      () => _i488.CartRemoteDataSource(gh<_i873.ApiClient>()),
+    );
+    gh.lazySingleton<_i830.CartRepository>(
+      () => _i939.CartRepositoryImpl(gh<_i488.CartRemoteDataSource>()),
+    );
     gh.factory<_i79.LearningBloc>(
       () => _i79.LearningBloc(gh<_i20.GetProducts>()),
     );
     gh.factory<_i591.OrderDetailBloc>(
-      () => _i591.OrderDetailBloc(gh<_i884.GetOrderDetail>()),
+      () => _i591.OrderDetailBloc(
+        gh<_i1107.GetCustomerOrderById>(),
+        gh<_i1105.CancelCustomerOrder>(),
+        gh<_i1106.ConfirmCustomerDelivery>(),
+      ),
     );
     gh.lazySingleton<_i805.GetProducerDashboard>(
       () =>
@@ -303,7 +348,7 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i209.AuthLocalDataSource(gh<_i460.SharedPreferences>()),
     );
     gh.factory<_i463.CheckoutBloc>(
-      () => _i463.CheckoutBloc(gh<_i680.ConfirmOrder>()),
+      () => _i463.CheckoutBloc(gh<_i680.ConfirmOrder>(), gh<_i535.GetCart>()),
     );
     gh.lazySingleton<_i141.ConfirmProducerOrder>(
       () => _i141.ConfirmProducerOrder(gh<_i649.ProducerOrdersRepository>()),
@@ -324,7 +369,12 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i226.OrdersBloc>(() => _i226.OrdersBloc(gh<_i52.GetOrders>()));
     gh.factory<_i1.ProducerOrdersBloc>(
-      () => _i1.ProducerOrdersBloc(gh<_i935.GetProducerOrders>()),
+      () => _i1.ProducerOrdersBloc(
+        gh<_i935.GetProducerOrders>(),
+        gh<_i141.ConfirmProducerOrder>(),
+        gh<_i885.RefuseProducerOrder>(),
+        gh<_i1038.UpdateProducerOrderStatus>(),
+      ),
     );
     gh.factory<_i432.RateProducerBloc>(
       () => _i432.RateProducerBloc(gh<_i907.RateProducer>()),
@@ -338,14 +388,14 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i252.GetInventoryProducts>(
       () => _i252.GetInventoryProducts(gh<_i276.InventoryRepository>()),
     );
-    gh.lazySingleton<_i626.UpdateInventoryProduct>(
-      () => _i626.UpdateInventoryProduct(gh<_i276.InventoryRepository>()),
+    gh.lazySingleton<_i627.UpdateInventoryProduct>(
+      () => _i627.UpdateInventoryProduct(gh<_i276.InventoryRepository>()),
     );
     gh.factory<_i760.ProductFormBloc>(
       () => _i760.ProductFormBloc(
         gh<_i252.GetInventoryProducts>(),
         gh<_i291.CreateInventoryProduct>(),
-        gh<_i626.UpdateInventoryProduct>(),
+        gh<_i627.UpdateInventoryProduct>(),
       ),
     );
     gh.lazySingleton<_i16.AdminRemoteDataSource>(
@@ -353,9 +403,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i201.AuthRemoteDataSource>(
       () => _i201.AuthRemoteDataSource(gh<_i873.ApiClient>()),
-    );
-    gh.lazySingleton<_i58.CartRemoteDataSource>(
-      () => _i58.CartRemoteDataSource(gh<_i873.ApiClient>()),
     );
     gh.lazySingleton<_i666.CustomerProfileRemoteDataSource>(
       () => _i666.CustomerProfileRemoteDataSource(gh<_i873.ApiClient>()),
@@ -384,7 +431,7 @@ extension GetItInjectableX on _i174.GetIt {
       ),
     );
     gh.lazySingleton<_i818.ProductDetailRepository>(
-      () => _i43.ProductDetailRepositoryImpl(
+      () => _i44.ProductDetailRepositoryImpl(
         gh<_i127.ProductDetailRemoteDataSource>(),
       ),
     );
@@ -395,20 +442,17 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i873.ApiClient>(),
       ),
     );
-    gh.lazySingleton<_i830.CartRepository>(
-      () => _i939.CartRepositoryImpl(gh<_i58.CartRemoteDataSource>()),
-    );
     gh.lazySingleton<_i38.SearchRepository>(
       () => _i563.SearchRepositoryImpl(gh<_i987.SearchRemoteDataSource>()),
     );
-    gh.lazySingleton<_i680.GetProductDetail>(
-      () => _i680.GetProductDetail(gh<_i818.ProductDetailRepository>()),
+    gh.lazySingleton<_i681.GetProductDetail>(
+      () => _i681.GetProductDetail(gh<_i818.ProductDetailRepository>()),
     );
     gh.lazySingleton<_i191.ForgotPassword>(
       () => _i191.ForgotPassword(gh<_i43.AuthRepository>()),
     );
-    gh.lazySingleton<_i846.GetCurrentUser>(
-      () => _i846.GetCurrentUser(gh<_i43.AuthRepository>()),
+    gh.lazySingleton<_i847.GetCurrentUser>(
+      () => _i847.GetCurrentUser(gh<_i43.AuthRepository>()),
     );
     gh.lazySingleton<_i1047.LoginUser>(
       () => _i1047.LoginUser(gh<_i43.AuthRepository>()),
@@ -429,7 +473,7 @@ extension GetItInjectableX on _i174.GetIt {
       ),
     );
     gh.factory<_i740.ProductDetailBloc>(
-      () => _i740.ProductDetailBloc(gh<_i680.GetProductDetail>()),
+      () => _i740.ProductDetailBloc(gh<_i681.GetProductDetail>()),
     );
     gh.lazySingleton<_i759.AdminRepository>(
       () => _i780.AdminRepositoryImpl(gh<_i16.AdminRemoteDataSource>()),
@@ -486,7 +530,7 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i475.AuthBloc>(
       () => _i475.AuthBloc(
-        gh<_i846.GetCurrentUser>(),
+        gh<_i847.GetCurrentUser>(),
         gh<_i418.Logout>(),
         gh<_i485.RequestPasswordReset>(),
       ),
@@ -554,8 +598,8 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i992.ClearCart>(),
       ),
     );
-    gh.factory<_i526.CustomerProfileBloc>(
-      () => _i526.CustomerProfileBloc(
+    gh.factory<_i527.CustomerProfileBloc>(
+      () => _i527.CustomerProfileBloc(
         gh<_i626.GetCustomerProfile>(),
         gh<_i436.UpdateCustomerProfile>(),
       ),

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -50,7 +50,17 @@ abstract final class ApiEndpoints {
 
   // Orders
   static String get orders => '$_base/orders';
+  static String get consumerOrders => '$_base/orders/consumer';
   static String order(String id) => '$_base/orders/$id';
+  static String customerOrder(String id) => '$_base/orders/customer/$id';
+  static String customerOrderCancel(String id) =>
+      '$_base/orders/customer/$id/cancel';
+  static String customerOrderConfirmDelivery(String id) =>
+      '$_base/orders/customer/$id/confirm-delivery';
+  static String orderCancel(String id) => '$_base/orders/$id/cancel';
+  static String orderStatus(String id) => '$_base/orders/$id/status';
+  static String orderConfirm(String id) => '$_base/orders/$id/confirm';
+  static String orderRepeat(String id) => '$_base/orders/$id/repeat';
   static String orderRating(String id) => '$_base/orders/$id/rating';
 
   // Customer cart
@@ -68,10 +78,11 @@ abstract final class ApiEndpoints {
 
   // Producer orders
   static String get producerOrders => '$_base/orders/producer';
+  static String producerOrder(String id) => '$_base/orders/producer/$id';
   static String get producerOrdersToday => '$_base/orders/today';
-  static String producerOrderConfirm(String id) => '$_base/orders/$id/confirm';
-  static String producerOrderStatus(String id) => '$_base/orders/$id/status';
-  static String producerOrderCancel(String id) => '$_base/orders/$id/cancel';
+  static String producerOrderConfirm(String id) => orderConfirm(id);
+  static String producerOrderStatus(String id) => orderStatus(id);
+  static String producerOrderCancel(String id) => orderCancel(id);
 
   // Admin
   static String get adminProducers => '$_base/admin/producers';

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -1,23 +1,20 @@
-abstract final class ApiEndpoints {
-  static const String _defaultBase = 'http://localhost:8080';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
 
-  /// `http://10.0.2.2:8080`, device físico `http://<IP_LAN>:8080`).
+abstract final class ApiEndpoints {
+  static String get _defaultBase {
+    if (kIsWeb) return 'http://localhost:8080';
+    if (Platform.isAndroid) return 'http://10.0.2.2:8080';
+    return 'http://localhost:8080';
+  }
+
   static final String _base = _resolveBaseUrl();
 
   static String _resolveBaseUrl() {
-    const rawBase = String.fromEnvironment(
-      'API_BASE_URL',
-      defaultValue: _defaultBase,
-    );
-    final normalized = rawBase.trim().replaceFirst(RegExp(r'\/+$'), '');
-    final uri = Uri.tryParse(normalized);
-    final hasHttpScheme = uri?.scheme == 'http' || uri?.scheme == 'https';
+    const rawBase = String.fromEnvironment('API_BASE_URL');
 
-    if (normalized.isEmpty || normalized == 'http:' || normalized == 'https:') {
-      return _defaultBase;
-    }
-
-    if (hasHttpScheme && (uri?.host.isNotEmpty ?? false)) {
+    if (rawBase.isNotEmpty) {
+      final normalized = rawBase.trim().replaceFirst(RegExp(r'\/+$'), '');
       return normalized;
     }
 

--- a/lib/core/network/api_exception.dart
+++ b/lib/core/network/api_exception.dart
@@ -2,6 +2,8 @@
 sealed class ApiException implements Exception {
   const ApiException(this.message);
   final String message;
+  @override
+  String toString() => message;
 }
 
 class UnauthorizedException extends ApiException {

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -16,6 +16,7 @@ import 'package:ragro_mobile/features/auth/presentation/pages/login_page.dart';
 import 'package:ragro_mobile/features/cart/presentation/pages/cart_page.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_bloc.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_event.dart';
+import 'package:ragro_mobile/features/customer_profile/presentation/pages/customer_edit_address_page.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/pages/customer_edit_profile_page.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/pages/customer_profile_page.dart';
 import 'package:ragro_mobile/features/home/presentation/pages/customer_home_page.dart';
@@ -183,6 +184,10 @@ class AppRouter {
         GoRoute(
           path: '/customer/checkout',
           builder: (_, __) => const OrderConfirmationPage(),
+        ),
+        GoRoute(
+          path: '/customer/edit-address',
+          builder: (_, __) => const CustomerEditAddressPage(),
         ),
 
         // Top-level producer profile (fullscreen) — used from outside the

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -28,6 +28,7 @@ import 'package:ragro_mobile/features/orders/presentation/pages/rate_producer_pa
 import 'package:ragro_mobile/features/producer_management/presentation/pages/producer_edit_profile_page.dart';
 import 'package:ragro_mobile/features/producer_management/presentation/pages/producer_profile_page.dart';
 import 'package:ragro_mobile/features/producer_management/presentation/pages/producer_settings_page.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/pages/producer_order_detail_page.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/pages/producer_orders_page.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/pages/route_calculation_page.dart';
@@ -205,6 +206,7 @@ class AppRouter {
                       path: 'orders/:orderId',
                       builder: (context, state) => ProducerOrderDetailPage(
                         orderId: state.pathParameters['orderId']!,
+                        initialOrder: state.extra as ProducerOrder?,
                       ),
                     ),
                     GoRoute(

--- a/lib/features/cart/data/models/cart_model.dart
+++ b/lib/features/cart/data/models/cart_model.dart
@@ -8,6 +8,10 @@ class CartModel extends Cart {
     required super.farmName,
     required super.items,
     required super.totalAmount,
+    super.bankName,
+    super.bankAgency,
+    super.bankAccount,
+    super.bankPixKey,
   });
 
   const CartModel.empty()
@@ -24,12 +28,26 @@ class CartModel extends Cart {
         .whereType<Map<String, dynamic>>()
         .toList();
 
+    final producer =
+        json['producer'] as Map<String, dynamic>? ??
+        json['farmer'] as Map<String, dynamic>?;
+    final bankJson =
+        json['bankInfo'] as Map<String, dynamic>? ??
+        producer?['bankInfo'] as Map<String, dynamic>? ??
+        const <String, dynamic>{};
+
     return CartModel(
       id: json['id'] as String? ?? '',
-      producerId: json['farmerId'] as String? ?? '',
+      producerId:
+          json['farmerId'] as String? ?? json['producerId'] as String? ?? '',
       farmName: json['farmName'] as String? ?? '',
       items: itemsJson.map(CartItemModel.fromJson).toList(),
       totalAmount: (json['totalAmount'] as num?)?.toDouble() ?? 0.0,
+      bankName: bankJson['bank'] as String? ?? '',
+      bankAgency: bankJson['agency'] as String? ?? '',
+      bankAccount: bankJson['account'] as String? ?? '',
+      bankPixKey:
+          bankJson['pixKey'] as String? ?? bankJson['pix_key'] as String? ?? '',
     );
   }
 }

--- a/lib/features/cart/data/models/cart_model.dart
+++ b/lib/features/cart/data/models/cart_model.dart
@@ -43,9 +43,17 @@ class CartModel extends Cart {
       farmName: json['farmName'] as String? ?? '',
       items: itemsJson.map(CartItemModel.fromJson).toList(),
       totalAmount: (json['totalAmount'] as num?)?.toDouble() ?? 0.0,
-      bankName: bankJson['bank'] as String? ?? '',
+      // Backend BankInfoResponse envia `bankName`. Fallback p/ `bank` mantém
+      // compat com payloads antigos.
+      bankName:
+          bankJson['bankName'] as String? ??
+          bankJson['bank'] as String? ??
+          '',
       bankAgency: bankJson['agency'] as String? ?? '',
-      bankAccount: bankJson['account'] as String? ?? '',
+      bankAccount:
+          bankJson['account'] as String? ??
+          bankJson['accountNumber'] as String? ??
+          '',
       bankPixKey:
           bankJson['pixKey'] as String? ?? bankJson['pix_key'] as String? ?? '',
     );

--- a/lib/features/cart/domain/entities/cart.dart
+++ b/lib/features/cart/domain/entities/cart.dart
@@ -8,6 +8,10 @@ class Cart extends Equatable {
     required this.farmName,
     required this.items,
     required this.totalAmount,
+    this.bankName = '',
+    this.bankAgency = '',
+    this.bankAccount = '',
+    this.bankPixKey = '',
   });
 
   const Cart.empty()
@@ -15,17 +19,35 @@ class Cart extends Equatable {
       producerId = '',
       farmName = '',
       items = const [],
-      totalAmount = 0;
+      totalAmount = 0,
+      bankName = '',
+      bankAgency = '',
+      bankAccount = '',
+      bankPixKey = '';
 
   final String id;
   final String producerId;
   final String farmName;
   final List<CartItem> items;
   final double totalAmount;
+  final String bankName;
+  final String bankAgency;
+  final String bankAccount;
+  final String bankPixKey;
 
   bool get isEmpty => items.isEmpty;
   int get itemCount => items.length;
 
   @override
-  List<Object?> get props => [id, producerId, farmName, items, totalAmount];
+  List<Object?> get props => [
+    id,
+    producerId,
+    farmName,
+    items,
+    totalAmount,
+    bankName,
+    bankAgency,
+    bankAccount,
+    bankPixKey,
+  ];
 }

--- a/lib/features/cart/presentation/bloc/cart_bloc.dart
+++ b/lib/features/cart/presentation/bloc/cart_bloc.dart
@@ -24,6 +24,7 @@ class CartBloc extends Bloc<CartEvent, CartState> {
     on<CartItemQuantityUpdated>(_onQuantityUpdated);
     on<CartItemRemoved>(_onItemRemoved);
     on<CartCleared>(_onCleared);
+    on<CartOrderPlaced>(_onOrderPlaced);
   }
 
   final GetCart _getCart;
@@ -103,4 +104,8 @@ class CartBloc extends Bloc<CartEvent, CartState> {
 
   Future<void> _onCleared(CartCleared event, Emitter<CartState> emit) =>
       _runMutation(_clearCart.call, 'Erro ao limpar carrinho.', emit);
+
+  void _onOrderPlaced(CartOrderPlaced event, Emitter<CartState> emit) {
+    emit(const CartInitial());
+  }
 }

--- a/lib/features/cart/presentation/bloc/cart_event.dart
+++ b/lib/features/cart/presentation/bloc/cart_event.dart
@@ -39,3 +39,7 @@ class CartItemRemoved extends CartEvent {
 class CartCleared extends CartEvent {
   const CartCleared();
 }
+
+class CartOrderPlaced extends CartEvent {
+  const CartOrderPlaced();
+}

--- a/lib/features/customer_profile/presentation/pages/customer_edit_address_page.dart
+++ b/lib/features/customer_profile/presentation/pages/customer_edit_address_page.dart
@@ -1,0 +1,454 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/core/formatters/input_masks.dart';
+import 'package:ragro_mobile/core/services/cep_service.dart';
+import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_bloc.dart';
+import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_event.dart';
+import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_state.dart';
+
+/// Page that lets the customer edit ONLY the delivery address.
+///
+/// Reuses the [CustomerProfileBloc]. Other profile fields (name, phone,
+/// email) are preserved by reading them from the current loaded profile
+/// and re-sending them on submit.
+class CustomerEditAddressPage extends StatelessWidget {
+  const CustomerEditAddressPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) =>
+          getIt<CustomerProfileBloc>()..add(const CustomerProfileStarted()),
+      child: const _CustomerEditAddressView(),
+    );
+  }
+}
+
+class _CustomerEditAddressView extends StatefulWidget {
+  const _CustomerEditAddressView();
+
+  @override
+  State<_CustomerEditAddressView> createState() =>
+      _CustomerEditAddressViewState();
+}
+
+class _CustomerEditAddressViewState extends State<_CustomerEditAddressView> {
+  final _formKey = GlobalKey<FormState>();
+  bool _didHydrateProfile = false;
+
+  late final TextEditingController _zipCodeController;
+  late final TextEditingController _streetController;
+  late final TextEditingController _numberController;
+  late final TextEditingController _complementController;
+  late final TextEditingController _neighborhoodController;
+  late final TextEditingController _cityController;
+  late final TextEditingController _stateController;
+
+  @override
+  void initState() {
+    super.initState();
+    _zipCodeController = TextEditingController();
+    _streetController = TextEditingController();
+    _numberController = TextEditingController();
+    _complementController = TextEditingController();
+    _neighborhoodController = TextEditingController();
+    _cityController = TextEditingController();
+    _stateController = TextEditingController();
+    _zipCodeController.addListener(_onZipCodeChanged);
+
+    _hydrateControllers(context.read<CustomerProfileBloc>().state);
+  }
+
+  @override
+  void dispose() {
+    _zipCodeController.dispose();
+    _streetController.dispose();
+    _numberController.dispose();
+    _complementController.dispose();
+    _neighborhoodController.dispose();
+    _cityController.dispose();
+    _stateController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<CustomerProfileBloc, CustomerProfileState>(
+      listener: (context, state) {
+        _hydrateControllers(state);
+        if (state is CustomerProfileUpdateSuccess) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Endereço atualizado com sucesso!'),
+              backgroundColor: AppColors.lightGreen,
+            ),
+          );
+          // Sinaliza para a tela anterior que houve mudança no endereço,
+          // permitindo recarregar dados dependentes (ex.: order_confirmation).
+          context.pop(true);
+        } else if (state is CustomerProfileUpdateFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: AppColors.red,
+            ),
+          );
+        } else if (state is CustomerProfileFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: AppColors.red,
+            ),
+          );
+        }
+      },
+      child: Scaffold(
+        backgroundColor: AppColors.white,
+        body: SafeArea(
+          child: Form(
+            key: _formKey,
+            child: Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      GestureDetector(
+                        onTap: () => context.pop(),
+                        child: const Icon(Icons.arrow_back, size: 24),
+                      ),
+                      const Expanded(
+                        child: Center(
+                          child: Text(
+                            'Editar Endereço',
+                            style: TextStyle(
+                              fontFamily: 'Figtree',
+                              fontWeight: FontWeight.w700,
+                              fontSize: 18,
+                              color: AppColors.black,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 32),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(26, 0, 26, 24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        const SizedBox(height: 16),
+                        _buildField(
+                          label: 'CEP',
+                          controller: _zipCodeController,
+                          icon: Icons.markunread_mailbox_outlined,
+                          hint: '00000-000',
+                          keyboardType: TextInputType.number,
+                          inputFormatters: [CepInputFormatter()],
+                          validator: (value) {
+                            final digits = (value ?? '').replaceAll(
+                              RegExp(r'\D'),
+                              '',
+                            );
+                            if (digits.length != 8) {
+                              return 'CEP deve ter 8 digitos';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 24),
+                        _buildField(
+                          label: 'Rua',
+                          controller: _streetController,
+                          icon: Icons.home_outlined,
+                          hint: 'Rua das Flores',
+                          validator: _requiredValidator,
+                        ),
+                        const SizedBox(height: 24),
+                        _buildField(
+                          label: 'Numero',
+                          controller: _numberController,
+                          icon: Icons.pin_outlined,
+                          hint: '123',
+                          validator: _requiredValidator,
+                        ),
+                        const SizedBox(height: 24),
+                        _buildField(
+                          label: 'Complemento',
+                          controller: _complementController,
+                          icon: Icons.apartment_outlined,
+                          hint: 'Apto 42 (opcional)',
+                        ),
+                        const SizedBox(height: 24),
+                        _buildField(
+                          label: 'Bairro',
+                          controller: _neighborhoodController,
+                          icon: Icons.location_city_outlined,
+                          hint: 'Centro',
+                          validator: _requiredValidator,
+                        ),
+                        const SizedBox(height: 24),
+                        _buildField(
+                          label: 'Cidade',
+                          controller: _cityController,
+                          icon: Icons.location_on_outlined,
+                          hint: 'Porto Alegre',
+                          validator: _requiredValidator,
+                        ),
+                        const SizedBox(height: 24),
+                        _buildField(
+                          label: 'Estado',
+                          controller: _stateController,
+                          icon: Icons.map_outlined,
+                          hint: 'RS',
+                          validator: (value) {
+                            final text = (value ?? '').trim();
+                            if (text.length != 2) {
+                              return 'Estado deve ter 2 letras';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 32),
+                        BlocBuilder<CustomerProfileBloc, CustomerProfileState>(
+                          builder: (context, state) {
+                            final isLoading = state is CustomerProfileUpdating;
+                            return Column(
+                              children: [
+                                GestureDetector(
+                                  onTap: isLoading ? null : _onSave,
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      vertical: 16,
+                                      horizontal: 24,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: AppColors.darkGreen,
+                                      borderRadius: BorderRadius.circular(16),
+                                      boxShadow: const [
+                                        BoxShadow(
+                                          color: Color(0x40000000),
+                                          blurRadius: 4,
+                                          offset: Offset(0, 4),
+                                        ),
+                                      ],
+                                    ),
+                                    child: Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      children: [
+                                        if (isLoading)
+                                          const SizedBox(
+                                            width: 18,
+                                            height: 18,
+                                            child: CircularProgressIndicator(
+                                              color: AppColors.white,
+                                              strokeWidth: 2,
+                                            ),
+                                          )
+                                        else ...[
+                                          const Icon(
+                                            Icons.save_outlined,
+                                            color: AppColors.white,
+                                            size: 18,
+                                          ),
+                                          const SizedBox(width: 8),
+                                        ],
+                                        const Text(
+                                          'Salvar Endereço',
+                                          style: TextStyle(
+                                            fontFamily: 'Figtree',
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 16,
+                                            color: AppColors.white,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                TextButton(
+                                  onPressed: () => context.pop(),
+                                  child: const Text(
+                                    'Cancelar',
+                                    style: TextStyle(
+                                      fontFamily: 'Figtree',
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 14,
+                                      color: AppColors.darkGreen,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            );
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _hydrateControllers(CustomerProfileState state) {
+    if (_didHydrateProfile) return;
+
+    final profile = switch (state) {
+      CustomerProfileLoaded(:final profile) => profile,
+      CustomerProfileUpdating(:final profile) => profile,
+      CustomerProfileUpdateSuccess(:final profile) => profile,
+      CustomerProfileUpdateFailure(:final profile) => profile,
+      _ => null,
+    };
+
+    if (profile == null) return;
+
+    final address = profile.primaryAddress;
+    _zipCodeController.text = CepInputFormatter.apply(address?.zipCode ?? '');
+    _streetController.text = address?.street ?? '';
+    _numberController.text = address?.number ?? '';
+    _complementController.text = address?.complement ?? '';
+    _neighborhoodController.text = address?.neighborhood ?? '';
+    _cityController.text = address?.city ?? '';
+    _stateController.text = address?.state ?? '';
+    _didHydrateProfile = true;
+  }
+
+  Widget _buildField({
+    required String label,
+    required TextEditingController controller,
+    required IconData icon,
+    required String hint,
+    String? Function(String?)? validator,
+    TextInputType? keyboardType,
+    List<TextInputFormatter>? inputFormatters,
+    bool readOnly = false,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 4, bottom: 6),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontFamily: 'Figtree',
+              fontWeight: FontWeight.w600,
+              fontSize: 14,
+              color: Color(0xFF1E293B),
+            ),
+          ),
+        ),
+        Container(
+          decoration: BoxDecoration(
+            color: AppColors.inputBackground,
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(color: const Color(0x332E5729)),
+          ),
+          child: TextFormField(
+            controller: controller,
+            validator: validator,
+            readOnly: readOnly,
+            keyboardType: keyboardType,
+            inputFormatters: inputFormatters,
+            style: const TextStyle(
+              fontFamily: 'Figtree',
+              fontWeight: FontWeight.w400,
+              fontSize: 16,
+              color: AppColors.black,
+            ),
+            decoration: InputDecoration(
+              hintText: hint,
+              hintStyle: const TextStyle(color: AppColors.placeholder),
+              prefixIcon: Icon(icon, color: AppColors.placeholder, size: 20),
+              border: InputBorder.none,
+              enabledBorder: InputBorder.none,
+              focusedBorder: InputBorder.none,
+              filled: false,
+              contentPadding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _onZipCodeChanged() {
+    final cep = _zipCodeController.text.replaceAll(RegExp(r'\D'), '');
+    if (cep.length == 8) {
+      _lookupZipCode(cep);
+    }
+  }
+
+  Future<void> _lookupZipCode(String cep) async {
+    final address = await getIt<CepService>().fetchAddress(cep);
+    if (address != null && mounted) {
+      setState(() {
+        _streetController.text = address.street;
+        _neighborhoodController.text = address.neighborhood;
+        _cityController.text = address.city;
+        _stateController.text = address.state;
+      });
+    }
+  }
+
+  String? _requiredValidator(String? value) {
+    if ((value ?? '').trim().isEmpty) {
+      return 'Campo obrigatorio';
+    }
+    return null;
+  }
+
+  void _onSave() {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    // Preserve other profile fields (name, phone) by reading from current state.
+    final state = context.read<CustomerProfileBloc>().state;
+    final profile = switch (state) {
+      CustomerProfileLoaded(:final profile) => profile,
+      CustomerProfileUpdating(:final profile) => profile,
+      CustomerProfileUpdateSuccess(:final profile) => profile,
+      CustomerProfileUpdateFailure(:final profile) => profile,
+      _ => null,
+    };
+
+    if (profile == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Aguarde o carregamento do perfil...'),
+          backgroundColor: AppColors.placeholder,
+        ),
+      );
+      return;
+    }
+
+    context.read<CustomerProfileBloc>().add(
+      CustomerProfileUpdateSubmitted(
+        name: profile.name,
+        phone: profile.phone,
+        street: _streetController.text.trim(),
+        number: _numberController.text.trim(),
+        city: _cityController.text.trim(),
+        state: _stateController.text.trim().toUpperCase(),
+        zipCode: _zipCodeController.text.trim(),
+        complement: _complementController.text.trim().isEmpty
+            ? null
+            : _complementController.text.trim(),
+        neighborhood: _neighborhoodController.text.trim(),
+      ),
+    );
+  }
+}

--- a/lib/features/orders/data/datasources/orders_remote_datasource.dart
+++ b/lib/features/orders/data/datasources/orders_remote_datasource.dart
@@ -180,15 +180,5 @@ class OrdersRemoteDatasource {
     return const [];
   }
 
-  // Backend OrderStatus enum (Java) é case-sensitive UPPERCASE.
-  // Ver ragro-backend/src/main/java/br/com/ragro/domain/enums/OrderStatus.java
-  String _statusQueryValue(OrderStatus status) {
-    return switch (status) {
-      OrderStatus.pending => 'PENDING',
-      OrderStatus.accepted => 'CONFIRMED',
-      OrderStatus.inDelivery => 'IN_DELIVERY',
-      OrderStatus.delivered => 'DELIVERED',
-      OrderStatus.cancelled => 'CANCELLED',
-    };
-  }
+  String _statusQueryValue(OrderStatus status) => status.backendValue;
 }

--- a/lib/features/orders/data/datasources/orders_remote_datasource.dart
+++ b/lib/features/orders/data/datasources/orders_remote_datasource.dart
@@ -1,295 +1,177 @@
+import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart' hide Order;
+import 'package:ragro_mobile/core/network/api_client.dart';
+import 'package:ragro_mobile/core/network/api_endpoints.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/orders/data/models/order_detail_model.dart';
+import 'package:ragro_mobile/features/orders/data/models/order_model.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
-import 'package:ragro_mobile/features/orders/domain/entities/order_item.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
 
 @lazySingleton
 class OrdersRemoteDatasource {
-  static final List<Order> _mockOrders = [
-    Order(
-      id: '4829',
-      producerId: 'p1',
-      producerPhone: '+5511998765432',
-      farmName: 'Fazenda Sol Nascente',
-      farmAvatarUrl: '',
-      ownerName: 'Manoel Silva',
-      items: const [
-        OrderItem(
-          productId: 'prod1',
-          name: 'Tomate',
-          imageUrl: '',
-          quantity: 1,
-          unityType: 'un',
-          totalPrice: 12.90,
-        ),
-        OrderItem(
-          productId: 'prod2',
-          name: 'Bananas',
-          imageUrl: '',
-          quantity: 3,
-          unityType: 'kg',
-          totalPrice: 18,
-        ),
-        OrderItem(
-          productId: 'prod3',
-          name: 'Maçã',
-          imageUrl: '',
-          quantity: 1,
-          unityType: 'kg',
-          totalPrice: 9,
-        ),
-        OrderItem(
-          productId: 'prod4',
-          name: 'Alface Crespa',
-          imageUrl: '',
-          quantity: 1,
-          unityType: 'un',
-          totalPrice: 4.50,
-        ),
-      ],
-      totalAmount: 145.90,
-      status: OrderStatus.pending,
-      createdAt: DateTime(2026, 1, 21, 21, 8),
-      deliveryAddress: const DeliveryAddress(
-        street: 'Rua das Flores, 123 - Apto 42',
-        neighborhood: 'Bairro Primavera',
-        city: 'São Paulo',
-        state: 'SP',
-        zipCode: '01310-100',
-      ),
-      bankInfo: const ProducerBankInfo(
-        bank: 'Nubank (260)',
-        agency: '0001',
-        account: '12345-6',
-        pixKey: 'fazenda.boavista@email.com',
-      ),
-    ),
-    Order(
-      id: '4828',
-      producerId: 'p1',
-      producerPhone: '+5511998765432',
-      farmName: 'Fazenda Sol Nascente',
-      farmAvatarUrl: '',
-      ownerName: 'Manoel Silva',
-      items: const [
-        OrderItem(
-          productId: 'prod1',
-          name: 'Tomate',
-          imageUrl: '',
-          quantity: 1,
-          unityType: 'un',
-          totalPrice: 12.90,
-        ),
-        OrderItem(
-          productId: 'prod2',
-          name: 'Bananas',
-          imageUrl: '',
-          quantity: 3,
-          unityType: 'kg',
-          totalPrice: 18,
-        ),
-        OrderItem(
-          productId: 'prod3',
-          name: 'Maçã',
-          imageUrl: '',
-          quantity: 1,
-          unityType: 'kg',
-          totalPrice: 9,
-        ),
-      ],
-      totalAmount: 145.90,
-      status: OrderStatus.accepted,
-      createdAt: DateTime(2026, 1, 21, 21, 8),
-      deliveryAddress: const DeliveryAddress(
-        street: 'Rua das Flores, 123 - Apto 42',
-        neighborhood: 'Bairro Primavera',
-        city: 'São Paulo',
-        state: 'SP',
-        zipCode: '01310-100',
-      ),
-      bankInfo: const ProducerBankInfo(
-        bank: 'Nubank (260)',
-        agency: '0001',
-        account: '12345-6',
-        pixKey: 'fazenda.boavista@email.com',
-      ),
-    ),
-    Order(
-      id: '4827',
-      producerId: 'p1',
-      producerPhone: '+5511998765432',
-      farmName: 'Fazenda Sol Nascente',
-      farmAvatarUrl: '',
-      ownerName: 'Manoel Silva',
-      items: const [
-        OrderItem(
-          productId: 'prod1',
-          name: 'Tomate',
-          imageUrl: '',
-          quantity: 1,
-          unityType: 'un',
-          totalPrice: 12.90,
-        ),
-        OrderItem(
-          productId: 'prod5',
-          name: 'Maçã',
-          imageUrl: '',
-          quantity: 1,
-          unityType: 'kg',
-          totalPrice: 9,
-        ),
-      ],
-      totalAmount: 145.90,
-      status: OrderStatus.delivered,
-      createdAt: DateTime(2026, 1, 21, 21, 8),
-      deliveryAddress: const DeliveryAddress(
-        street: 'Rua das Flores, 123 - Apto 42',
-        neighborhood: 'Bairro Primavera',
-        city: 'São Paulo',
-        state: 'SP',
-        zipCode: '01310-100',
-      ),
-      bankInfo: const ProducerBankInfo(
-        bank: 'Nubank (260)',
-        agency: '0001',
-        account: '12345-6',
-        pixKey: 'fazenda.boavista@email.com',
-      ),
-    ),
-    Order(
-      id: '4826',
-      producerId: 'p1',
-      producerPhone: '+5511998765432',
-      farmName: 'Fazenda Sol Nascente',
-      farmAvatarUrl: '',
-      ownerName: 'Manoel Silva',
-      items: const [
-        OrderItem(
-          productId: 'prod2',
-          name: 'Bananas',
-          imageUrl: '',
-          quantity: 3,
-          unityType: 'kg',
-          totalPrice: 18,
-        ),
-      ],
-      totalAmount: 145.90,
-      status: OrderStatus.cancelled,
-      createdAt: DateTime(2026, 1, 21, 21, 8),
-      deliveryAddress: const DeliveryAddress(
-        street: 'Rua das Flores, 123 - Apto 42',
-        neighborhood: 'Bairro Primavera',
-        city: 'São Paulo',
-        state: 'SP',
-        zipCode: '01310-100',
-      ),
-      bankInfo: const ProducerBankInfo(
-        bank: 'Nubank (260)',
-        agency: '0001',
-        account: '12345-6',
-        pixKey: 'fazenda.boavista@email.com',
-      ),
-    ),
-  ];
+  const OrdersRemoteDatasource(this._apiClient);
 
-  /// Gets consumer orders, optionally filtered by [status].
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<List<Order>>` getOrders({OrderStatus? status}) async {
-  ///   try {
-  ///     final response = await _apiClient.dio.get`<Map<String, dynamic>>`(
-  ///       ApiEndpoints.orders,
-  ///       queryParameters: {
-  ///         if (status != null) 'status': status.name,
-  ///       },
-  ///     );
-  ///     return (response.data!['data'] as List)
-  ///         .map((e) => Order.fromJson(e as `Map<String, dynamic>`))
-  ///         .toList();
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
+  final ApiClient _apiClient;
+
   Future<List<Order>> getOrders({OrderStatus? status}) async {
-    await Future<void>.delayed(const Duration(milliseconds: 600));
-    if (status == null) return List.from(_mockOrders);
-    return _mockOrders.where((o) => o.status == status).toList();
+    try {
+      final response = await _apiClient.dio.get<dynamic>(
+        ApiEndpoints.consumerOrders,
+        queryParameters: {
+          if (status != null) 'status': _statusQueryValue(status),
+        },
+      );
+
+      return _readList(response.data).map(OrderModel.fromJson).toList();
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
   }
 
-  /// Gets a single order by [id].
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<Order>` getOrderById(String id) async {
-  ///   try {
-  ///     final response = await _apiClient.dio.get`<Map<String, dynamic>>`(
-  ///       ApiEndpoints.order(id),
-  ///     );
-  ///     return Order.fromJson(response.data!);
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<Order> getOrderById(String id) async {
-    await Future<void>.delayed(const Duration(milliseconds: 400));
-    return _mockOrders.firstWhere(
-      (o) => o.id == id,
-      orElse: () => _mockOrders.first,
-    );
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        ApiEndpoints.customerOrder(id),
+      );
+
+      return OrderModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
   }
 
-  /// Confirms an order from cart (POST /orders).
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<Order>` confirmOrder(String cartId) async {
-  ///   try {
-  ///     final response = await _apiClient.dio.post`<Map<String, dynamic>>`(
-  ///       ApiEndpoints.orders,
-  ///       data: {'cart_id': cartId},
-  ///     );
-  ///     return Order.fromJson(response.data!);
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
-  Future<Order> confirmOrder(String cartId) async {
-    await Future<void>.delayed(const Duration(milliseconds: 800));
-    return _mockOrders.first;
+  Future<OrderDetail> getCustomerOrderById(String id) async {
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        ApiEndpoints.customerOrder(id),
+      );
+
+      return OrderDetailModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
   }
 
-  /// Rates a producer for a completed order.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<void>` rateProducer(String orderId, int rating) async {
-  ///   try {
-  ///     await _apiClient.dio.post`<void>`(
-  ///       ApiEndpoints.orderRating(orderId),
-  ///       data: {'rating': rating},
-  ///     );
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
+  Future<Order> createOrderFromCart() async {
+    try {
+      final response = await _apiClient.dio.post<Map<String, dynamic>>(
+        ApiEndpoints.orders,
+      );
+
+      return OrderModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  Future<Order> cancelOrder(String id) async {
+    try {
+      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
+        ApiEndpoints.orderCancel(id),
+      );
+
+      return OrderModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  Future<OrderDetail> cancelCustomerOrder(String id) async {
+    try {
+      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
+        ApiEndpoints.customerOrderCancel(id),
+      );
+
+      return OrderDetailModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  Future<OrderDetail> confirmCustomerDelivery(String id) async {
+    try {
+      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
+        ApiEndpoints.customerOrderConfirmDelivery(id),
+      );
+
+      return OrderDetailModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  Future<Order> updateStatus(String id, OrderStatus status) async {
+    try {
+      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
+        ApiEndpoints.orderStatus(id),
+        data: {'status': _statusQueryValue(status)},
+      );
+
+      return OrderModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  Future<Order> confirmOrder(String id) async {
+    try {
+      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
+        ApiEndpoints.orderConfirm(id),
+      );
+
+      return OrderModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  Future<Order> repeatOrder(String id) async {
+    try {
+      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
+        ApiEndpoints.orderRepeat(id),
+      );
+
+      return OrderModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
   Future<void> rateProducer(String orderId, int rating) async {
-    await Future<void>.delayed(const Duration(milliseconds: 400));
+    try {
+      await _apiClient.dio.post<void>(
+        ApiEndpoints.orderRating(orderId),
+        data: {'rating': rating},
+      );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  List<Map<String, dynamic>> _readList(dynamic data) {
+    if (data is List<dynamic>) {
+      return data.whereType<Map<String, dynamic>>().toList();
+    }
+    if (data is Map<String, dynamic>) {
+      for (final key in const ['data', 'content', 'items', 'orders', 'result', 'list']) {
+        if (data[key] is List<dynamic>) {
+          return (data[key] as List<dynamic>)
+              .whereType<Map<String, dynamic>>()
+              .toList();
+        }
+      }
+    }
+    return const [];
+  }
+
+  String _statusQueryValue(OrderStatus status) {
+    return switch (status) {
+      OrderStatus.accepted => 'confirmed',
+      OrderStatus.pending => 'pending',
+      OrderStatus.delivered => 'delivered',
+      OrderStatus.cancelled => 'cancelled',
+    };
   }
 }

--- a/lib/features/orders/data/datasources/orders_remote_datasource.dart
+++ b/lib/features/orders/data/datasources/orders_remote_datasource.dart
@@ -78,13 +78,12 @@ class OrdersRemoteDatasource {
     }
   }
 
-  Future<OrderDetail> cancelCustomerOrder(String id) async {
+  Future<void> cancelCustomerOrder(String id, {required String reason, String? details}) async {
     try {
-      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
-        ApiEndpoints.customerOrderCancel(id),
+      await _apiClient.dio.patch<void>(
+        ApiEndpoints.orderCancel(id),
+        data: {'reason': reason, if (details != null) 'details': details},
       );
-
-      return OrderDetailModel.fromJson(response.data!);
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();
     }
@@ -170,6 +169,7 @@ class OrdersRemoteDatasource {
     return switch (status) {
       OrderStatus.accepted => 'confirmed',
       OrderStatus.pending => 'pending',
+      OrderStatus.inDelivery => 'in_delivery',
       OrderStatus.delivered => 'delivered',
       OrderStatus.cancelled => 'cancelled',
     };

--- a/lib/features/orders/data/models/order_detail_model.dart
+++ b/lib/features/orders/data/models/order_detail_model.dart
@@ -26,9 +26,19 @@ class OrderDetailBankInfoModel extends OrderDetailBankInfo {
 
   factory OrderDetailBankInfoModel.fromJson(Map<String, dynamic> json) {
     return OrderDetailBankInfoModel(
-      bank: json['bank'] as String? ?? '',
+      // Backend BankInfoResponse envia `bankName`. Mantém fallbacks para
+      // compatibilidade com payloads antigos / variantes snake_case.
+      bank:
+          json['bankName'] as String? ??
+          json['bank_name'] as String? ??
+          json['bank'] as String? ??
+          '',
       agency: json['agency'] as String? ?? '',
-      account: json['account'] as String? ?? '',
+      account:
+          json['account'] as String? ??
+          json['accountNumber'] as String? ??
+          json['account_number'] as String? ??
+          '',
       pixKey: json['pixKey'] as String? ?? json['pix_key'] as String? ?? '',
     );
   }
@@ -156,17 +166,21 @@ class OrderDetailModel extends OrderDetail {
           '',
       producerPhone:
           json['producerPhone'] as String? ??
+          json['producerWhatsapp'] as String? ??
           producerJson?['phone'] as String?,
       producerPicture:
           json['producerPicture'] as String? ??
           json['producerPhoto'] as String? ??
           json['producerPhotoUrl'] as String? ??
-          producerJson?['photoUrl'] as String?,
+          json['producerAvatarUrl'] as String? ??
+          producerJson?['photoUrl'] as String? ??
+          producerJson?['picture'] as String?,
       items: items,
       totalAmount:
           (json['totalAmount'] as num? ??
                   json['total'] as num? ??
                   json['totalPrice'] as num? ??
+                  json['price'] as num? ??
                   0)
               .toDouble(),
       deliveryAddress: OrderDetailAddressModel.fromJson(

--- a/lib/features/orders/data/models/order_detail_model.dart
+++ b/lib/features/orders/data/models/order_detail_model.dart
@@ -1,0 +1,193 @@
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+
+class OrderDetailActionsModel extends OrderDetailActions {
+  const OrderDetailActionsModel({
+    required super.canConfirmDelivery,
+    required super.canCancel,
+    required super.canContactProducer,
+  });
+
+  factory OrderDetailActionsModel.fromJson(Map<String, dynamic> json) {
+    return OrderDetailActionsModel(
+      canConfirmDelivery: json['canConfirmDelivery'] as bool? ?? false,
+      canCancel: json['canCancel'] as bool? ?? false,
+      canContactProducer: json['canContactProducer'] as bool? ?? false,
+    );
+  }
+}
+
+class OrderDetailBankInfoModel extends OrderDetailBankInfo {
+  const OrderDetailBankInfoModel({
+    required super.bank,
+    required super.agency,
+    required super.account,
+    required super.pixKey,
+  });
+
+  factory OrderDetailBankInfoModel.fromJson(Map<String, dynamic> json) {
+    return OrderDetailBankInfoModel(
+      bank: json['bank'] as String? ?? '',
+      agency: json['agency'] as String? ?? '',
+      account: json['account'] as String? ?? '',
+      pixKey: json['pixKey'] as String? ?? json['pix_key'] as String? ?? '',
+    );
+  }
+}
+
+class OrderDetailAddressModel extends OrderDetailAddress {
+  const OrderDetailAddressModel({
+    required super.street,
+    required super.number,
+    required super.complement,
+    required super.neighborhood,
+    required super.city,
+    required super.state,
+    required super.reference,
+    super.zipCode,
+  });
+
+  factory OrderDetailAddressModel.fromJson(Map<String, dynamic> json) {
+    return OrderDetailAddressModel(
+      street: json['street'] as String? ?? '',
+      number: json['number'] as String? ?? '',
+      complement: json['complement'] as String? ?? '',
+      neighborhood: json['neighborhood'] as String? ?? '',
+      city: json['city'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      reference: json['reference'] as String? ?? '',
+      zipCode:
+          json['zipCode'] as String? ??
+          json['zip_code'] as String? ??
+          json['cep'] as String? ??
+          '',
+    );
+  }
+}
+
+class OrderDetailItemModel extends OrderDetailItem {
+  const OrderDetailItemModel({
+    required super.id,
+    required super.productId,
+    required super.productName,
+    required super.productPhoto,
+    required super.quantity,
+    required super.unityType,
+    required super.unitPrice,
+    required super.subtotal,
+  });
+
+  factory OrderDetailItemModel.fromJson(Map<String, dynamic> json) {
+    return OrderDetailItemModel(
+      id: json['id'] as String? ?? '',
+      productId:
+          json['productId'] as String? ?? json['product_id'] as String? ?? '',
+      productName:
+          json['productName'] as String? ?? json['name'] as String? ?? '',
+      productPhoto:
+          json['productPhoto'] as String? ??
+          json['productPhotoUrl'] as String? ??
+          json['imageUrl'] as String? ??
+          json['imageS3'] as String? ??
+          '',
+      quantity: (json['quantity'] as num? ?? 0).toDouble(),
+      unityType:
+          json['unityType'] as String? ??
+          json['unit'] as String? ??
+          json['unity_type'] as String? ??
+          '',
+      unitPrice: (json['unitPrice'] as num? ?? json['unit_price'] as num? ?? 0)
+          .toDouble(),
+      subtotal:
+          (json['subtotal'] as num? ??
+                  json['totalPrice'] as num? ??
+                  json['total'] as num? ??
+                  0)
+              .toDouble(),
+    );
+  }
+}
+
+class OrderDetailModel extends OrderDetail {
+  const OrderDetailModel({
+    required super.id,
+    required super.orderNumber,
+    required super.status,
+    required super.statusLabel,
+    required super.createdAt,
+    required super.producerId,
+    required super.producerName,
+    required super.producerPhone,
+    required super.producerPicture,
+    required super.items,
+    required super.totalAmount,
+    required super.deliveryAddress,
+    required super.actions,
+    super.bankInfo,
+  });
+
+  factory OrderDetailModel.fromJson(Map<String, dynamic> json) {
+    final items = (json['items'] as List<dynamic>? ?? [])
+        .whereType<Map<String, dynamic>>()
+        .map(OrderDetailItemModel.fromJson)
+        .toList();
+    final address = json['deliveryAddress'] as Map<String, dynamic>?;
+    final actions = json['actions'] as Map<String, dynamic>?;
+    final producerJson =
+        json['producer'] as Map<String, dynamic>? ??
+        json['farmer'] as Map<String, dynamic>?;
+    final bankJson =
+        json['bankInfo'] as Map<String, dynamic>? ??
+        producerJson?['bankInfo'] as Map<String, dynamic>?;
+
+    return OrderDetailModel(
+      id: json['id'] as String? ?? '',
+      orderNumber: json['orderNumber'] as String?,
+      status: _normalizeStatus(json['status'] as String?),
+      statusLabel: json['statusLabel'] as String?,
+      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? ''),
+      producerId:
+          json['producerId'] as String? ??
+          producerJson?['id'] as String? ??
+          '',
+      producerName:
+          json['producerName'] as String? ??
+          json['farmName'] as String? ??
+          producerJson?['name'] as String? ??
+          '',
+      producerPhone:
+          json['producerPhone'] as String? ??
+          producerJson?['phone'] as String?,
+      producerPicture:
+          json['producerPicture'] as String? ??
+          json['producerPhoto'] as String? ??
+          json['producerPhotoUrl'] as String? ??
+          producerJson?['photoUrl'] as String?,
+      items: items,
+      totalAmount:
+          (json['totalAmount'] as num? ??
+                  json['total'] as num? ??
+                  json['totalPrice'] as num? ??
+                  0)
+              .toDouble(),
+      deliveryAddress: OrderDetailAddressModel.fromJson(
+        address ?? const <String, dynamic>{},
+      ),
+      actions: actions == null
+          ? null
+          : OrderDetailActionsModel.fromJson(actions),
+      bankInfo: bankJson == null
+          ? null
+          : OrderDetailBankInfoModel.fromJson(bankJson),
+    );
+  }
+
+  static String _normalizeStatus(String? status) {
+    return switch (status?.trim().toUpperCase()) {
+      'ACCEPTED' || 'CONFIRMED' => 'CONFIRMED',
+      'INDELIVERY' || 'IN_DELIVERY' || 'OUT_FOR_DELIVERY' => 'IN_DELIVERY',
+      'DELIVERED' => 'DELIVERED',
+      'CANCELED' || 'CANCELLED' => 'CANCELLED',
+      _ => 'PENDING',
+    };
+  }
+}

--- a/lib/features/orders/data/models/order_item_model.dart
+++ b/lib/features/orders/data/models/order_item_model.dart
@@ -1,0 +1,39 @@
+import 'package:ragro_mobile/features/orders/domain/entities/order_item.dart';
+
+class OrderItemModel extends OrderItem {
+  const OrderItemModel({
+    required super.productId,
+    required super.name,
+    required super.imageUrl,
+    required super.quantity,
+    required super.unityType,
+    required super.totalPrice,
+  });
+
+  factory OrderItemModel.fromJson(Map<String, dynamic> json) {
+    final quantity = json['quantity'] as num? ?? 0;
+    final subtotal =
+        json['subtotal'] as num? ??
+        json['totalPrice'] as num? ??
+        json['total'] as num? ??
+        0;
+
+    return OrderItemModel(
+      productId:
+          json['productId'] as String? ?? json['product_id'] as String? ?? '',
+      name: json['productName'] as String? ?? json['name'] as String? ?? '',
+      imageUrl:
+          json['imageUrl'] as String? ??
+          json['imageS3'] as String? ??
+          json['productPhoto'] as String? ??
+          '',
+      quantity: quantity.toInt(),
+      unityType:
+          json['unityType'] as String? ??
+          json['unit'] as String? ??
+          json['unity_type'] as String? ??
+          '',
+      totalPrice: subtotal.toDouble(),
+    );
+  }
+}

--- a/lib/features/orders/data/models/order_model.dart
+++ b/lib/features/orders/data/models/order_model.dart
@@ -6,6 +6,7 @@ class OrderModel extends Order {
   const OrderModel({
     required super.id,
     required super.producerId,
+    required super.producerPhone,
     required super.farmName,
     required super.farmAvatarUrl,
     required super.ownerName,
@@ -35,6 +36,10 @@ class OrderModel extends Order {
 
     return OrderModel(
       id: json['id'] as String? ?? '',
+      producerPhone:
+          json['producerPhone'] as String? ??
+          json['phone'] as String? ??
+          '',
       producerId:
           json['producerId'] as String? ??
           json['farmerId'] as String? ??
@@ -72,6 +77,7 @@ class OrderModel extends Order {
   static OrderStatus _parseStatus(String? status) {
     return switch (status?.toLowerCase()) {
       'confirmed' || 'accepted' => OrderStatus.accepted,
+      'in_delivery' || 'indelivery' => OrderStatus.inDelivery,
       'delivered' => OrderStatus.delivered,
       'cancelled' || 'canceled' => OrderStatus.cancelled,
       _ => OrderStatus.pending,

--- a/lib/features/orders/data/models/order_model.dart
+++ b/lib/features/orders/data/models/order_model.dart
@@ -5,6 +5,7 @@ import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
 class OrderModel extends Order {
   const OrderModel({
     required super.id,
+    required super.orderNumber,
     required super.producerId,
     required super.producerPhone,
     required super.farmName,
@@ -36,6 +37,7 @@ class OrderModel extends Order {
 
     return OrderModel(
       id: json['id'] as String? ?? '',
+      orderNumber: json['orderNumber'] as String? ?? '',
       producerPhone:
           json['producerPhone'] as String? ??
           json['phone'] as String? ??
@@ -46,11 +48,12 @@ class OrderModel extends Order {
           producerJson?['id'] as String? ??
           '',
       farmName:
-          json['producerName'] as String? ??
           json['farmName'] as String? ??
+          json['producerName'] as String? ??
           producerJson?['name'] as String? ??
           '',
       farmAvatarUrl:
+          json['producerPicture'] as String? ??
           json['producerPhoto'] as String? ??
           json['producerPhotoUrl'] as String? ??
           json['farmAvatarUrl'] as String? ??
@@ -65,6 +68,7 @@ class OrderModel extends Order {
           (json['total'] as num? ??
                   json['totalAmount'] as num? ??
                   json['totalPrice'] as num? ??
+                  json['price'] as num? ??
                   0)
               .toDouble(),
       status: _parseStatus(json['status'] as String?),

--- a/lib/features/orders/data/models/order_model.dart
+++ b/lib/features/orders/data/models/order_model.dart
@@ -1,0 +1,109 @@
+import 'package:ragro_mobile/features/orders/data/models/order_item_model.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
+
+class OrderModel extends Order {
+  const OrderModel({
+    required super.id,
+    required super.producerId,
+    required super.farmName,
+    required super.farmAvatarUrl,
+    required super.ownerName,
+    required super.items,
+    required super.totalAmount,
+    required super.status,
+    required super.createdAt,
+    required super.deliveryAddress,
+    required super.bankInfo,
+  });
+
+  factory OrderModel.fromJson(Map<String, dynamic> json) {
+    final producer = json['producer'] as Map<String, dynamic>?;
+    final farmer = json['farmer'] as Map<String, dynamic>?;
+    final producerJson = producer ?? farmer;
+    final addressJson =
+        json['deliveryAddress'] as Map<String, dynamic>? ??
+        json['address'] as Map<String, dynamic>? ??
+        const <String, dynamic>{};
+    final bankJson =
+        json['bankInfo'] as Map<String, dynamic>? ??
+        producerJson?['bankInfo'] as Map<String, dynamic>? ??
+        const <String, dynamic>{};
+    final itemsJson = (json['items'] as List<dynamic>? ?? [])
+        .whereType<Map<String, dynamic>>()
+        .toList();
+
+    return OrderModel(
+      id: json['id'] as String? ?? '',
+      producerId:
+          json['producerId'] as String? ??
+          json['farmerId'] as String? ??
+          producerJson?['id'] as String? ??
+          '',
+      farmName:
+          json['producerName'] as String? ??
+          json['farmName'] as String? ??
+          producerJson?['name'] as String? ??
+          '',
+      farmAvatarUrl:
+          json['producerPhoto'] as String? ??
+          json['producerPhotoUrl'] as String? ??
+          json['farmAvatarUrl'] as String? ??
+          producerJson?['photoUrl'] as String? ??
+          '',
+      ownerName:
+          json['ownerName'] as String? ??
+          producerJson?['ownerName'] as String? ??
+          '',
+      items: itemsJson.map(OrderItemModel.fromJson).toList(),
+      totalAmount:
+          (json['total'] as num? ??
+                  json['totalAmount'] as num? ??
+                  json['totalPrice'] as num? ??
+                  0)
+              .toDouble(),
+      status: _parseStatus(json['status'] as String?),
+      createdAt: _parseDate(json['createdAt'] as String?),
+      deliveryAddress: _parseAddress(addressJson),
+      bankInfo: _parseBankInfo(bankJson),
+    );
+  }
+
+  static OrderStatus _parseStatus(String? status) {
+    return switch (status?.toLowerCase()) {
+      'confirmed' || 'accepted' => OrderStatus.accepted,
+      'delivered' => OrderStatus.delivered,
+      'cancelled' || 'canceled' => OrderStatus.cancelled,
+      _ => OrderStatus.pending,
+    };
+  }
+
+  static DateTime _parseDate(String? value) {
+    if (value == null || value.isEmpty) return DateTime.now();
+    return DateTime.tryParse(value)?.toLocal() ?? DateTime.now();
+  }
+
+  static DeliveryAddress _parseAddress(Map<String, dynamic> json) {
+    final number = json['number'] as String? ?? '';
+    final street = json['street'] as String? ?? '';
+    final streetWithNumber = number.isEmpty ? street : '$street, $number';
+
+    return DeliveryAddress(
+      street: streetWithNumber,
+      neighborhood:
+          json['neighborhood'] as String? ?? json['district'] as String? ?? '',
+      city: json['city'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      zipCode: json['zipCode'] as String? ?? json['zip_code'] as String? ?? '',
+    );
+  }
+
+  static ProducerBankInfo _parseBankInfo(Map<String, dynamic> json) {
+    return ProducerBankInfo(
+      bank: json['bank'] as String? ?? '',
+      agency: json['agency'] as String? ?? '',
+      account: json['account'] as String? ?? '',
+      pixKey: json['pixKey'] as String? ?? json['pix_key'] as String? ?? '',
+    );
+  }
+}

--- a/lib/features/orders/data/repositories/orders_repository_impl.dart
+++ b/lib/features/orders/data/repositories/orders_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:injectable/injectable.dart' hide Order;
 import 'package:ragro_mobile/features/orders/data/datasources/orders_remote_datasource.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
 import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
 
@@ -17,7 +18,32 @@ class OrdersRepositoryImpl implements OrdersRepository {
   Future<Order> getOrderById(String id) => _datasource.getOrderById(id);
 
   @override
-  Future<Order> confirmOrder(String cartId) => _datasource.confirmOrder(cartId);
+  Future<OrderDetail> getCustomerOrderById(String id) =>
+      _datasource.getCustomerOrderById(id);
+
+  @override
+  Future<Order> createOrderFromCart() => _datasource.createOrderFromCart();
+
+  @override
+  Future<Order> cancelOrder(String id) => _datasource.cancelOrder(id);
+
+  @override
+  Future<OrderDetail> cancelCustomerOrder(String id) =>
+      _datasource.cancelCustomerOrder(id);
+
+  @override
+  Future<OrderDetail> confirmCustomerDelivery(String id) =>
+      _datasource.confirmCustomerDelivery(id);
+
+  @override
+  Future<Order> updateStatus(String id, OrderStatus status) =>
+      _datasource.updateStatus(id, status);
+
+  @override
+  Future<Order> confirmOrder(String id) => _datasource.confirmOrder(id);
+
+  @override
+  Future<Order> repeatOrder(String id) => _datasource.repeatOrder(id);
 
   @override
   Future<void> rateProducer(String orderId, int rating) =>

--- a/lib/features/orders/data/repositories/orders_repository_impl.dart
+++ b/lib/features/orders/data/repositories/orders_repository_impl.dart
@@ -28,8 +28,8 @@ class OrdersRepositoryImpl implements OrdersRepository {
   Future<Order> cancelOrder(String id) => _datasource.cancelOrder(id);
 
   @override
-  Future<OrderDetail> cancelCustomerOrder(String id) =>
-      _datasource.cancelCustomerOrder(id);
+  Future<void> cancelCustomerOrder(String id, {required String reason, String? details}) =>
+      _datasource.cancelCustomerOrder(id, reason: reason, details: details);
 
   @override
   Future<OrderDetail> confirmCustomerDelivery(String id) =>

--- a/lib/features/orders/domain/entities/order.dart
+++ b/lib/features/orders/domain/entities/order.dart
@@ -44,6 +44,7 @@ class DeliveryAddress extends Equatable {
 class Order extends Equatable {
   const Order({
     required this.id,
+    required this.orderNumber,
     required this.producerId,
     required this.producerPhone,
     required this.farmName,
@@ -58,6 +59,7 @@ class Order extends Equatable {
   });
 
   final String id;
+  final String orderNumber;
   final String producerId;
   final String producerPhone;
   final String farmName;
@@ -82,6 +84,7 @@ class Order extends Equatable {
   @override
   List<Object?> get props => [
     id,
+    orderNumber,
     producerId,
     producerPhone,
     farmName,

--- a/lib/features/orders/domain/entities/order_detail.dart
+++ b/lib/features/orders/domain/entities/order_detail.dart
@@ -163,11 +163,12 @@ class OrderDetail extends Equatable {
   }
 
   bool get isPending => _normalizedStatus == 'PENDING';
+  bool get isAccepted => _normalizedStatus == 'CONFIRMED';
   bool get isInDelivery => _normalizedStatus == 'IN_DELIVERY';
 
   bool get canConfirmDelivery => actions?.canConfirmDelivery ?? isInDelivery;
 
-  bool get canCancel => actions?.canCancel ?? isPending;
+  bool get canCancel => actions?.canCancel ?? (isPending || isAccepted);
 
   bool get canContactProducer =>
       actions?.canContactProducer ??
@@ -186,6 +187,29 @@ class OrderDetail extends Equatable {
   }
 
   String get _normalizedStatus => status.trim().toUpperCase();
+
+  OrderDetail copyWith({
+    String? status,
+    String? statusLabel,
+    OrderDetailActions? actions,
+  }) {
+    return OrderDetail(
+      id: id,
+      orderNumber: orderNumber,
+      status: status ?? this.status,
+      statusLabel: statusLabel ?? this.statusLabel,
+      createdAt: createdAt,
+      producerId: producerId,
+      producerName: producerName,
+      producerPhone: producerPhone,
+      producerPicture: producerPicture,
+      items: items,
+      totalAmount: totalAmount,
+      deliveryAddress: deliveryAddress,
+      actions: actions ?? this.actions,
+      bankInfo: bankInfo,
+    );
+  }
 
   @override
   List<Object?> get props => [

--- a/lib/features/orders/domain/entities/order_detail.dart
+++ b/lib/features/orders/domain/entities/order_detail.dart
@@ -1,0 +1,207 @@
+import 'package:equatable/equatable.dart';
+
+class OrderDetailActions extends Equatable {
+  const OrderDetailActions({
+    required this.canConfirmDelivery,
+    required this.canCancel,
+    required this.canContactProducer,
+  });
+
+  final bool canConfirmDelivery;
+  final bool canCancel;
+  final bool canContactProducer;
+
+  @override
+  List<Object?> get props => [
+    canConfirmDelivery,
+    canCancel,
+    canContactProducer,
+  ];
+}
+
+class OrderDetailBankInfo extends Equatable {
+  const OrderDetailBankInfo({
+    required this.bank,
+    required this.agency,
+    required this.account,
+    required this.pixKey,
+  });
+
+  final String bank;
+  final String agency;
+  final String account;
+  final String pixKey;
+
+  bool get hasAnyInfo =>
+      bank.isNotEmpty || account.isNotEmpty || pixKey.isNotEmpty;
+
+  @override
+  List<Object?> get props => [bank, agency, account, pixKey];
+}
+
+class OrderDetailAddress extends Equatable {
+  const OrderDetailAddress({
+    required this.street,
+    required this.number,
+    required this.complement,
+    required this.neighborhood,
+    required this.city,
+    required this.state,
+    required this.reference,
+    this.zipCode = '',
+  });
+
+  final String street;
+  final String number;
+  final String complement;
+  final String neighborhood;
+  final String city;
+  final String state;
+  final String reference;
+  final String zipCode;
+
+  String get streetLine {
+    final base = [street, number].where((part) => part.isNotEmpty).join(', ');
+    if (complement.isEmpty) return base;
+    return '$base - $complement';
+  }
+
+  String get cityLine {
+    final cityState = [
+      city,
+      state,
+    ].where((part) => part.isNotEmpty).join(' - ');
+    if (neighborhood.isEmpty) return cityState;
+    if (cityState.isEmpty) return neighborhood;
+    return '$neighborhood, $cityState';
+  }
+
+  @override
+  List<Object?> get props => [
+    street,
+    number,
+    complement,
+    neighborhood,
+    city,
+    state,
+    reference,
+    zipCode,
+  ];
+}
+
+class OrderDetailItem extends Equatable {
+  const OrderDetailItem({
+    required this.id,
+    required this.productId,
+    required this.productName,
+    required this.productPhoto,
+    required this.quantity,
+    required this.unityType,
+    required this.unitPrice,
+    required this.subtotal,
+  });
+
+  final String id;
+  final String productId;
+  final String productName;
+  final String productPhoto;
+  final double quantity;
+  final String unityType;
+  final double unitPrice;
+  final double subtotal;
+
+  @override
+  List<Object?> get props => [
+    id,
+    productId,
+    productName,
+    productPhoto,
+    quantity,
+    unityType,
+    unitPrice,
+    subtotal,
+  ];
+}
+
+class OrderDetail extends Equatable {
+  const OrderDetail({
+    required this.id,
+    required this.orderNumber,
+    required this.status,
+    required this.statusLabel,
+    required this.createdAt,
+    required this.producerId,
+    required this.producerName,
+    required this.producerPhone,
+    required this.producerPicture,
+    required this.items,
+    required this.totalAmount,
+    required this.deliveryAddress,
+    required this.actions,
+    this.bankInfo,
+  });
+
+  final String id;
+  final String? orderNumber;
+  final String status;
+  final String? statusLabel;
+  final DateTime? createdAt;
+  final String producerId;
+  final String producerName;
+  final String? producerPhone;
+  final String? producerPicture;
+  final List<OrderDetailItem> items;
+  final double totalAmount;
+  final OrderDetailAddress deliveryAddress;
+  final OrderDetailActions? actions;
+  final OrderDetailBankInfo? bankInfo;
+
+  String get displayNumber {
+    if (orderNumber != null && orderNumber!.isNotEmpty) return orderNumber!;
+    final shortId = id.length > 4 ? id.substring(0, 4) : id;
+    return '#$shortId';
+  }
+
+  bool get isPending => _normalizedStatus == 'PENDING';
+  bool get isInDelivery => _normalizedStatus == 'IN_DELIVERY';
+
+  bool get canConfirmDelivery => actions?.canConfirmDelivery ?? isInDelivery;
+
+  bool get canCancel => actions?.canCancel ?? isPending;
+
+  bool get canContactProducer =>
+      actions?.canContactProducer ??
+      ((producerPhone?.trim().isNotEmpty ?? false));
+
+  String get friendlyStatusLabel {
+    if (statusLabel != null && statusLabel!.isNotEmpty) return statusLabel!;
+    return switch (_normalizedStatus) {
+      'PENDING' => 'Pendente',
+      'CONFIRMED' => 'Aceito',
+      'IN_DELIVERY' => 'A caminho',
+      'DELIVERED' => 'Entregue',
+      'CANCELLED' => 'Cancelado',
+      _ => status,
+    };
+  }
+
+  String get _normalizedStatus => status.trim().toUpperCase();
+
+  @override
+  List<Object?> get props => [
+    id,
+    orderNumber,
+    status,
+    statusLabel,
+    createdAt,
+    producerId,
+    producerName,
+    producerPhone,
+    producerPicture,
+    items,
+    totalAmount,
+    deliveryAddress,
+    actions,
+    bankInfo,
+  ];
+}

--- a/lib/features/orders/domain/entities/order_detail.dart
+++ b/lib/features/orders/domain/entities/order_detail.dart
@@ -172,7 +172,7 @@ class OrderDetail extends Equatable {
 
   bool get canContactProducer =>
       actions?.canContactProducer ??
-      ((producerPhone?.trim().isNotEmpty ?? false));
+      (producerPhone?.trim().isNotEmpty ?? false);
 
   String get friendlyStatusLabel {
     if (statusLabel != null && statusLabel!.isNotEmpty) return statusLabel!;

--- a/lib/features/orders/domain/entities/order_status.dart
+++ b/lib/features/orders/domain/entities/order_status.dart
@@ -8,4 +8,14 @@ extension OrderStatusLabel on OrderStatus {
     OrderStatus.delivered => 'ENTREGUE',
     OrderStatus.cancelled => 'CANCELADO',
   };
+
+  /// Valor enviado/recebido pelo backend (Java OrderStatus, UPPERCASE).
+  /// Ver ragro-backend/src/main/java/br/com/ragro/domain/enums/OrderStatus.java
+  String get backendValue => switch (this) {
+    OrderStatus.pending => 'PENDING',
+    OrderStatus.accepted => 'CONFIRMED',
+    OrderStatus.inDelivery => 'IN_DELIVERY',
+    OrderStatus.delivered => 'DELIVERED',
+    OrderStatus.cancelled => 'CANCELLED',
+  };
 }

--- a/lib/features/orders/domain/entities/order_status.dart
+++ b/lib/features/orders/domain/entities/order_status.dart
@@ -1,9 +1,10 @@
-enum OrderStatus { pending, accepted, delivered, cancelled }
+enum OrderStatus { pending, accepted, inDelivery, delivered, cancelled }
 
 extension OrderStatusLabel on OrderStatus {
   String get label => switch (this) {
     OrderStatus.pending => 'PENDENTE',
     OrderStatus.accepted => 'ACEITO',
+    OrderStatus.inDelivery => 'A CAMINHO',
     OrderStatus.delivered => 'ENTREGUE',
     OrderStatus.cancelled => 'CANCELADO',
   };

--- a/lib/features/orders/domain/repositories/orders_repository.dart
+++ b/lib/features/orders/domain/repositories/orders_repository.dart
@@ -8,7 +8,7 @@ abstract class OrdersRepository {
   Future<OrderDetail> getCustomerOrderById(String id);
   Future<Order> createOrderFromCart();
   Future<Order> cancelOrder(String id);
-  Future<OrderDetail> cancelCustomerOrder(String id);
+  Future<void> cancelCustomerOrder(String id, {required String reason, String? details});
   Future<OrderDetail> confirmCustomerDelivery(String id);
   Future<Order> updateStatus(String id, OrderStatus status);
   Future<Order> confirmOrder(String id);

--- a/lib/features/orders/domain/repositories/orders_repository.dart
+++ b/lib/features/orders/domain/repositories/orders_repository.dart
@@ -1,9 +1,17 @@
 import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
 
 abstract class OrdersRepository {
   Future<List<Order>> getOrders({OrderStatus? status});
   Future<Order> getOrderById(String id);
-  Future<Order> confirmOrder(String cartId);
+  Future<OrderDetail> getCustomerOrderById(String id);
+  Future<Order> createOrderFromCart();
+  Future<Order> cancelOrder(String id);
+  Future<OrderDetail> cancelCustomerOrder(String id);
+  Future<OrderDetail> confirmCustomerDelivery(String id);
+  Future<Order> updateStatus(String id, OrderStatus status);
+  Future<Order> confirmOrder(String id);
+  Future<Order> repeatOrder(String id);
   Future<void> rateProducer(String orderId, int rating);
 }

--- a/lib/features/orders/domain/usecases/cancel_customer_order.dart
+++ b/lib/features/orders/domain/usecases/cancel_customer_order.dart
@@ -1,5 +1,4 @@
 import 'package:injectable/injectable.dart';
-import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
 
 @lazySingleton
@@ -8,6 +7,6 @@ class CancelCustomerOrder {
 
   final OrdersRepository _repository;
 
-  Future<OrderDetail> call(String orderId) =>
-      _repository.cancelCustomerOrder(orderId);
+  Future<void> call(String orderId, {required String reason, String? details}) =>
+      _repository.cancelCustomerOrder(orderId, reason: reason, details: details);
 }

--- a/lib/features/orders/domain/usecases/cancel_customer_order.dart
+++ b/lib/features/orders/domain/usecases/cancel_customer_order.dart
@@ -1,0 +1,13 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+
+@lazySingleton
+class CancelCustomerOrder {
+  const CancelCustomerOrder(this._repository);
+
+  final OrdersRepository _repository;
+
+  Future<OrderDetail> call(String orderId) =>
+      _repository.cancelCustomerOrder(orderId);
+}

--- a/lib/features/orders/domain/usecases/cancel_order.dart
+++ b/lib/features/orders/domain/usecases/cancel_order.dart
@@ -3,8 +3,10 @@ import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
 import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
 
 @lazySingleton
-class ConfirmOrder {
-  const ConfirmOrder(this._repository);
+class CancelOrder {
+  const CancelOrder(this._repository);
+
   final OrdersRepository _repository;
-  Future<Order> call([String? cartId]) => _repository.createOrderFromCart();
+
+  Future<Order> call(String id) => _repository.cancelOrder(id);
 }

--- a/lib/features/orders/domain/usecases/confirm_customer_delivery.dart
+++ b/lib/features/orders/domain/usecases/confirm_customer_delivery.dart
@@ -1,0 +1,13 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+
+@lazySingleton
+class ConfirmCustomerDelivery {
+  const ConfirmCustomerDelivery(this._repository);
+
+  final OrdersRepository _repository;
+
+  Future<OrderDetail> call(String orderId) =>
+      _repository.confirmCustomerDelivery(orderId);
+}

--- a/lib/features/orders/domain/usecases/confirm_existing_order.dart
+++ b/lib/features/orders/domain/usecases/confirm_existing_order.dart
@@ -3,8 +3,10 @@ import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
 import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
 
 @lazySingleton
-class ConfirmOrder {
-  const ConfirmOrder(this._repository);
+class ConfirmExistingOrder {
+  const ConfirmExistingOrder(this._repository);
+
   final OrdersRepository _repository;
-  Future<Order> call([String? cartId]) => _repository.createOrderFromCart();
+
+  Future<Order> call(String id) => _repository.confirmOrder(id);
 }

--- a/lib/features/orders/domain/usecases/get_customer_order_by_id.dart
+++ b/lib/features/orders/domain/usecases/get_customer_order_by_id.dart
@@ -1,0 +1,13 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+
+@lazySingleton
+class GetCustomerOrderById {
+  const GetCustomerOrderById(this._repository);
+
+  final OrdersRepository _repository;
+
+  Future<OrderDetail> call(String orderId) =>
+      _repository.getCustomerOrderById(orderId);
+}

--- a/lib/features/orders/domain/usecases/repeat_order.dart
+++ b/lib/features/orders/domain/usecases/repeat_order.dart
@@ -3,8 +3,10 @@ import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
 import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
 
 @lazySingleton
-class ConfirmOrder {
-  const ConfirmOrder(this._repository);
+class RepeatOrder {
+  const RepeatOrder(this._repository);
+
   final OrdersRepository _repository;
-  Future<Order> call([String? cartId]) => _repository.createOrderFromCart();
+
+  Future<Order> call(String id) => _repository.repeatOrder(id);
 }

--- a/lib/features/orders/domain/usecases/update_order_status.dart
+++ b/lib/features/orders/domain/usecases/update_order_status.dart
@@ -1,10 +1,14 @@
 import 'package:injectable/injectable.dart' hide Order;
 import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
 import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
 
 @lazySingleton
-class ConfirmOrder {
-  const ConfirmOrder(this._repository);
+class UpdateOrderStatus {
+  const UpdateOrderStatus(this._repository);
+
   final OrdersRepository _repository;
-  Future<Order> call([String? cartId]) => _repository.createOrderFromCart();
+
+  Future<Order> call(String id, OrderStatus status) =>
+      _repository.updateStatus(id, status);
 }

--- a/lib/features/orders/presentation/bloc/checkout_bloc.dart
+++ b/lib/features/orders/presentation/bloc/checkout_bloc.dart
@@ -1,17 +1,20 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/cart/domain/usecases/get_cart.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/confirm_order.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_state.dart';
 
 @injectable
 class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
-  CheckoutBloc(this._confirmOrder) : super(const CheckoutInitial()) {
+  CheckoutBloc(this._confirmOrder, this._getCart)
+    : super(const CheckoutInitial()) {
     on<CheckoutStarted>(_onStarted);
     on<CheckoutConfirmed>(_onConfirmed);
   }
 
   final ConfirmOrder _confirmOrder;
+  final GetCart _getCart;
 
   Future<void> _onStarted(
     CheckoutStarted event,
@@ -19,11 +22,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
   ) async {
     emit(const CheckoutLoading());
     try {
-      // Load the order preview from the cart
-      final order = await _confirmOrder(event.cartId);
-      emit(CheckoutReady(order));
+      final cart = await _getCart();
+      emit(CheckoutReady(cart));
     } on Exception catch (e) {
-      emit(CheckoutFailure(e.toString()));
+      emit(CheckoutFailure(message: e.toString()));
     }
   }
 
@@ -31,12 +33,18 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     CheckoutConfirmed event,
     Emitter<CheckoutState> emit,
   ) async {
-    emit(const CheckoutLoading());
+    final cart = switch (state) {
+      CheckoutReady(:final cart) => cart,
+      CheckoutFailure(:final cart) => cart,
+      _ => null,
+    };
+    if (cart == null) return;
+    emit(CheckoutConfirming(cart));
     try {
       final order = await _confirmOrder(event.cartId);
       emit(CheckoutSuccess(order));
     } on Exception catch (e) {
-      emit(CheckoutFailure(e.toString()));
+      emit(CheckoutFailure(cart: cart, message: e.toString()));
     }
   }
 }

--- a/lib/features/orders/presentation/bloc/checkout_bloc.dart
+++ b/lib/features/orders/presentation/bloc/checkout_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/cart/domain/usecases/get_cart.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/confirm_order.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_event.dart';
@@ -24,8 +25,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     try {
       final cart = await _getCart();
       emit(CheckoutReady(cart));
-    } on Exception catch (e) {
-      emit(CheckoutFailure(message: e.toString()));
+    } on ApiException catch (e) {
+      emit(CheckoutFailure(message: e.message));
+    } on Exception catch (_) {
+      emit(const CheckoutFailure(message: 'Não foi possível carregar o carrinho.'));
     }
   }
 
@@ -43,8 +46,10 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     try {
       final order = await _confirmOrder(event.cartId);
       emit(CheckoutSuccess(order));
-    } on Exception catch (e) {
-      emit(CheckoutFailure(cart: cart, message: e.toString()));
+    } on ApiException catch (e) {
+      emit(CheckoutFailure(cart: cart, message: e.message));
+    } on Exception catch (_) {
+      emit(CheckoutFailure(cart: cart, message: 'Erro ao confirmar pedido.'));
     }
   }
 }

--- a/lib/features/orders/presentation/bloc/checkout_state.dart
+++ b/lib/features/orders/presentation/bloc/checkout_state.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:ragro_mobile/features/cart/domain/entities/cart.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
 
 sealed class CheckoutState extends Equatable {
@@ -16,10 +17,18 @@ class CheckoutLoading extends CheckoutState {
 }
 
 class CheckoutReady extends CheckoutState {
-  const CheckoutReady(this.order);
-  final Order order;
+  const CheckoutReady(this.cart);
+  final Cart cart;
   @override
-  List<Object?> get props => [order];
+  List<Object?> get props => [cart];
+}
+
+/// Cart loaded and order confirmation API call is in progress.
+class CheckoutConfirming extends CheckoutState {
+  const CheckoutConfirming(this.cart);
+  final Cart cart;
+  @override
+  List<Object?> get props => [cart];
 }
 
 class CheckoutSuccess extends CheckoutState {
@@ -30,8 +39,9 @@ class CheckoutSuccess extends CheckoutState {
 }
 
 class CheckoutFailure extends CheckoutState {
-  const CheckoutFailure(this.message);
+  const CheckoutFailure({required this.message, this.cart});
+  final Cart? cart;
   final String message;
   @override
-  List<Object?> get props => [message];
+  List<Object?> get props => [cart, message];
 }

--- a/lib/features/orders/presentation/bloc/order_detail_bloc.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_bloc.dart
@@ -1,16 +1,26 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
-import 'package:ragro_mobile/features/orders/domain/usecases/get_order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/cancel_customer_order.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/confirm_customer_delivery.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/get_customer_order_by_id.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_state.dart';
 
 @injectable
 class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
-  OrderDetailBloc(this._getOrderDetail) : super(const OrderDetailInitial()) {
+  OrderDetailBloc(
+    this._getCustomerOrderById,
+    this._cancelOrder,
+    this._confirmDelivery,
+  ) : super(const OrderDetailInitial()) {
     on<OrderDetailStarted>(_onStarted);
+    on<OrderDetailCancelled>(_onCancelled);
+    on<OrderDetailDeliveryConfirmed>(_onDeliveryConfirmed);
   }
 
-  final GetOrderDetail _getOrderDetail;
+  final GetCustomerOrderById _getCustomerOrderById;
+  final CancelCustomerOrder _cancelOrder;
+  final ConfirmCustomerDelivery _confirmDelivery;
 
   Future<void> _onStarted(
     OrderDetailStarted event,
@@ -18,7 +28,49 @@ class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
   ) async {
     emit(const OrderDetailLoading());
     try {
-      final order = await _getOrderDetail(event.orderId);
+      final order = await _getCustomerOrderById(event.orderId);
+      emit(OrderDetailLoaded(order));
+    } on Exception catch (e) {
+      emit(OrderDetailFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onCancelled(
+    OrderDetailCancelled event,
+    Emitter<OrderDetailState> emit,
+  ) async {
+    final current = state;
+    if (current is! OrderDetailLoaded) return;
+    emit(OrderDetailUpdating(current.order));
+    try {
+      final order = await _cancelOrder(event.orderId);
+      emit(
+        OrderDetailActionSuccess(
+          order: order,
+          message: 'Pedido cancelado com sucesso.',
+        ),
+      );
+      emit(OrderDetailLoaded(order));
+    } on Exception catch (e) {
+      emit(OrderDetailFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onDeliveryConfirmed(
+    OrderDetailDeliveryConfirmed event,
+    Emitter<OrderDetailState> emit,
+  ) async {
+    final current = state;
+    if (current is! OrderDetailLoaded) return;
+    emit(OrderDetailUpdating(current.order));
+    try {
+      final order = await _confirmDelivery(event.orderId);
+      emit(
+        OrderDetailActionSuccess(
+          order: order,
+          message: 'Entrega confirmada com sucesso.',
+        ),
+      );
       emit(OrderDetailLoaded(order));
     } on Exception catch (e) {
       emit(OrderDetailFailure(e.toString()));

--- a/lib/features/orders/presentation/bloc/order_detail_bloc.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/cancel_customer_order.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/confirm_customer_delivery.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/get_customer_order_by_id.dart';
@@ -43,16 +44,30 @@ class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
     if (current is! OrderDetailLoaded) return;
     emit(OrderDetailUpdating(current.order));
     try {
-      final order = await _cancelOrder(event.orderId);
+      await _cancelOrder(event.orderId, reason: event.reason, details: event.details);
+      final cancelled = current.order.copyWith(
+        status: 'CANCELLED',
+        actions: const OrderDetailActions(
+          canConfirmDelivery: false,
+          canCancel: false,
+          canContactProducer: false,
+        ),
+      );
       emit(
         OrderDetailActionSuccess(
-          order: order,
+          order: cancelled,
           message: 'Pedido cancelado com sucesso.',
         ),
       );
-      emit(OrderDetailLoaded(order));
+      emit(OrderDetailLoaded(cancelled));
     } on Exception catch (e) {
-      emit(OrderDetailFailure(e.toString()));
+      emit(
+        OrderDetailActionFailure(
+          order: current.order,
+          message: e.toString(),
+        ),
+      );
+      emit(OrderDetailLoaded(current.order));
     }
   }
 

--- a/lib/features/orders/presentation/bloc/order_detail_bloc.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_bloc.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/cancel_customer_order.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/confirm_customer_delivery.dart';
 import 'package:ragro_mobile/features/orders/domain/usecases/get_customer_order_by_id.dart';
@@ -49,7 +50,7 @@ class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
     try {
       await _cancelOrder(event.orderId, reason: event.reason, details: event.details);
       final cancelled = current.order.copyWith(
-        status: 'CANCELLED',
+        status: OrderStatus.cancelled.backendValue,
         actions: const OrderDetailActions(
           canConfirmDelivery: false,
           canCancel: false,

--- a/lib/features/orders/presentation/bloc/order_detail_event.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_event.dart
@@ -12,3 +12,17 @@ class OrderDetailStarted extends OrderDetailEvent {
   @override
   List<Object?> get props => [orderId];
 }
+
+class OrderDetailCancelled extends OrderDetailEvent {
+  const OrderDetailCancelled(this.orderId);
+  final String orderId;
+  @override
+  List<Object?> get props => [orderId];
+}
+
+class OrderDetailDeliveryConfirmed extends OrderDetailEvent {
+  const OrderDetailDeliveryConfirmed(this.orderId);
+  final String orderId;
+  @override
+  List<Object?> get props => [orderId];
+}

--- a/lib/features/orders/presentation/bloc/order_detail_event.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_event.dart
@@ -14,10 +14,12 @@ class OrderDetailStarted extends OrderDetailEvent {
 }
 
 class OrderDetailCancelled extends OrderDetailEvent {
-  const OrderDetailCancelled(this.orderId);
+  const OrderDetailCancelled(this.orderId, {required this.reason, this.details});
   final String orderId;
+  final String reason;
+  final String? details;
   @override
-  List<Object?> get props => [orderId];
+  List<Object?> get props => [orderId, reason, details];
 }
 
 class OrderDetailDeliveryConfirmed extends OrderDetailEvent {

--- a/lib/features/orders/presentation/bloc/order_detail_state.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_state.dart
@@ -39,6 +39,14 @@ class OrderDetailActionSuccess extends OrderDetailState {
   List<Object?> get props => [order, message];
 }
 
+class OrderDetailActionFailure extends OrderDetailState {
+  const OrderDetailActionFailure({required this.order, required this.message});
+  final OrderDetail order;
+  final String message;
+  @override
+  List<Object?> get props => [order, message];
+}
+
 class OrderDetailFailure extends OrderDetailState {
   const OrderDetailFailure(this.message);
   final String message;

--- a/lib/features/orders/presentation/bloc/order_detail_state.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_state.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 
 sealed class OrderDetailState extends Equatable {
   const OrderDetailState();
@@ -17,9 +17,26 @@ class OrderDetailLoading extends OrderDetailState {
 
 class OrderDetailLoaded extends OrderDetailState {
   const OrderDetailLoaded(this.order);
-  final Order order;
+  final OrderDetail order;
   @override
   List<Object?> get props => [order];
+}
+
+class OrderDetailUpdating extends OrderDetailState {
+  const OrderDetailUpdating(this.order);
+  final OrderDetail order;
+  @override
+  List<Object?> get props => [order];
+}
+
+class OrderDetailActionSuccess extends OrderDetailState {
+  const OrderDetailActionSuccess({required this.order, required this.message});
+
+  final OrderDetail order;
+  final String message;
+
+  @override
+  List<Object?> get props => [order, message];
 }
 
 class OrderDetailFailure extends OrderDetailState {

--- a/lib/features/orders/presentation/pages/customer_orders_page.dart
+++ b/lib/features/orders/presentation/pages/customer_orders_page.dart
@@ -32,6 +32,7 @@ class _OrdersView extends StatelessWidget {
   static const _tabs = [
     (OrderStatus.pending, 'Pendentes'),
     (OrderStatus.accepted, 'Aceitos'),
+    (OrderStatus.inDelivery, 'A caminho'),
     (OrderStatus.delivered, 'Entregues'),
     (OrderStatus.cancelled, 'Cancelados'),
   ];

--- a/lib/features/orders/presentation/pages/customer_orders_page.dart
+++ b/lib/features/orders/presentation/pages/customer_orders_page.dart
@@ -26,9 +26,15 @@ class CustomerOrdersPage extends StatelessWidget {
   }
 }
 
-class _OrdersView extends StatelessWidget {
+class _OrdersView extends StatefulWidget {
   const _OrdersView();
 
+  @override
+  State<_OrdersView> createState() => _OrdersViewState();
+}
+
+class _OrdersViewState extends State<_OrdersView>
+    with SingleTickerProviderStateMixin {
   static const _tabs = [
     (OrderStatus.pending, 'Pendentes'),
     (OrderStatus.accepted, 'Aceitos'),
@@ -36,6 +42,20 @@ class _OrdersView extends StatelessWidget {
     (OrderStatus.delivered, 'Entregues'),
     (OrderStatus.cancelled, 'Cancelados'),
   ];
+
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: _tabs.length, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -45,9 +65,8 @@ class _OrdersView extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Title
             const Padding(
-              padding: EdgeInsets.fromLTRB(20, 10, 0, 0),
+              padding: EdgeInsets.fromLTRB(20, 10, 0, 16),
               child: Text(
                 'Pedidos',
                 style: TextStyle(
@@ -58,132 +77,122 @@ class _OrdersView extends StatelessWidget {
                 ),
               ),
             ),
-            // Tab bar
-            BlocBuilder<OrdersBloc, OrdersState>(
-              builder: (context, state) {
-                final activeTab = state is OrdersLoading
-                    ? state.activeTab
-                    : state is OrdersLoaded
-                    ? state.activeTab
-                    : OrderStatus.pending;
-                return SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.only(left: 16),
-                  child: Row(
-                    children: _tabs.map((tab) {
-                      final isActive = activeTab == tab.$1;
-                      return GestureDetector(
-                        onTap: () => context.read<OrdersBloc>().add(
-                          OrdersTabChanged(tab.$1),
-                        ),
-                        child: Container(
-                          padding: const EdgeInsets.fromLTRB(24, 17, 24, 18),
-                          decoration: BoxDecoration(
-                            border: isActive
-                                ? const Border(
-                                    bottom: BorderSide(
-                                      color: AppColors.darkGreen,
-                                      width: 3,
-                                    ),
-                                  )
-                                : null,
-                          ),
-                          child: Text(
-                            tab.$2,
-                            style: TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: isActive
-                                  ? FontWeight.w700
-                                  : FontWeight.w500,
-                              fontSize: 14,
-                              color: isActive
-                                  ? AppColors.darkGreen
-                                  : AppColors.placeholder,
-                            ),
-                          ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                );
-              },
+            TabBar(
+              controller: _tabController,
+              isScrollable: true,
+              tabAlignment: TabAlignment.start,
+              labelPadding: const EdgeInsets.symmetric(horizontal: 24),
+              indicatorColor: AppColors.darkGreen,
+              indicatorWeight: 3,
+              indicatorSize: TabBarIndicatorSize.tab,
+              dividerColor: Colors.transparent,
+              labelColor: AppColors.darkGreen,
+              unselectedLabelColor: AppColors.placeholder,
+              labelStyle: const TextStyle(
+                fontFamily: 'Manrope',
+                fontWeight: FontWeight.w700,
+                fontSize: 14,
+              ),
+              unselectedLabelStyle: const TextStyle(
+                fontFamily: 'Manrope',
+                fontWeight: FontWeight.w500,
+                fontSize: 14,
+              ),
+              tabs: _tabs.map((tab) => Tab(text: tab.$2)).toList(),
             ),
-            // Content
             Expanded(
-              child: BlocBuilder<OrdersBloc, OrdersState>(
-                builder: (context, state) {
-                  if (state is OrdersLoading) {
-                    return const Center(
-                      child: CircularProgressIndicator(
-                        color: AppColors.darkGreen,
-                      ),
-                    );
-                  }
-                  if (state is OrdersFailure) {
-                    return Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            state.message,
-                            textAlign: TextAlign.center,
-                            style: const TextStyle(
-                              fontFamily: 'Manrope',
-                              fontSize: 14,
-                              color: AppColors.placeholder,
-                            ),
-                          ),
-                          const SizedBox(height: 16),
-                          TextButton(
-                            onPressed: () => context.read<OrdersBloc>().add(
-                              const OrdersStarted(OrderStatus.pending),
-                            ),
-                            child: const Text('Tentar novamente'),
-                          ),
-                        ],
-                      ),
-                    );
-                  }
-                  if (state is! OrdersLoaded) return const SizedBox.shrink();
-                  final orders = state.orders
-                      .where((order) => order.status == state.activeTab)
-                      .toList();
-                  if (orders.isEmpty) {
-                    return Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(
-                            Icons.shopping_bag_outlined,
-                            size: 64,
-                            color: AppColors.placeholder,
-                          ),
-                          const SizedBox(height: 16),
-                          Text(
-                            'Nenhum pedido ${state.activeTab.label.toLowerCase()}',
-                            style: const TextStyle(
-                              fontFamily: 'Manrope',
-                              fontSize: 16,
-                              color: AppColors.placeholder,
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }
-                  return ListView.separated(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                    itemCount: orders.length,
-                    separatorBuilder: (_, __) => const SizedBox(height: 13),
-                    itemBuilder: (context, index) =>
-                        OrderCard(order: orders[index]),
-                  );
-                },
+              child: TabBarView(
+                controller: _tabController,
+                children: _tabs
+                    .map((tab) => _OrderTabContent(status: tab.$1))
+                    .toList(),
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+class _OrderTabContent extends StatelessWidget {
+  const _OrderTabContent({required this.status});
+
+  final OrderStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<OrdersBloc, OrdersState>(
+      builder: (context, state) {
+        if (state is OrdersLoading || state is OrdersInitial) {
+          return const Center(
+            child: CircularProgressIndicator(color: AppColors.darkGreen),
+          );
+        }
+
+        if (state is OrdersFailure) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  state.message,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 14,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () => context.read<OrdersBloc>().add(
+                    const OrdersRefreshed(),
+                  ),
+                  child: const Text('Tentar novamente'),
+                ),
+              ],
+            ),
+          );
+        }
+
+        if (state is! OrdersLoaded) return const SizedBox.shrink();
+
+        final orders = state.orders
+            .where((order) => order.status == status)
+            .toList();
+
+        if (orders.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.shopping_bag_outlined,
+                  size: 64,
+                  color: AppColors.placeholder,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Nenhum pedido ${status.label.toLowerCase()}',
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 16,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return ListView.separated(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+          itemCount: orders.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 13),
+          itemBuilder: (context, index) => OrderCard(order: orders[index]),
+        );
+      },
     );
   }
 }

--- a/lib/features/orders/presentation/pages/customer_orders_page.dart
+++ b/lib/features/orders/presentation/pages/customer_orders_page.dart
@@ -30,8 +30,8 @@ class _OrdersView extends StatelessWidget {
   const _OrdersView();
 
   static const _tabs = [
-    (OrderStatus.accepted, 'Aceitos'),
     (OrderStatus.pending, 'Pendentes'),
+    (OrderStatus.accepted, 'Aceitos'),
     (OrderStatus.delivered, 'Entregues'),
     (OrderStatus.cancelled, 'Cancelados'),
   ];
@@ -119,10 +119,35 @@ class _OrdersView extends StatelessWidget {
                     );
                   }
                   if (state is OrdersFailure) {
-                    return Center(child: Text(state.message));
+                    return Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            state.message,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              fontFamily: 'Manrope',
+                              fontSize: 14,
+                              color: AppColors.placeholder,
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          TextButton(
+                            onPressed: () => context.read<OrdersBloc>().add(
+                              const OrdersStarted(OrderStatus.pending),
+                            ),
+                            child: const Text('Tentar novamente'),
+                          ),
+                        ],
+                      ),
+                    );
                   }
                   if (state is! OrdersLoaded) return const SizedBox.shrink();
-                  if (state.orders.isEmpty) {
+                  final orders = state.orders
+                      .where((order) => order.status == state.activeTab)
+                      .toList();
+                  if (orders.isEmpty) {
                     return Center(
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
@@ -147,10 +172,10 @@ class _OrdersView extends StatelessWidget {
                   }
                   return ListView.separated(
                     padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                    itemCount: state.orders.length,
+                    itemCount: orders.length,
                     separatorBuilder: (_, __) => const SizedBox(height: 13),
                     itemBuilder: (context, index) =>
-                        OrderCard(order: state.orders[index]),
+                        OrderCard(order: orders[index]),
                   );
                 },
               ),

--- a/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -8,13 +8,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/cart/domain/entities/cart.dart';
+import 'package:ragro_mobile/features/cart/domain/entities/cart_item.dart';
 import 'package:ragro_mobile/features/cart/presentation/bloc/cart_bloc.dart';
 import 'package:ragro_mobile/features/cart/presentation/bloc/cart_event.dart';
-import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_bloc.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_state.dart';
-import 'package:ragro_mobile/features/orders/presentation/widgets/order_item_row.dart';
 
 class OrderConfirmationPage extends StatelessWidget {
   const OrderConfirmationPage({super.key});
@@ -26,10 +26,17 @@ class OrderConfirmationPage extends StatelessWidget {
       child: BlocListener<CheckoutBloc, CheckoutState>(
         listener: (context, state) {
           if (state is CheckoutSuccess) {
-            // Clear the cart after confirming
-            getIt<CartBloc>().add(const CartCleared());
-            // Navigate to order detail
+            getIt<CartBloc>().add(const CartOrderPlaced());
             context.go('/customer/orders/${state.order.id}');
+          }
+          if (state is CheckoutFailure) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(_friendlyError(state.message)),
+                backgroundColor: AppColors.red,
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
           }
         },
         child: BlocBuilder<CheckoutBloc, CheckoutState>(
@@ -41,29 +48,88 @@ class OrderConfirmationPage extends StatelessWidget {
                 ),
               );
             }
-            if (state is CheckoutFailure) {
-              return Scaffold(body: Center(child: Text(state.message)));
-            }
-            if (state is! CheckoutReady && state is! CheckoutSuccess) {
-              return const Scaffold();
+
+            final cart = switch (state) {
+              CheckoutReady(:final cart) => cart,
+              CheckoutConfirming(:final cart) => cart,
+              CheckoutFailure(:final cart) => cart,
+              _ => null,
+            };
+
+            if (cart == null) {
+              return Scaffold(
+                backgroundColor: AppColors.white,
+                body: SafeArea(
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(
+                            Icons.shopping_cart_outlined,
+                            size: 56,
+                            color: AppColors.placeholder,
+                          ),
+                          const SizedBox(height: 16),
+                          const Text(
+                            'Não foi possível carregar o carrinho.',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              fontFamily: 'Manrope',
+                              fontSize: 16,
+                              color: AppColors.black,
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          ElevatedButton(
+                            onPressed: () => context
+                                .read<CheckoutBloc>()
+                                .add(const CheckoutStarted('cart')),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.darkGreen,
+                              foregroundColor: AppColors.white,
+                            ),
+                            child: const Text('Tentar novamente'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              );
             }
 
-            final order = state is CheckoutReady
-                ? state.order
-                : (state as CheckoutSuccess).order;
-
-            return _CheckoutView(order: order);
+            return _CheckoutView(
+              cart: cart,
+              isConfirming: state is CheckoutConfirming,
+            );
           },
         ),
       ),
     );
   }
+
+  static String _friendlyError(String message) {
+    final lower = message.toLowerCase();
+    if (lower.contains('400') || lower.contains('invalid')) {
+      return 'Pedido inválido. Verifique seu carrinho e tente novamente.';
+    }
+    if (lower.contains('401') || lower.contains('unauthorized')) {
+      return 'Sessão expirada. Faça login novamente.';
+    }
+    if (lower.contains('404') || lower.contains('notfound')) {
+      return 'Carrinho não encontrado.';
+    }
+    return 'Não foi possível confirmar o pedido. Tente novamente.';
+  }
 }
 
 class _CheckoutView extends StatelessWidget {
-  const _CheckoutView({required this.order});
+  const _CheckoutView({required this.cart, this.isConfirming = false});
 
-  final Order order;
+  final Cart cart;
+  final bool isConfirming;
 
   String _formatPrice(double price) =>
       'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
@@ -171,7 +237,7 @@ class _CheckoutView extends StatelessWidget {
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
                                     Text(
-                                      order.deliveryAddress.fullAddress,
+                                      cart.farmName,
                                       style: const TextStyle(
                                         fontFamily: 'Manrope',
                                         fontWeight: FontWeight.w700,
@@ -180,7 +246,7 @@ class _CheckoutView extends StatelessWidget {
                                       ),
                                     ),
                                     Text(
-                                      order.deliveryAddress.cityStateZip,
+                                      'Endereço será confirmado pelo cadastro',
                                       style: const TextStyle(
                                         fontFamily: 'Manrope',
                                         fontSize: 14,
@@ -261,7 +327,7 @@ class _CheckoutView extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(9999),
                               ),
                               child: Text(
-                                '${order.items.length} Itens',
+                                '${cart.items.length} Itens',
                                 style: const TextStyle(
                                   fontFamily: 'Manrope',
                                   fontWeight: FontWeight.w700,
@@ -274,7 +340,7 @@ class _CheckoutView extends StatelessWidget {
                           ],
                         ),
                         const SizedBox(height: 16),
-                        ...order.items.map((item) => OrderItemRow(item: item)),
+                        ...cart.items.map((item) => _CartItemRow(item: item)),
                       ],
                     ),
                   ),
@@ -332,7 +398,9 @@ class _CheckoutView extends StatelessWidget {
                                           ),
                                         ),
                                         Text(
-                                          order.bankInfo.bank,
+                                          cart.bankName.isNotEmpty
+                                              ? cart.bankName
+                                              : '-',
                                           style: const TextStyle(
                                             fontFamily: 'Manrope',
                                             fontWeight: FontWeight.w700,
@@ -364,7 +432,9 @@ class _CheckoutView extends StatelessWidget {
                                           ),
                                         ),
                                         Text(
-                                          order.bankInfo.agency,
+                                          cart.bankAgency.isNotEmpty
+                                              ? cart.bankAgency
+                                              : '-',
                                           style: const TextStyle(
                                             fontFamily: 'Manrope',
                                             fontWeight: FontWeight.w700,
@@ -390,7 +460,9 @@ class _CheckoutView extends StatelessWidget {
                                           ),
                                         ),
                                         Text(
-                                          order.bankInfo.account,
+                                          cart.bankAccount.isNotEmpty
+                                              ? cart.bankAccount
+                                              : '-',
                                           style: const TextStyle(
                                             fontFamily: 'Manrope',
                                             fontWeight: FontWeight.w700,
@@ -431,7 +503,9 @@ class _CheckoutView extends StatelessWidget {
                                           ),
                                         ),
                                         Text(
-                                          order.bankInfo.pixKey,
+                                          cart.bankPixKey.isNotEmpty
+                                              ? cart.bankPixKey
+                                              : 'Disponível nos detalhes do pedido',
                                           style: const TextStyle(
                                             fontFamily: 'Manrope',
                                             fontWeight: FontWeight.w700,
@@ -543,7 +617,7 @@ class _CheckoutView extends StatelessWidget {
                         ),
                       ),
                       Text(
-                        _formatPrice(order.totalAmount),
+                        _formatPrice(cart.totalAmount),
                         style: const TextStyle(
                           fontFamily: 'Manrope',
                           fontSize: 14,
@@ -591,7 +665,7 @@ class _CheckoutView extends StatelessWidget {
                         ),
                       ),
                       Text(
-                        _formatPrice(order.totalAmount),
+                        _formatPrice(cart.totalAmount),
                         style: const TextStyle(
                           fontFamily: 'Manrope',
                           fontWeight: FontWeight.w700,
@@ -603,50 +677,47 @@ class _CheckoutView extends StatelessWidget {
                   ),
                   const SizedBox(height: 16),
                   // Confirm button
-                  BlocBuilder<CheckoutBloc, CheckoutState>(
-                    builder: (context, state) {
-                      final isLoading = state is CheckoutLoading;
-                      return GestureDetector(
-                        onTap: isLoading
-                            ? null
-                            : () => context.read<CheckoutBloc>().add(
-                                const CheckoutConfirmed('cart'),
-                              ),
-                        child: Container(
-                          height: 56,
-                          decoration: BoxDecoration(
-                            color: AppColors.darkGreen,
-                            borderRadius: BorderRadius.circular(24),
+                  GestureDetector(
+                    onTap: isConfirming
+                        ? null
+                        : () => context.read<CheckoutBloc>().add(
+                            const CheckoutConfirmed('cart'),
                           ),
-                          child: Center(
-                            child: isLoading
-                                ? const CircularProgressIndicator(
-                                    color: AppColors.white,
-                                  )
-                                : const Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      Text(
-                                        'Confirmar Pedido',
-                                        style: TextStyle(
-                                          fontFamily: 'Manrope',
-                                          fontWeight: FontWeight.w700,
-                                          fontSize: 16,
-                                          color: AppColors.white,
-                                        ),
-                                      ),
-                                      SizedBox(width: 8),
-                                      Icon(
-                                        Icons.check_circle_outline,
-                                        color: AppColors.white,
-                                        size: 20,
-                                      ),
-                                    ],
+                    child: Container(
+                      height: 56,
+                      decoration: BoxDecoration(
+                        color: isConfirming
+                            ? AppColors.darkGreen.withValues(alpha: 0.7)
+                            : AppColors.darkGreen,
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      child: Center(
+                        child: isConfirming
+                            ? const CircularProgressIndicator(
+                                color: AppColors.white,
+                              )
+                            : const Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    'Confirmar Pedido',
+                                    style: TextStyle(
+                                      fontFamily: 'Manrope',
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 16,
+                                      color: AppColors.white,
+                                    ),
                                   ),
-                          ),
-                        ),
-                      );
-                    },
+                                  SizedBox(width: 8),
+                                  Icon(
+                                    Icons.check_circle_outline,
+                                    color: AppColors.white,
+                                    size: 20,
+                                  ),
+                                ],
+                              ),
+                      ),
+                    ),
                   ),
                   const SizedBox(height: 8),
                   const Text(
@@ -663,6 +734,77 @@ class _CheckoutView extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _CartItemRow extends StatelessWidget {
+  const _CartItemRow({required this.item});
+
+  final CartItem item;
+
+  String _formatPrice(double price) =>
+      'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
+
+  String _formatQuantity(double quantity) {
+    if (quantity % 1 == 0) return quantity.toInt().toString();
+    return quantity.toStringAsFixed(2).replaceAll('.', ',');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              width: 64,
+              height: 64,
+              color: AppColors.lightGreen.withValues(alpha: 0.05),
+              child: item.imageUrl.isNotEmpty
+                  ? Image.network(item.imageUrl, fit: BoxFit.cover)
+                  : const Icon(Icons.eco, color: AppColors.lightGreen),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.productName,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Qtd: ${_formatQuantity(item.quantity)}${item.unityType}',
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 14,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            _formatPrice(item.subtotal),
+            style: const TextStyle(
+              fontFamily: 'Manrope',
+              fontWeight: FontWeight.w700,
+              fontSize: 14,
+              color: AppColors.black,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -8,10 +8,14 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/auth/domain/entities/address.dart';
 import 'package:ragro_mobile/features/cart/domain/entities/cart.dart';
 import 'package:ragro_mobile/features/cart/domain/entities/cart_item.dart';
 import 'package:ragro_mobile/features/cart/presentation/bloc/cart_bloc.dart';
 import 'package:ragro_mobile/features/cart/presentation/bloc/cart_event.dart';
+import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_bloc.dart';
+import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_event.dart';
+import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_state.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_bloc.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_state.dart';
@@ -21,8 +25,20 @@ class OrderConfirmationPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => getIt<CheckoutBloc>()..add(const CheckoutStarted('cart')),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (_) =>
+              getIt<CheckoutBloc>()..add(const CheckoutStarted('cart')),
+        ),
+        // CustomerProfileBloc é factory no DI; o BlocProvider mantém uma única
+        // instância no subtree, então context.read<CustomerProfileBloc>() em
+        // callbacks (ex.: botão "Alterar") referencia o mesmo bloc do BlocBuilder.
+        BlocProvider(
+          create: (_) => getIt<CustomerProfileBloc>()
+            ..add(const CustomerProfileStarted()),
+        ),
+      ],
       child: BlocListener<CheckoutBloc, CheckoutState>(
         listener: (context, state) {
           if (state is CheckoutSuccess) {
@@ -173,133 +189,9 @@ class _CheckoutView extends StatelessWidget {
             Expanded(
               child: ListView(
                 children: [
-                  // Delivery address section
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            const Text(
-                              'Endereço de Entrega',
-                              style: TextStyle(
-                                fontFamily: 'Manrope',
-                                fontWeight: FontWeight.w700,
-                                fontSize: 18,
-                                color: AppColors.black,
-                              ),
-                            ),
-                            GestureDetector(
-                              onTap: () {},
-                              child: const Text(
-                                'Alterar',
-                                style: TextStyle(
-                                  fontFamily: 'Figtree',
-                                  fontWeight: FontWeight.w600,
-                                  fontSize: 14,
-                                  color: AppColors.darkGreen,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 16),
-                        Container(
-                          padding: const EdgeInsets.all(17),
-                          decoration: BoxDecoration(
-                            color: AppColors.lightGreen.withValues(alpha: 0.05),
-                            borderRadius: BorderRadius.circular(24),
-                            border: Border.all(
-                              color: AppColors.lightGreen.withValues(
-                                alpha: 0.1,
-                              ),
-                            ),
-                          ),
-                          child: Row(
-                            children: [
-                              Container(
-                                padding: const EdgeInsets.all(12),
-                                decoration: BoxDecoration(
-                                  color: AppColors.darkGreen,
-                                  borderRadius: BorderRadius.circular(16),
-                                ),
-                                child: const Icon(
-                                  Icons.location_on,
-                                  color: AppColors.white,
-                                  size: 20,
-                                ),
-                              ),
-                              const SizedBox(width: 16),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      cart.farmName,
-                                      style: const TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 16,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                    Text(
-                                      'Endereço será confirmado pelo cadastro',
-                                      style: const TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontSize: 14,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        const SizedBox(height: 16),
-                        // Map placeholder
-                        Container(
-                          height: 128,
-                          decoration: BoxDecoration(
-                            color: AppColors.lightGreen.withValues(alpha: 0.1),
-                            borderRadius: BorderRadius.circular(24),
-                            border: Border.all(color: AppColors.black),
-                          ),
-                          child: const Center(
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  Icons.map_outlined,
-                                  color: AppColors.darkGreen,
-                                  size: 24,
-                                ),
-                                SizedBox(width: 8),
-                                Text(
-                                  'Mapa de Entrega',
-                                  style: TextStyle(
-                                    fontFamily: 'Manrope',
-                                    fontSize: 14,
-                                    color: AppColors.darkGreen,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  // Divider
-                  Container(height: 8, color: const Color(0xFFF6F7F6)),
-
                   // Order items summary
                   Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 24, 16, 24),
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -519,6 +411,81 @@ class _CheckoutView extends StatelessWidget {
                                 ],
                               ),
                             ],
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        // Delivery address
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text(
+                              'Endereço de Entrega',
+                              style: TextStyle(
+                                fontFamily: 'Manrope',
+                                fontWeight: FontWeight.w700,
+                                fontSize: 18,
+                                color: AppColors.black,
+                              ),
+                            ),
+                            GestureDetector(
+                              onTap: () async {
+                                final updated = await context.push<bool>(
+                                  '/customer/edit-address',
+                                );
+                                if ((updated ?? false) && context.mounted) {
+                                  // Recarrega checkout + perfil para refletir
+                                  // o endereço atualizado.
+                                  context.read<CheckoutBloc>().add(
+                                    const CheckoutStarted('cart'),
+                                  );
+                                  context.read<CustomerProfileBloc>().add(
+                                    const CustomerProfileStarted(),
+                                  );
+                                }
+                              },
+                              child: const Text(
+                                'Alterar',
+                                style: TextStyle(
+                                  fontFamily: 'Figtree',
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 14,
+                                  color: AppColors.darkGreen,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        const _DeliveryAddressCard(),
+                        const SizedBox(height: 16),
+                        // Map placeholder
+                        Container(
+                          height: 128,
+                          decoration: BoxDecoration(
+                            color: AppColors.lightGreen.withValues(alpha: 0.1),
+                            borderRadius: BorderRadius.circular(24),
+                            border: Border.all(color: AppColors.black),
+                          ),
+                          child: const Center(
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(
+                                  Icons.map_outlined,
+                                  color: AppColors.darkGreen,
+                                  size: 24,
+                                ),
+                                SizedBox(width: 8),
+                                Text(
+                                  'Mapa de Entrega',
+                                  style: TextStyle(
+                                    fontFamily: 'Manrope',
+                                    fontSize: 14,
+                                    color: AppColors.darkGreen,
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                         const SizedBox(height: 24),
@@ -807,5 +774,139 @@ class _CartItemRow extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+/// Card que exibe o endereço primário do customer logado.
+/// Lê do [CustomerProfileBloc] já provido pela página.
+class _DeliveryAddressCard extends StatelessWidget {
+  const _DeliveryAddressCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(17),
+      decoration: BoxDecoration(
+        color: AppColors.lightGreen.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(
+          color: AppColors.lightGreen.withValues(alpha: 0.1),
+        ),
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: AppColors.darkGreen,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: const Icon(
+              Icons.location_on,
+              color: AppColors.white,
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: BlocBuilder<CustomerProfileBloc, CustomerProfileState>(
+              builder: (context, state) {
+                if (state is CustomerProfileInitial ||
+                    state is CustomerProfileLoading) {
+                  return const SizedBox(
+                    height: 40,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: AppColors.darkGreen,
+                        ),
+                      ),
+                    ),
+                  );
+                }
+
+                final profile = switch (state) {
+                  CustomerProfileLoaded(:final profile) => profile,
+                  CustomerProfileUpdating(:final profile) => profile,
+                  CustomerProfileUpdateSuccess(:final profile) => profile,
+                  CustomerProfileUpdateFailure(:final profile) => profile,
+                  _ => null,
+                };
+
+                final address = profile?.primaryAddress;
+                if (address == null) {
+                  return const Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Você ainda não tem endereço cadastrado',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontWeight: FontWeight.w700,
+                          fontSize: 16,
+                          color: AppColors.black,
+                        ),
+                      ),
+                      SizedBox(height: 4),
+                      Text(
+                        'Toque em Alterar para cadastrar',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontSize: 14,
+                          color: AppColors.placeholder,
+                        ),
+                      ),
+                    ],
+                  );
+                }
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _formatStreet(address),
+                      style: const TextStyle(
+                        fontFamily: 'Manrope',
+                        fontWeight: FontWeight.w700,
+                        fontSize: 16,
+                        color: AppColors.black,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      _formatLocality(address),
+                      style: const TextStyle(
+                        fontFamily: 'Manrope',
+                        fontSize: 14,
+                        color: AppColors.black,
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatStreet(Address address) {
+    final complement = (address.complement ?? '').trim();
+    final base = '${address.street}, ${address.number}';
+    return complement.isEmpty ? base : '$base - $complement';
+  }
+
+  String _formatLocality(Address address) {
+    final neighborhood = (address.neighborhood ?? '').trim();
+    final cityState = '${address.city}/${address.state}';
+    final cep = 'CEP ${address.zipCode}';
+    return neighborhood.isEmpty
+        ? '$cityState • $cep'
+        : '$neighborhood • $cityState • $cep';
   }
 }

--- a/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -179,31 +179,14 @@ class _CheckoutView extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            const Text(
-                              'Endereço de Entrega',
-                              style: TextStyle(
-                                fontFamily: 'Manrope',
-                                fontWeight: FontWeight.w700,
-                                fontSize: 18,
-                                color: AppColors.black,
-                              ),
-                            ),
-                            GestureDetector(
-                              onTap: () {},
-                              child: const Text(
-                                'Alterar',
-                                style: TextStyle(
-                                  fontFamily: 'Figtree',
-                                  fontWeight: FontWeight.w600,
-                                  fontSize: 14,
-                                  color: AppColors.darkGreen,
-                                ),
-                              ),
-                            ),
-                          ],
+                        const Text(
+                          'Endereço de Entrega',
+                          style: TextStyle(
+                            fontFamily: 'Manrope',
+                            fontWeight: FontWeight.w700,
+                            fontSize: 18,
+                            color: AppColors.black,
+                          ),
                         ),
                         const SizedBox(height: 16),
                         Container(
@@ -245,9 +228,9 @@ class _CheckoutView extends StatelessWidget {
                                         color: AppColors.black,
                                       ),
                                     ),
-                                    Text(
+                                    const Text(
                                       'Endereço será confirmado pelo cadastro',
-                                      style: const TextStyle(
+                                      style: TextStyle(
                                         fontFamily: 'Manrope',
                                         fontSize: 14,
                                         color: AppColors.black,

--- a/lib/features/orders/presentation/pages/order_detail_page.dart
+++ b/lib/features/orders/presentation/pages/order_detail_page.dart
@@ -307,19 +307,7 @@ class _ProducerHeader extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
       child: Row(
         children: [
-          CircleAvatar(
-            radius: 22,
-            backgroundColor: AppColors.lightGreen.withValues(alpha: 0.12),
-            backgroundImage:
-                order.producerPicture != null &&
-                    order.producerPicture!.isNotEmpty
-                ? NetworkImage(order.producerPicture!)
-                : null,
-            child:
-                order.producerPicture == null || order.producerPicture!.isEmpty
-                ? const Icon(Icons.storefront, color: AppColors.lightGreen)
-                : null,
-          ),
+          _ProducerAvatar(url: order.producerPicture),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -351,6 +339,37 @@ class _ProducerHeader extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _ProducerAvatar extends StatelessWidget {
+  const _ProducerAvatar({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasUrl = url != null && url!.isNotEmpty;
+    return Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: AppColors.lightGreen.withValues(alpha: 0.12),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: hasUrl
+          ? Image.network(
+              url!,
+              fit: BoxFit.cover,
+              errorBuilder: (_, __, ___) => const Center(
+                child: Icon(Icons.storefront, color: AppColors.lightGreen),
+              ),
+            )
+          : const Center(
+              child: Icon(Icons.storefront, color: AppColors.lightGreen),
+            ),
     );
   }
 }
@@ -446,7 +465,12 @@ class _OrderDetailItemRow extends StatelessWidget {
               height: 64,
               color: AppColors.lightGreen.withValues(alpha: 0.05),
               child: item.productPhoto.isNotEmpty
-                  ? Image.network(item.productPhoto, fit: BoxFit.cover)
+                  ? Image.network(
+                      item.productPhoto,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) =>
+                          const Icon(Icons.eco, color: AppColors.lightGreen),
+                    )
                   : const Icon(Icons.eco, color: AppColors.lightGreen),
             ),
           ),

--- a/lib/features/orders/presentation/pages/order_detail_page.dart
+++ b/lib/features/orders/presentation/pages/order_detail_page.dart
@@ -13,6 +13,7 @@ import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_bloc.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_state.dart';
+import 'package:ragro_mobile/shared/widgets/cancel_order_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class OrderDetailPage extends StatelessWidget {
@@ -31,6 +32,14 @@ class OrderDetailPage extends StatelessWidget {
               SnackBar(
                 content: Text(state.message),
                 backgroundColor: AppColors.darkGreen,
+              ),
+            );
+          }
+          if (state is OrderDetailActionFailure) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: AppColors.red,
               ),
             );
           }
@@ -53,6 +62,9 @@ class OrderDetailPage extends StatelessWidget {
               isUpdating: true,
             ),
             OrderDetailActionSuccess(:final order) => _OrderDetailView(
+              order: order,
+            ),
+            OrderDetailActionFailure(:final order) => _OrderDetailView(
               order: order,
             ),
           };
@@ -804,26 +816,11 @@ class _ActionFooter extends StatelessWidget {
   }
 
   Future<void> _confirmCancel(BuildContext context) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Cancelar pedido'),
-        content: const Text('Tem certeza que deseja cancelar este pedido?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('Voltar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('Cancelar pedido'),
-          ),
-        ],
-      ),
-    );
-
-    if ((confirmed ?? false) && context.mounted) {
-      context.read<OrderDetailBloc>().add(OrderDetailCancelled(order.id));
+    final result = await CancelOrderDialog.showForCustomer(context);
+    if (result != null && context.mounted) {
+      context.read<OrderDetailBloc>().add(
+        OrderDetailCancelled(order.id, reason: result.reason, details: result.details),
+      );
     }
   }
 

--- a/lib/features/orders/presentation/pages/order_detail_page.dart
+++ b/lib/features/orders/presentation/pages/order_detail_page.dart
@@ -1,18 +1,18 @@
 // Screen: Detalhes do Pedido
-// User Story: US-12 — View Order Details
-// Epic: EPIC 3 — Shopping & Orders
-// Routes: GET /orders/:id
+// User Story: US-12 - View Order Details
+// Epic: EPIC 3 - Shopping & Orders
+// Routes: GET /orders/customer/:id
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_bloc.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_state.dart';
-import 'package:ragro_mobile/features/orders/presentation/widgets/order_item_row.dart';
-import 'package:ragro_mobile/features/orders/presentation/widgets/order_status_badge.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class OrderDetailPage extends StatelessWidget {
@@ -20,333 +20,872 @@ class OrderDetailPage extends StatelessWidget {
 
   final String orderId;
 
-  String _formatPrice(double price) =>
-      'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
-
-  Future<void> _openWhatsApp(BuildContext context, String phoneNumber) async {
-    try {
-      final cleanPhone = phoneNumber.replaceAll(RegExp(r'[^\d+]'), '');
-      final formattedPhone = cleanPhone.startsWith('+')
-          ? cleanPhone.replaceFirst('+', '')
-          : cleanPhone;
-      final whatsappUrl = 'https://wa.me/$formattedPhone';
-
-      if (await canLaunchUrl(Uri.parse(whatsappUrl))) {
-        await launchUrl(
-          Uri.parse(whatsappUrl),
-          mode: LaunchMode.externalApplication,
-        );
-      } else {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Não foi possível abrir o WhatsApp'),
-              duration: Duration(seconds: 2),
-            ),
-          );
-        }
-      }
-    } on Object catch (e) {
-      debugPrint('Erro ao abrir WhatsApp: $e');
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Erro: $e'),
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) => getIt<OrderDetailBloc>()..add(OrderDetailStarted(orderId)),
-      child: BlocBuilder<OrderDetailBloc, OrderDetailState>(
-        builder: (context, state) {
-          if (state is OrderDetailLoading || state is OrderDetailInitial) {
-            return const Scaffold(
-              body: Center(
-                child: CircularProgressIndicator(color: AppColors.darkGreen),
+      child: BlocConsumer<OrderDetailBloc, OrderDetailState>(
+        listener: (context, state) {
+          if (state is OrderDetailActionSuccess) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: AppColors.darkGreen,
               ),
             );
           }
-          if (state is OrderDetailFailure) {
-            return Scaffold(body: Center(child: Text(state.message)));
-          }
-          if (state is! OrderDetailLoaded) return const Scaffold();
+        },
+        builder: (context, state) {
+          return switch (state) {
+            OrderDetailLoading() || OrderDetailInitial() => const Scaffold(
+              backgroundColor: AppColors.white,
+              body: Center(
+                child: CircularProgressIndicator(color: AppColors.darkGreen),
+              ),
+            ),
+            OrderDetailFailure(:final message) => _OrderDetailErrorView(
+              orderId: orderId,
+              message: _friendlyErrorMessage(message),
+            ),
+            OrderDetailLoaded(:final order) => _OrderDetailView(order: order),
+            OrderDetailUpdating(:final order) => _OrderDetailView(
+              order: order,
+              isUpdating: true,
+            ),
+            OrderDetailActionSuccess(:final order) => _OrderDetailView(
+              order: order,
+            ),
+          };
+        },
+      ),
+    );
+  }
 
-          final order = state.order;
-          return Scaffold(
-            backgroundColor: AppColors.white,
-            body: SafeArea(
-              child: Stack(
+  static String _friendlyErrorMessage(String message) {
+    final lower = message.toLowerCase();
+    if (lower.contains('404') ||
+        lower.contains('notfound') ||
+        lower.contains('não encontrado') ||
+        lower.contains('nao encontrado')) {
+      return 'Pedido não encontrado.';
+    }
+    return 'Não foi possível carregar os detalhes do pedido.';
+  }
+}
+
+class _OrderDetailErrorView extends StatelessWidget {
+  const _OrderDetailErrorView({required this.orderId, required this.message});
+
+  final String orderId;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.receipt_long_outlined,
+                  size: 56,
+                  color: AppColors.placeholder,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  message,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 16,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () => context.read<OrderDetailBloc>().add(
+                    OrderDetailStarted(orderId),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.darkGreen,
+                    foregroundColor: AppColors.white,
+                  ),
+                  child: const Text('Tentar novamente'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OrderDetailView extends StatelessWidget {
+  const _OrderDetailView({required this.order, this.isUpdating = false});
+
+  final OrderDetail order;
+  final bool isUpdating;
+
+  static final _currency = NumberFormat.currency(
+    locale: 'pt_BR',
+    symbol: r'R$',
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: Stack(
+          children: [
+            SingleChildScrollView(
+              padding: const EdgeInsets.only(bottom: 180),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Main scroll
-                  SingleChildScrollView(
-                    padding: const EdgeInsets.only(bottom: 80),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
                       children: [
-                        // Header
-                        Padding(
-                          padding: const EdgeInsets.all(16),
-                          child: Row(
-                            children: [
-                              GestureDetector(
-                                onTap: () => context.pop(),
-                                child: const Padding(
-                                  padding: EdgeInsets.all(8),
-                                  child: Icon(Icons.arrow_back, size: 16),
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: Text(
-                                  'Detalhes do Pedido\n#${order.id}',
-                                  style: const TextStyle(
-                                    fontFamily: 'Manrope',
-                                    fontWeight: FontWeight.w700,
-                                    fontSize: 18,
-                                    color: AppColors.black,
-                                  ),
-                                ),
-                              ),
-                              OrderStatusBadge(status: order.status),
-                            ],
+                        GestureDetector(
+                          onTap: () => Navigator.of(context).maybePop(),
+                          child: const Padding(
+                            padding: EdgeInsets.all(8),
+                            child: Icon(Icons.arrow_back, size: 18),
                           ),
                         ),
-
-                        // ITENS DO PEDIDO
-                        const Padding(
-                          padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
-                          child: Text(
-                            'ITENS DO PEDIDO',
-                            style: TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 14,
-                              color: AppColors.darkGreen,
-                              letterSpacing: 1.4,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 12),
-                        Container(
-                          margin: const EdgeInsets.symmetric(horizontal: 16),
-                          decoration: BoxDecoration(
-                            color: AppColors.white,
-                            borderRadius: BorderRadius.circular(24),
-                            border: Border.all(
-                              color: AppColors.lightGreen.withValues(
-                                alpha: 0.05,
-                              ),
-                            ),
-                            boxShadow: const [
-                              BoxShadow(
-                                color: Color(0x0D000000),
-                                blurRadius: 2,
-                                offset: Offset(0, 1),
-                              ),
-                            ],
-                          ),
+                        const SizedBox(width: 8),
+                        Expanded(
                           child: Column(
-                            children: [
-                              ...order.items.asMap().entries.map((entry) {
-                                final isLast =
-                                    entry.key == order.items.length - 1;
-                                return Column(
-                                  children: [
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 16,
-                                      ),
-                                      child: OrderItemRow(item: entry.value),
-                                    ),
-                                    if (!isLast)
-                                      Divider(
-                                        color: AppColors.lightGreen.withValues(
-                                          alpha: 0.05,
-                                        ),
-                                        height: 1,
-                                      ),
-                                  ],
-                                );
-                              }),
-                              // Total
-                              Container(
-                                decoration: BoxDecoration(
-                                  color: AppColors.lightGreen.withValues(
-                                    alpha: 0.05,
-                                  ),
-                                  borderRadius: const BorderRadius.vertical(
-                                    bottom: Radius.circular(24),
-                                  ),
-                                  border: Border(
-                                    top: BorderSide(
-                                      color: AppColors.lightGreen.withValues(
-                                        alpha: 0.1,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                padding: const EdgeInsets.fromLTRB(
-                                  16,
-                                  17,
-                                  16,
-                                  16,
-                                ),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    const Text(
-                                      'Total',
-                                      style: TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 18,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                    Text(
-                                      _formatPrice(order.totalAmount),
-                                      style: const TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 18,
-                                        color: AppColors.darkGreen,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-
-                        const SizedBox(height: 16),
-
-                        // ENTREGA
-                        const Padding(
-                          padding: EdgeInsets.fromLTRB(16, 0, 16, 12),
-                          child: Text(
-                            'ENTREGA',
-                            style: TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 14,
-                              color: AppColors.darkGreen,
-                              letterSpacing: 1.4,
-                            ),
-                          ),
-                        ),
-                        Container(
-                          margin: const EdgeInsets.symmetric(horizontal: 16),
-                          padding: const EdgeInsets.all(17),
-                          decoration: BoxDecoration(
-                            color: AppColors.white,
-                            borderRadius: BorderRadius.circular(24),
-                            border: Border.all(
-                              color: AppColors.lightGreen.withValues(
-                                alpha: 0.05,
-                              ),
-                            ),
-                            boxShadow: const [
-                              BoxShadow(
-                                color: Color(0x0D000000),
-                                blurRadius: 2,
-                                offset: Offset(0, 1),
-                              ),
-                            ],
-                          ),
-                          child: Row(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const Icon(
-                                Icons.location_on_outlined,
-                                size: 20,
-                                color: AppColors.darkGreen,
+                              const Text(
+                                'Detalhes do Pedido',
+                                style: TextStyle(
+                                  fontFamily: 'Manrope',
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 18,
+                                  color: AppColors.black,
+                                ),
                               ),
-                              const SizedBox(width: 12),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    const Text(
-                                      'Endereço',
-                                      style: TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 14,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                    Text(
-                                      order.deliveryAddress.fullAddress,
-                                      style: const TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontSize: 16,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                    Text(
-                                      order.deliveryAddress.cityStateZip,
-                                      style: const TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontSize: 16,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                  ],
+                              Text(
+                                order.displayNumber,
+                                style: const TextStyle(
+                                  fontFamily: 'Manrope',
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 14,
+                                  color: AppColors.placeholder,
                                 ),
                               ),
                             ],
                           ),
                         ),
-                        const SizedBox(height: 80),
+                        _StatusBadge(order: order),
                       ],
                     ),
                   ),
-
-                  // WhatsApp button
-                  Positioned(
-                    left: 27,
-                    right: 27,
-                    bottom: 16,
-                    child: GestureDetector(
-                      onTap: () => _openWhatsApp(context, order.producerPhone),
-                      child: Container(
-                        height: 52,
-                        decoration: BoxDecoration(
-                          color: const Color(0xFF25D366),
-                          borderRadius: BorderRadius.circular(24),
-                        ),
-                        child: const Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(Icons.chat, color: Colors.white, size: 20),
-                            SizedBox(width: 8),
-                            Text(
-                              'Contatar Produtor',
-                              style: TextStyle(
-                                fontFamily: 'Manrope',
-                                fontWeight: FontWeight.w700,
-                                fontSize: 16,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ],
-                        ),
+                  if (order.producerName.isNotEmpty) _ProducerHeader(order),
+                  const _SectionTitle('ITENS DO PEDIDO'),
+                  Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 16),
+                    decoration: BoxDecoration(
+                      color: AppColors.white,
+                      borderRadius: BorderRadius.circular(24),
+                      border: Border.all(
+                        color: AppColors.lightGreen.withValues(alpha: 0.08),
                       ),
+                      boxShadow: const [
+                        BoxShadow(
+                          color: Color(0x0D000000),
+                          blurRadius: 2,
+                          offset: Offset(0, 1),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      children: [
+                        ...order.items.asMap().entries.map((entry) {
+                          final isLast = entry.key == order.items.length - 1;
+                          return Column(
+                            children: [
+                              _OrderDetailItemRow(item: entry.value),
+                              if (!isLast)
+                                Divider(
+                                  color: AppColors.lightGreen.withValues(
+                                    alpha: 0.08,
+                                  ),
+                                  height: 1,
+                                ),
+                            ],
+                          );
+                        }),
+                        Container(
+                          padding: const EdgeInsets.all(16),
+                          decoration: BoxDecoration(
+                            color: AppColors.lightGreen.withValues(alpha: 0.05),
+                            borderRadius: const BorderRadius.vertical(
+                              bottom: Radius.circular(24),
+                            ),
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              const Text(
+                                'Total',
+                                style: TextStyle(
+                                  fontFamily: 'Manrope',
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 18,
+                                  color: AppColors.black,
+                                ),
+                              ),
+                              Text(
+                                _currency.format(order.totalAmount),
+                                style: const TextStyle(
+                                  fontFamily: 'Manrope',
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 18,
+                                  color: AppColors.darkGreen,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
                   ),
+                  const SizedBox(height: 18),
+                  const _SectionTitle('ENTREGA'),
+                  _DeliveryCard(address: order.deliveryAddress),
+                  if (order.bankInfo != null && order.bankInfo!.hasAnyInfo) ...[
+                    const SizedBox(height: 18),
+                    const _SectionTitle('PAGAMENTO'),
+                    _PaymentCard(bankInfo: order.bankInfo!),
+                  ],
+                  const SizedBox(height: 8),
                 ],
               ),
             ),
-          );
-        },
+            Positioned(
+              left: 16,
+              right: 16,
+              bottom: 16,
+              child: _ActionFooter(order: order, isUpdating: isUpdating),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProducerHeader extends StatelessWidget {
+  const _ProducerHeader(this.order);
+
+  final OrderDetail order;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 22,
+            backgroundColor: AppColors.lightGreen.withValues(alpha: 0.12),
+            backgroundImage:
+                order.producerPicture != null &&
+                    order.producerPicture!.isNotEmpty
+                ? NetworkImage(order.producerPicture!)
+                : null,
+            child:
+                order.producerPicture == null || order.producerPicture!.isEmpty
+                ? const Icon(Icons.storefront, color: AppColors.lightGreen)
+                : null,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  order.producerName,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                    color: AppColors.black,
+                  ),
+                ),
+                if (order.createdAt != null)
+                  Text(
+                    DateFormat(
+                      'dd/MM/yyyy, HH:mm',
+                      'pt_BR',
+                    ).format(order.createdAt!),
+                    style: const TextStyle(
+                      fontFamily: 'Manrope',
+                      fontSize: 12,
+                      color: AppColors.placeholder,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontFamily: 'Manrope',
+          fontWeight: FontWeight.w700,
+          fontSize: 14,
+          color: AppColors.darkGreen,
+          letterSpacing: 1.4,
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.order});
+
+  final OrderDetail order;
+
+  Color get _color {
+    return switch (order.status) {
+      'PENDING' => const Color(0xFFFFB413),
+      'CONFIRMED' => AppColors.lightGreen,
+      'IN_DELIVERY' => AppColors.lightGreen,
+      'DELIVERED' => const Color(0xFF3B82F6),
+      'CANCELLED' => AppColors.red,
+      _ => AppColors.placeholder,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: _color,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        order.friendlyStatusLabel.toUpperCase(),
+        style: const TextStyle(
+          fontFamily: 'Manrope',
+          fontWeight: FontWeight.w700,
+          fontSize: 10,
+          color: AppColors.white,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _OrderDetailItemRow extends StatelessWidget {
+  const _OrderDetailItemRow({required this.item});
+
+  final OrderDetailItem item;
+
+  static final _currency = NumberFormat.currency(
+    locale: 'pt_BR',
+    symbol: r'R$',
+  );
+
+  String get _quantity {
+    final value = item.quantity % 1 == 0
+        ? item.quantity.toInt().toString()
+        : item.quantity.toStringAsFixed(2).replaceAll('.', ',');
+    return 'Qtd: $value${item.unityType}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              width: 64,
+              height: 64,
+              color: AppColors.lightGreen.withValues(alpha: 0.05),
+              child: item.productPhoto.isNotEmpty
+                  ? Image.network(item.productPhoto, fit: BoxFit.cover)
+                  : const Icon(Icons.eco, color: AppColors.lightGreen),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.productName,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _quantity,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 13,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+                Text(
+                  _currency.format(item.unitPrice),
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 13,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            _currency.format(item.subtotal),
+            style: const TextStyle(
+              fontFamily: 'Manrope',
+              fontWeight: FontWeight.w700,
+              fontSize: 14,
+              color: AppColors.black,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeliveryCard extends StatelessWidget {
+  const _DeliveryCard({required this.address});
+
+  final OrderDetailAddress address;
+
+  @override
+  Widget build(BuildContext context) {
+    final lines = [
+      address.streetLine,
+      address.cityLine,
+      if (address.zipCode.isNotEmpty) 'CEP: ${address.zipCode}',
+      address.reference,
+    ].where((line) => line.isNotEmpty).toList();
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(17),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.lightGreen.withValues(alpha: 0.08)),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0D000000),
+            blurRadius: 2,
+            offset: Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.location_on_outlined,
+            size: 20,
+            color: AppColors.darkGreen,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Endereço',
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                ...lines.map(
+                  (line) => Text(
+                    line,
+                    style: const TextStyle(
+                      fontFamily: 'Manrope',
+                      fontSize: 15,
+                      color: AppColors.black,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PaymentCard extends StatelessWidget {
+  const _PaymentCard({required this.bankInfo});
+
+  final OrderDetailBankInfo bankInfo;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(17),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.lightGreen.withValues(alpha: 0.08)),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0D000000),
+            blurRadius: 2,
+            offset: Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              Icon(
+                Icons.account_balance_wallet_outlined,
+                size: 20,
+                color: AppColors.darkGreen,
+              ),
+              SizedBox(width: 12),
+              Text(
+                'Dados para pagamento',
+                style: TextStyle(
+                  fontFamily: 'Manrope',
+                  fontWeight: FontWeight.w700,
+                  fontSize: 14,
+                  color: AppColors.black,
+                ),
+              ),
+            ],
+          ),
+          if (bankInfo.pixKey.isNotEmpty) ...[
+            const SizedBox(height: 14),
+            _PixRow(pixKey: bankInfo.pixKey),
+          ],
+          if (bankInfo.bank.isNotEmpty || bankInfo.account.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            const Divider(height: 1),
+            const SizedBox(height: 12),
+            if (bankInfo.bank.isNotEmpty)
+              _InfoRow(label: 'Banco', value: bankInfo.bank),
+            if (bankInfo.agency.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              _InfoRow(label: 'Agência', value: bankInfo.agency),
+            ],
+            if (bankInfo.account.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              _InfoRow(label: 'Conta', value: bankInfo.account),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PixRow extends StatelessWidget {
+  const _PixRow({required this.pixKey});
+
+  final String pixKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.lightGreen.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          const Text(
+            'PIX',
+            style: TextStyle(
+              fontFamily: 'Manrope',
+              fontWeight: FontWeight.w700,
+              fontSize: 12,
+              color: AppColors.darkGreen,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              pixKey,
+              style: const TextStyle(
+                fontFamily: 'Manrope',
+                fontSize: 13,
+                color: AppColors.black,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          GestureDetector(
+            onTap: () {
+              Clipboard.setData(ClipboardData(text: pixKey));
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Chave PIX copiada!'),
+                  duration: Duration(seconds: 2),
+                ),
+              );
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              decoration: BoxDecoration(
+                color: AppColors.darkGreen,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Text(
+                'COPIAR',
+                style: TextStyle(
+                  fontFamily: 'Manrope',
+                  fontWeight: FontWeight.w700,
+                  fontSize: 11,
+                  color: AppColors.white,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 64,
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontFamily: 'Manrope',
+              fontSize: 13,
+              color: AppColors.placeholder,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(
+              fontFamily: 'Manrope',
+              fontWeight: FontWeight.w600,
+              fontSize: 13,
+              color: AppColors.black,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionFooter extends StatelessWidget {
+  const _ActionFooter({required this.order, required this.isUpdating});
+
+  final OrderDetail order;
+  final bool isUpdating;
+
+  @override
+  Widget build(BuildContext context) {
+    final buttons = <Widget>[
+      if (order.canConfirmDelivery)
+        _ActionButton(
+          label: 'Confirmar Entrega',
+          icon: Icons.check_circle_outline,
+          color: AppColors.darkGreen,
+          onTap: isUpdating
+              ? null
+              : () => context.read<OrderDetailBloc>().add(
+                  OrderDetailDeliveryConfirmed(order.id),
+                ),
+        ),
+      if (order.canCancel)
+        _ActionButton(
+          label: 'Cancelar Pedido',
+          icon: Icons.cancel_outlined,
+          color: AppColors.red,
+          onTap: isUpdating ? null : () => _confirmCancel(context),
+        ),
+      if (order.canContactProducer)
+        _ActionButton(
+          label: 'Contatar Produtor',
+          icon: Icons.chat,
+          color: const Color(0xFF25D366),
+          onTap: isUpdating ? null : () => _contactProducer(context),
+        ),
+    ];
+
+    if (buttons.isEmpty) return const SizedBox.shrink();
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x1A000000),
+            blurRadius: 18,
+            offset: Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isUpdating)
+              const Padding(
+                padding: EdgeInsets.only(bottom: 10),
+                child: LinearProgressIndicator(color: AppColors.darkGreen),
+              ),
+            ...buttons
+                .expand((button) => [button, const SizedBox(height: 8)])
+                .take(buttons.length * 2 - 1),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmCancel(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Cancelar pedido'),
+        content: const Text('Tem certeza que deseja cancelar este pedido?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Voltar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Cancelar pedido'),
+          ),
+        ],
+      ),
+    );
+
+    if ((confirmed ?? false) && context.mounted) {
+      context.read<OrderDetailBloc>().add(OrderDetailCancelled(order.id));
+    }
+  }
+
+  Future<void> _contactProducer(BuildContext context) async {
+    final cleanPhone = (order.producerPhone ?? '').replaceAll(
+      RegExp('[^0-9]'),
+      '',
+    );
+    if (cleanPhone.isEmpty) return;
+
+    final uri = Uri.parse('https://wa.me/55$cleanPhone');
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!launched && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Não foi possível abrir o contato do produtor.'),
+          backgroundColor: AppColors.red,
+        ),
+      );
+    }
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.label,
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final Color color;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 52,
+        decoration: BoxDecoration(
+          color: onTap == null ? color.withValues(alpha: 0.6) : color,
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: AppColors.white, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: const TextStyle(
+                fontFamily: 'Manrope',
+                fontWeight: FontWeight.w700,
+                fontSize: 16,
+                color: AppColors.white,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/orders/presentation/widgets/order_card.dart
+++ b/lib/features/orders/presentation/widgets/order_card.dart
@@ -18,121 +18,146 @@ class OrderCard extends StatelessWidget {
     return '$d/$m/$y, ${h}h$min';
   }
 
-  String _formatPrice(double price) =>
-      'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
+  String get _displayNumber {
+    if (order.orderNumber.isNotEmpty) return 'Pedido ${order.orderNumber}';
+    final short = order.id.length > 8 ? order.id.substring(0, 8).toUpperCase() : order.id;
+    return 'Pedido #$short';
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 156,
-      decoration: BoxDecoration(
-        color: const Color(0xFFF4F4F4),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Stack(
-        children: [
-          // Order number (top-left)
-          Positioned(
-            top: 8,
-            left: 8,
-            child: Text(
-              'Pedido #${order.id}',
-              style: const TextStyle(
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w500,
-                fontSize: 12,
-                color: AppColors.placeholder,
-              ),
+    return GestureDetector(
+      onTap: () => context.push('/customer/orders/${order.id}'),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: const Color(0xFFEEF2EE)),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x0A000000),
+              blurRadius: 8,
+              offset: Offset(0, 2),
             ),
-          ),
-          // Date (top-right)
-          Positioned(
-            top: 8,
-            right: 8,
-            child: Text(
-              _formatDate(order.createdAt),
-              style: const TextStyle(
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w500,
-                fontSize: 10,
-                color: AppColors.black,
-              ),
-            ),
-          ),
-          // Status badge
-          Positioned(
-            top: 28,
-            right: 8,
-            child: OrderStatusBadge(status: order.status),
-          ),
-          // Producer info
-          Positioned(
-            top: 27,
-            left: 8,
-            child: Row(
+          ],
+        ),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Row 1: order number + date
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                CircleAvatar(
-                  radius: 17,
-                  backgroundColor: AppColors.lightGreen.withValues(alpha: 0.2),
-                  backgroundImage: order.farmAvatarUrl.isNotEmpty
-                      ? NetworkImage(order.farmAvatarUrl)
-                      : null,
-                  child: order.farmAvatarUrl.isEmpty
-                      ? const Icon(
-                          Icons.storefront,
-                          size: 16,
-                          color: AppColors.lightGreen,
-                        )
-                      : null,
+                Text(
+                  _displayNumber,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 13,
+                    color: AppColors.darkGreen,
+                  ),
                 ),
-                const SizedBox(width: 8),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      order.farmName,
-                      style: const TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w700,
-                        fontSize: 14,
-                      ),
-                    ),
-                    Text(
-                      order.ownerName,
-                      style: const TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w200,
-                        fontSize: 12,
-                      ),
-                    ),
-                  ],
+                Text(
+                  _formatDate(order.createdAt),
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 11,
+                    color: AppColors.placeholder,
+                  ),
                 ),
               ],
             ),
-          ),
-          // Items preview
-          Positioned(
-            top: 75,
-            left: 8,
-            right: 8,
-            child: Text(
-              order.shortItemsPreview,
-              style: const TextStyle(
-                fontFamily: 'Manrope',
-                fontSize: 14,
-                color: AppColors.black,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+            const SizedBox(height: 12),
+
+            // Row 2: avatar + farm/owner names + status badge
+            Row(
+              children: [
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: AppColors.lightGreen.withValues(alpha: 0.15),
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: order.farmAvatarUrl.isNotEmpty
+                      ? Image.network(
+                          order.farmAvatarUrl,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => const Center(
+                            child: Icon(
+                              Icons.storefront,
+                              size: 20,
+                              color: AppColors.lightGreen,
+                            ),
+                          ),
+                        )
+                      : const Center(
+                          child: Icon(
+                            Icons.storefront,
+                            size: 20,
+                            color: AppColors.lightGreen,
+                          ),
+                        ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        order.farmName,
+                        style: const TextStyle(
+                          fontFamily: 'Manrope',
+                          fontWeight: FontWeight.w700,
+                          fontSize: 15,
+                          color: AppColors.black,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      if (order.ownerName.isNotEmpty)
+                        Text(
+                          order.ownerName,
+                          style: const TextStyle(
+                            fontFamily: 'Manrope',
+                            fontWeight: FontWeight.w400,
+                            fontSize: 12,
+                            color: AppColors.placeholder,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                OrderStatusBadge(status: order.status),
+              ],
             ),
-          ),
-          // Bottom row: total + button
-          Positioned(
-            bottom: 8,
-            left: 8,
-            right: 8,
-            child: Row(
+
+            if (order.shortItemsPreview.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              // Row 3: items preview
+              Text(
+                order.shortItemsPreview,
+                style: const TextStyle(
+                  fontFamily: 'Manrope',
+                  fontSize: 13,
+                  color: AppColors.black,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+
+            const SizedBox(height: 14),
+
+            // Row 4: total + button
+            Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.end,
               children: [
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -140,48 +165,58 @@ class OrderCard extends StatelessWidget {
                     const Text(
                       'Total do Pedido',
                       style: TextStyle(
-                        fontFamily: 'Figtree',
-                        fontWeight: FontWeight.w300,
+                        fontFamily: 'Manrope',
+                        fontWeight: FontWeight.w400,
                         fontSize: 12,
+                        color: AppColors.placeholder,
                       ),
                     ),
+                    const SizedBox(height: 2),
                     Text(
-                      _formatPrice(order.totalAmount),
+                      'R\$ ${order.totalAmount.toStringAsFixed(2).replaceAll('.', ',')}',
                       style: const TextStyle(
-                        fontFamily: 'Figtree',
+                        fontFamily: 'Manrope',
                         fontWeight: FontWeight.w700,
-                        fontSize: 12,
+                        fontSize: 15,
                         color: AppColors.darkGreen,
                       ),
                     ),
                   ],
                 ),
-                GestureDetector(
-                  onTap: () => context.push('/customer/orders/${order.id}'),
-                  child: Container(
-                    height: 30,
-                    padding: const EdgeInsets.symmetric(horizontal: 10),
-                    decoration: BoxDecoration(
-                      color: AppColors.darkGreen,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: const Center(
-                      child: Text(
-                        'Ver pedido',
-                        style: TextStyle(
-                          fontFamily: 'Manrope',
-                          fontWeight: FontWeight.w700,
-                          fontSize: 14,
-                          color: AppColors.white,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+                _VerPedidoButton(orderId: order.id),
               ],
             ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VerPedidoButton extends StatelessWidget {
+  const _VerPedidoButton({required this.orderId});
+
+  final String orderId;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => context.push('/customer/orders/$orderId'),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+        decoration: BoxDecoration(
+          color: AppColors.darkGreen,
+          borderRadius: BorderRadius.circular(22),
+        ),
+        child: const Text(
+          'Ver pedido',
+          style: TextStyle(
+            fontFamily: 'Manrope',
+            fontWeight: FontWeight.w700,
+            fontSize: 13,
+            color: Colors.white,
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/features/orders/presentation/widgets/order_status_badge.dart
+++ b/lib/features/orders/presentation/widgets/order_status_badge.dart
@@ -15,33 +15,35 @@ class OrderStatusBadge extends StatelessWidget {
     OrderStatus.cancelled => AppColors.red,
   };
 
+  IconData get _icon => switch (status) {
+    OrderStatus.pending => Icons.schedule,
+    OrderStatus.accepted => Icons.check_circle_outline,
+    OrderStatus.inDelivery => Icons.local_shipping_outlined,
+    OrderStatus.delivered => Icons.check_circle,
+    OrderStatus.cancelled => Icons.cancel_outlined,
+  };
+
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
       decoration: BoxDecoration(
         color: _backgroundColor,
-        borderRadius: BorderRadius.circular(6),
+        borderRadius: BorderRadius.circular(20),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (status != OrderStatus.cancelled) ...[
-            const Icon(
-              Icons.check_circle_outline,
-              color: Colors.white,
-              size: 12,
-            ),
-            const SizedBox(width: 4),
-          ],
+          Icon(_icon, color: Colors.white, size: 13),
+          const SizedBox(width: 5),
           Text(
-            status.label,
+            status.label.toUpperCase(),
             style: const TextStyle(
               fontFamily: 'Manrope',
-              fontWeight: FontWeight.w500,
-              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              fontSize: 11,
               color: Colors.white,
-              letterSpacing: 0.6,
+              letterSpacing: 0.5,
             ),
           ),
         ],

--- a/lib/features/orders/presentation/widgets/order_status_badge.dart
+++ b/lib/features/orders/presentation/widgets/order_status_badge.dart
@@ -10,6 +10,7 @@ class OrderStatusBadge extends StatelessWidget {
   Color get _backgroundColor => switch (status) {
     OrderStatus.pending => const Color(0xFFFFB413),
     OrderStatus.accepted => AppColors.lightGreen,
+    OrderStatus.inDelivery => AppColors.lightGreen,
     OrderStatus.delivered => const Color(0xFF3B82F6),
     OrderStatus.cancelled => AppColors.red,
   };

--- a/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
+++ b/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
@@ -1,310 +1,97 @@
+import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/network/api_client.dart';
+import 'package:ragro_mobile/core/network/api_endpoints.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/producer_orders/data/models/producer_order_model.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
-import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_item.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
 
 @lazySingleton
 class ProducerOrdersRemoteDataSource {
-  static final List<ProducerOrder> _mockOrders = [
-    ProducerOrder(
-      id: 'po001',
-      consumerName: 'João Silva',
-      consumerAvatarUrl: '',
-      consumerSince: 'Janeiro de 2025',
-      status: ProducerOrderStatus.pending,
-      totalPrice: 47.80,
-      deliveryAddress: 'Rua das Flores, 123',
-      deliveryNeighborhood: 'Bairro Jardim',
-      deliveryCityState: 'Porto Alegre, RS',
-      deliveryComplement: 'Apto 42',
-      items: const [
-        ProducerOrderItem(
-          productId: 'p001',
-          name: 'Tomate Cereja Orgânico',
-          imageUrl: '',
-          unitPrice: 2.50,
-          totalPrice: 25,
-          quantity: 10,
-          unityType: 'kg',
-        ),
-        ProducerOrderItem(
-          productId: 'p002',
-          name: 'Couve Manteiga',
-          imageUrl: '',
-          unitPrice: 4.90,
-          totalPrice: 14.70,
-          quantity: 3,
-          unityType: 'maço',
-        ),
-        ProducerOrderItem(
-          productId: 'p003',
-          name: 'Batata Monalisa',
-          imageUrl: '',
-          unitPrice: 8.20,
-          totalPrice: 8.20,
-          quantity: 1,
-          unityType: 'kg',
-        ),
-      ],
-      createdAt: DateTime.now().subtract(const Duration(hours: 1)),
-      isNew: true,
-      consumerPhone: '51999990001',
-    ),
-    ProducerOrder(
-      id: 'po002',
-      consumerName: 'Maria Costa',
-      consumerAvatarUrl: '',
-      consumerSince: 'Março de 2024',
-      status: ProducerOrderStatus.accepted,
-      totalPrice: 32.60,
-      deliveryAddress: 'Av. Independência, 456',
-      deliveryNeighborhood: 'Bom Fim',
-      deliveryCityState: 'Porto Alegre, RS',
-      deliveryComplement: '',
-      items: const [
-        ProducerOrderItem(
-          productId: 'p001',
-          name: 'Tomate Cereja Orgânico',
-          imageUrl: '',
-          unitPrice: 2.50,
-          totalPrice: 12.50,
-          quantity: 5,
-          unityType: 'kg',
-        ),
-        ProducerOrderItem(
-          productId: 'p002',
-          name: 'Couve Manteiga',
-          imageUrl: '',
-          unitPrice: 4.90,
-          totalPrice: 9.80,
-          quantity: 2,
-          unityType: 'maço',
-        ),
-        ProducerOrderItem(
-          productId: 'p003',
-          name: 'Batata Monalisa',
-          imageUrl: '',
-          unitPrice: 8.20,
-          totalPrice: 8.20,
-          quantity: 1,
-          unityType: 'kg',
-        ),
-      ],
-      createdAt: DateTime.now().subtract(const Duration(hours: 3)),
-      isNew: false,
-      consumerPhone: '51999990002',
-    ),
-    ProducerOrder(
-      id: 'po003',
-      consumerName: 'Carlos Mendes',
-      consumerAvatarUrl: '',
-      consumerSince: 'Junho de 2024',
-      status: ProducerOrderStatus.inDelivery,
-      totalPrice: 19.60,
-      deliveryAddress: 'Rua Osvaldo Aranha, 789',
-      deliveryNeighborhood: 'Bom Fim',
-      deliveryCityState: 'Porto Alegre, RS',
-      deliveryComplement: 'Casa 2',
-      items: const [
-        ProducerOrderItem(
-          productId: 'p002',
-          name: 'Couve Manteiga',
-          imageUrl: '',
-          unitPrice: 4.90,
-          totalPrice: 9.80,
-          quantity: 2,
-          unityType: 'maço',
-        ),
-        ProducerOrderItem(
-          productId: 'p003',
-          name: 'Batata Monalisa',
-          imageUrl: '',
-          unitPrice: 8.20,
-          totalPrice: 8.20,
-          quantity: 1,
-          unityType: 'kg',
-        ),
-      ],
-      createdAt: DateTime.now().subtract(const Duration(hours: 5)),
-      isNew: false,
-      consumerPhone: '51999990003',
-    ),
-    ProducerOrder(
-      id: 'po004',
-      consumerName: 'Ana Souza',
-      consumerAvatarUrl: '',
-      consumerSince: 'Novembro de 2023',
-      status: ProducerOrderStatus.delivered,
-      totalPrice: 56.40,
-      deliveryAddress: 'Rua 24 de Outubro, 200',
-      deliveryNeighborhood: 'Moinhos de Vento',
-      deliveryCityState: 'Porto Alegre, RS',
-      deliveryComplement: 'Apto 301',
-      items: const [
-        ProducerOrderItem(
-          productId: 'p001',
-          name: 'Tomate Cereja Orgânico',
-          imageUrl: '',
-          unitPrice: 2.50,
-          totalPrice: 25,
-          quantity: 10,
-          unityType: 'kg',
-        ),
-        ProducerOrderItem(
-          productId: 'p002',
-          name: 'Couve Manteiga',
-          imageUrl: '',
-          unitPrice: 4.90,
-          totalPrice: 24.50,
-          quantity: 5,
-          unityType: 'maço',
-        ),
-        ProducerOrderItem(
-          productId: 'p003',
-          name: 'Batata Monalisa',
-          imageUrl: '',
-          unitPrice: 8.20,
-          totalPrice: 8.20,
-          quantity: 1,
-          unityType: 'kg',
-        ),
-      ],
-      createdAt: DateTime.now().subtract(const Duration(hours: 24)),
-      isNew: false,
-      consumerPhone: '51999990004',
-    ),
-  ];
+  const ProducerOrdersRemoteDataSource(this._apiClient);
 
-  /// Gets producer orders, optionally filtered by [status].
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<List<ProducerOrder>>` getOrders({ProducerOrderStatus? status}) async {
-  ///   try {
-  ///     final response = await _apiClient.dio.get`<Map<String, dynamic>>`(
-  ///       ApiEndpoints.producerOrders,
-  ///       queryParameters: {
-  ///         if (status != null) 'status': status.name,
-  ///       },
-  ///     );
-  ///     return (response.data!['data'] as List)
-  ///         .map((e) => ProducerOrder.fromJson(e as `Map<String, dynamic>`))
-  ///         .toList();
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
+  final ApiClient _apiClient;
+
   Future<List<ProducerOrder>> getOrders({ProducerOrderStatus? status}) async {
-    await Future<void>.delayed(const Duration(milliseconds: 400));
-    if (status == null) return List.from(_mockOrders);
-    return _mockOrders.where((o) => o.status == status).toList();
+    try {
+      final response = await _apiClient.dio.get<dynamic>(
+        ApiEndpoints.producerOrders,
+        queryParameters: {
+          if (status != null) 'status': _statusQueryValue(status),
+        },
+      );
+
+      return _readList(response.data).map(ProducerOrderModel.fromJson).toList();
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
   }
 
-  /// Gets a single producer order by [id].
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<ProducerOrder>` getOrderById(String id) async {
-  ///   try {
-  ///     final response = await _apiClient.dio.get`<Map<String, dynamic>>`(
-  ///       '${ApiEndpoints.producerOrders}/$id',
-  ///     );
-  ///     return ProducerOrder.fromJson(response.data!);
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<ProducerOrder> getOrderById(String id) async {
-    await Future<void>.delayed(const Duration(milliseconds: 300));
-    return _mockOrders.firstWhere((o) => o.id == id);
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        ApiEndpoints.producerOrder(id),
+      );
+
+      return ProducerOrderModel.fromJson(response.data!);
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
   }
 
-  /// Confirms a producer order (accept it).
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<void>` confirmOrder(String id) async {
-  ///   try {
-  ///     await _apiClient.dio.post`<void>`(
-  ///       ApiEndpoints.producerOrderConfirm(id),
-  ///     );
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<void> confirmOrder(String id) async {
-    await Future<void>.delayed(const Duration(milliseconds: 300));
-    final idx = _mockOrders.indexWhere((o) => o.id == id);
-    if (idx >= 0) {
-      _mockOrders[idx] = _mockOrders[idx].copyWith(
-        status: ProducerOrderStatus.accepted,
-        isNew: false,
-      );
+    try {
+      await _apiClient.dio.patch<void>(ApiEndpoints.producerOrderConfirm(id));
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
     }
   }
 
-  /// Refuses/cancels a producer order.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<void>` refuseOrder(String id) async {
-  ///   try {
-  ///     await _apiClient.dio.post`<void>`(
-  ///       ApiEndpoints.producerOrderCancel(id),
-  ///     );
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<void> refuseOrder(String id) async {
-    await Future<void>.delayed(const Duration(milliseconds: 300));
-    final idx = _mockOrders.indexWhere((o) => o.id == id);
-    if (idx >= 0) {
-      _mockOrders[idx] = _mockOrders[idx].copyWith(
-        status: ProducerOrderStatus.cancelled,
+    try {
+      await _apiClient.dio.patch<void>(
+        ApiEndpoints.producerOrderStatus(id),
+        data: {'status': 'CANCELLED'},
       );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
     }
   }
 
-  /// Updates the status of a producer order.
-  ///
-  /// === REAL IMPLEMENTATION (uncomment when backend is ready) ===
-  ///
-  /// Future`<void>` updateStatus(String id, ProducerOrderStatus status) async {
-  ///   try {
-  ///     await _apiClient.dio.patch`<void>`(
-  ///       ApiEndpoints.producerOrderStatus(id),
-  ///       data: {'status': status.name},
-  ///     );
-  ///   } on DioException catch (e) {
-  ///     throw e.error as ApiException? ?? const UnknownApiException();
-  ///   }
-  /// }
-  ///
-  /// === END REAL IMPLEMENTATION ===
-  ///
-  /// MOCK TEMPORÁRIO — remover quando backend estiver conectado:
   Future<void> updateStatus(String id, ProducerOrderStatus status) async {
-    await Future<void>.delayed(const Duration(milliseconds: 300));
-    final idx = _mockOrders.indexWhere((o) => o.id == id);
-    if (idx >= 0) {
-      _mockOrders[idx] = _mockOrders[idx].copyWith(status: status);
+    try {
+      await _apiClient.dio.patch<void>(
+        ApiEndpoints.producerOrderStatus(id),
+        data: {'status': _statusQueryValue(status)},
+      );
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
     }
+  }
+
+  List<Map<String, dynamic>> _readList(dynamic data) {
+    final rawList = switch (data) {
+      final List<dynamic> list => list,
+      final Map<String, dynamic> map when map['data'] is List<dynamic> =>
+        map['data'] as List<dynamic>,
+      final Map<String, dynamic> map when map['content'] is List<dynamic> =>
+        map['content'] as List<dynamic>,
+      final Map<String, dynamic> map when map['items'] is List<dynamic> =>
+        map['items'] as List<dynamic>,
+      _ => const <dynamic>[],
+    };
+
+    return rawList.whereType<Map<String, dynamic>>().toList();
+  }
+
+  String _statusQueryValue(ProducerOrderStatus status) {
+    return switch (status) {
+      ProducerOrderStatus.pending => 'pending',
+      ProducerOrderStatus.accepted => 'confirmed',
+      ProducerOrderStatus.inDelivery => 'IN_DELIVERY',
+      ProducerOrderStatus.delivered => 'DELIVERED',
+      ProducerOrderStatus.cancelled => 'cancelled',
+    };
   }
 }

--- a/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
+++ b/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
@@ -48,11 +48,11 @@ class ProducerOrdersRemoteDataSource {
     }
   }
 
-  Future<void> refuseOrder(String id) async {
+  Future<void> refuseOrder(String id, {required String reason, String? details}) async {
     try {
       await _apiClient.dio.patch<void>(
-        ApiEndpoints.producerOrderStatus(id),
-        data: {'status': 'CANCELLED'},
+        ApiEndpoints.producerOrderCancel(id),
+        data: {'reason': reason, if (details != null) 'details': details},
       );
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();

--- a/lib/features/producer_orders/data/models/producer_order_item_model.dart
+++ b/lib/features/producer_orders/data/models/producer_order_item_model.dart
@@ -1,0 +1,42 @@
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_item.dart';
+
+class ProducerOrderItemModel extends ProducerOrderItem {
+  const ProducerOrderItemModel({
+    required super.productId,
+    required super.name,
+    required super.imageUrl,
+    required super.unitPrice,
+    required super.totalPrice,
+    required super.quantity,
+    required super.unityType,
+  });
+
+  factory ProducerOrderItemModel.fromJson(Map<String, dynamic> json) {
+    final quantity = json['quantity'] as num? ?? 0;
+
+    return ProducerOrderItemModel(
+      productId:
+          json['productId'] as String? ?? json['product_id'] as String? ?? '',
+      name: json['productName'] as String? ?? json['name'] as String? ?? '',
+      imageUrl:
+          json['imageUrl'] as String? ??
+          json['imageS3'] as String? ??
+          json['productPhoto'] as String? ??
+          '',
+      unitPrice: (json['unitPrice'] as num? ?? json['unit_price'] as num? ?? 0)
+          .toDouble(),
+      totalPrice:
+          (json['subtotal'] as num? ??
+                  json['totalPrice'] as num? ??
+                  json['total'] as num? ??
+                  0)
+              .toDouble(),
+      quantity: quantity.toInt(),
+      unityType:
+          json['unityType'] as String? ??
+          json['unit'] as String? ??
+          json['unity_type'] as String? ??
+          '',
+    );
+  }
+}

--- a/lib/features/producer_orders/data/models/producer_order_model.dart
+++ b/lib/features/producer_orders/data/models/producer_order_model.dart
@@ -1,0 +1,113 @@
+import 'package:ragro_mobile/features/producer_orders/data/models/producer_order_item_model.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
+
+class ProducerOrderModel extends ProducerOrder {
+  const ProducerOrderModel({
+    required super.id,
+    required super.consumerName,
+    required super.consumerAvatarUrl,
+    required super.consumerSince,
+    required super.status,
+    required super.totalPrice,
+    required super.deliveryAddress,
+    required super.deliveryNeighborhood,
+    required super.deliveryCityState,
+    required super.deliveryComplement,
+    required super.items,
+    required super.createdAt,
+    required super.isNew,
+    required super.consumerPhone,
+  });
+
+  factory ProducerOrderModel.fromJson(Map<String, dynamic> json) {
+    final consumer =
+        json['consumer'] as Map<String, dynamic>? ??
+        json['customer'] as Map<String, dynamic>?;
+    final address =
+        json['deliveryAddress'] as Map<String, dynamic>? ??
+        json['address'] as Map<String, dynamic>? ??
+        const <String, dynamic>{};
+    final itemsJson = (json['items'] as List<dynamic>? ?? [])
+        .whereType<Map<String, dynamic>>()
+        .toList();
+
+    return ProducerOrderModel(
+      id: json['id'] as String? ?? '',
+      consumerName:
+          json['consumerName'] as String? ??
+          json['customerName'] as String? ??
+          consumer?['name'] as String? ??
+          '',
+      consumerAvatarUrl:
+          json['consumerAvatarUrl'] as String? ??
+          json['customerPhoto'] as String? ??
+          consumer?['photoUrl'] as String? ??
+          '',
+      consumerSince:
+          json['consumerSince'] as String? ??
+          consumer?['memberSince'] as String? ??
+          '',
+      status: _parseStatus(json['status'] as String?),
+      totalPrice:
+          (json['total'] as num? ??
+                  json['totalPrice'] as num? ??
+                  json['totalAmount'] as num? ??
+                  0)
+              .toDouble(),
+      deliveryAddress: _street(address),
+      deliveryNeighborhood:
+          address['neighborhood'] as String? ??
+          address['district'] as String? ??
+          '',
+      deliveryCityState: _cityState(address),
+      deliveryComplement: address['complement'] as String? ?? '',
+      items: itemsJson.map(ProducerOrderItemModel.fromJson).toList(),
+      createdAt: _parseDate(json['createdAt'] as String?),
+      isNew: json['isNew'] as bool? ?? _isNew(json['createdAt'] as String?),
+      consumerPhone:
+          json['consumerPhone'] as String? ??
+          json['customerPhone'] as String? ??
+          consumer?['phone'] as String? ??
+          '',
+    );
+  }
+
+  static ProducerOrderStatus _parseStatus(String? status) {
+    return switch (status?.trim().toUpperCase()) {
+      'CONFIRMED' || 'ACCEPTED' => ProducerOrderStatus.accepted,
+      'OUT_FOR_DELIVERY' ||
+      'INDELIVERY' ||
+      'IN_DELIVERY' => ProducerOrderStatus.inDelivery,
+      'DELIVERED' => ProducerOrderStatus.delivered,
+      'CANCELLED' || 'CANCELED' => ProducerOrderStatus.cancelled,
+      _ => ProducerOrderStatus.pending,
+    };
+  }
+
+  static DateTime _parseDate(String? value) {
+    if (value == null || value.isEmpty) return DateTime.now();
+    return DateTime.tryParse(value)?.toLocal() ?? DateTime.now();
+  }
+
+  static bool _isNew(String? value) {
+    final createdAt = DateTime.tryParse(value ?? '')?.toLocal();
+    if (createdAt == null) return false;
+    return DateTime.now().difference(createdAt) < const Duration(hours: 2);
+  }
+
+  static String _street(Map<String, dynamic> json) {
+    final street = json['street'] as String? ?? '';
+    final number = json['number'] as String? ?? '';
+    if (number.isEmpty) return street;
+    return '$street, $number';
+  }
+
+  static String _cityState(Map<String, dynamic> json) {
+    final city = json['city'] as String? ?? '';
+    final state = json['state'] as String? ?? '';
+    if (city.isEmpty) return state;
+    if (state.isEmpty) return city;
+    return '$city, $state';
+  }
+}

--- a/lib/features/producer_orders/data/repositories/producer_orders_repository_impl.dart
+++ b/lib/features/producer_orders/data/repositories/producer_orders_repository_impl.dart
@@ -21,7 +21,8 @@ class ProducerOrdersRepositoryImpl implements ProducerOrdersRepository {
   Future<void> confirmOrder(String id) => _dataSource.confirmOrder(id);
 
   @override
-  Future<void> refuseOrder(String id) => _dataSource.refuseOrder(id);
+  Future<void> refuseOrder(String id, {required String reason, String? details}) =>
+      _dataSource.refuseOrder(id, reason: reason, details: details);
 
   @override
   Future<void> updateStatus(String id, ProducerOrderStatus status) =>

--- a/lib/features/producer_orders/domain/repositories/producer_orders_repository.dart
+++ b/lib/features/producer_orders/domain/repositories/producer_orders_repository.dart
@@ -5,6 +5,6 @@ abstract class ProducerOrdersRepository {
   Future<List<ProducerOrder>> getOrders({ProducerOrderStatus? status});
   Future<ProducerOrder> getOrderById(String id);
   Future<void> confirmOrder(String id);
-  Future<void> refuseOrder(String id);
+  Future<void> refuseOrder(String id, {required String reason, String? details});
   Future<void> updateStatus(String id, ProducerOrderStatus status);
 }

--- a/lib/features/producer_orders/domain/usecases/refuse_producer_order.dart
+++ b/lib/features/producer_orders/domain/usecases/refuse_producer_order.dart
@@ -7,5 +7,6 @@ class RefuseProducerOrder {
 
   final ProducerOrdersRepository _repository;
 
-  Future<void> call(String id) => _repository.refuseOrder(id);
+  Future<void> call(String id, {required String reason, String? details}) =>
+      _repository.refuseOrder(id, reason: reason, details: details);
 }

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
@@ -72,7 +72,7 @@ class ProducerOrderDetailBloc
     if (current is! ProducerOrderDetailLoaded) return;
     emit(ProducerOrderDetailRefusing(current.order));
     try {
-      await _refuseOrder(event.orderId);
+      await _refuseOrder(event.orderId, reason: event.reason, details: event.details);
       final updated = current.order.copyWith(
         status: ProducerOrderStatus.cancelled,
       );

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/confirm_producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/get_producer_order_detail.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/refuse_producer_order.dart';
@@ -31,6 +32,10 @@ class ProducerOrderDetailBloc
     ProducerOrderDetailStarted event,
     Emitter<ProducerOrderDetailState> emit,
   ) async {
+    if (event.initialOrder != null) {
+      emit(ProducerOrderDetailLoaded(event.initialOrder!));
+      return;
+    }
     emit(const ProducerOrderDetailLoading());
     try {
       final order = await _getDetail(event.orderId);
@@ -49,7 +54,9 @@ class ProducerOrderDetailBloc
     emit(ProducerOrderDetailConfirming(current.order));
     try {
       await _confirmOrder(event.orderId);
-      final updated = await _getDetail(event.orderId);
+      final updated = current.order.copyWith(
+        status: ProducerOrderStatus.accepted,
+      );
       emit(ProducerOrderDetailSuccess(order: updated, action: 'confirmed'));
       emit(ProducerOrderDetailLoaded(updated));
     } on Exception catch (e) {
@@ -66,7 +73,9 @@ class ProducerOrderDetailBloc
     emit(ProducerOrderDetailRefusing(current.order));
     try {
       await _refuseOrder(event.orderId);
-      final updated = await _getDetail(event.orderId);
+      final updated = current.order.copyWith(
+        status: ProducerOrderStatus.cancelled,
+      );
       emit(ProducerOrderDetailSuccess(order: updated, action: 'refused'));
       emit(ProducerOrderDetailLoaded(updated));
     } on Exception catch (e) {
@@ -83,7 +92,7 @@ class ProducerOrderDetailBloc
     emit(ProducerOrderDetailUpdatingStatus(current.order));
     try {
       await _updateStatus(event.orderId, event.status);
-      final updated = await _getDetail(event.orderId);
+      final updated = current.order.copyWith(status: event.status);
       emit(
         ProducerOrderDetailSuccess(order: updated, action: 'status_updated'),
       );

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_event.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_event.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
 
 sealed class ProducerOrderDetailEvent extends Equatable {
@@ -8,10 +9,11 @@ sealed class ProducerOrderDetailEvent extends Equatable {
 }
 
 class ProducerOrderDetailStarted extends ProducerOrderDetailEvent {
-  const ProducerOrderDetailStarted(this.orderId);
+  const ProducerOrderDetailStarted(this.orderId, {this.initialOrder});
   final String orderId;
+  final ProducerOrder? initialOrder;
   @override
-  List<Object?> get props => [orderId];
+  List<Object?> get props => [orderId, initialOrder];
 }
 
 class ProducerOrderDetailConfirmed extends ProducerOrderDetailEvent {

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_event.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_event.dart
@@ -24,10 +24,12 @@ class ProducerOrderDetailConfirmed extends ProducerOrderDetailEvent {
 }
 
 class ProducerOrderDetailRefused extends ProducerOrderDetailEvent {
-  const ProducerOrderDetailRefused(this.orderId);
+  const ProducerOrderDetailRefused(this.orderId, {required this.reason, this.details});
   final String orderId;
+  final String reason;
+  final String? details;
   @override
-  List<Object?> get props => [orderId];
+  List<Object?> get props => [orderId, reason, details];
 }
 
 class ProducerOrderDetailStatusUpdated extends ProducerOrderDetailEvent {

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
@@ -94,7 +94,7 @@ class ProducerOrdersBloc
 
     emit(ProducerOrdersLoading(_activeTab));
     try {
-      await _refuseProducerOrder(event.orderId);
+      await _refuseProducerOrder(event.orderId, reason: event.reason, details: event.details);
       final updated = currentOrders
           .map(
             (o) => o.id == event.orderId

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
@@ -1,21 +1,37 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/usecases/confirm_producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/get_producer_orders.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/usecases/refuse_producer_order.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/usecases/update_producer_order_status.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_event.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_state.dart';
 
 @injectable
 class ProducerOrdersBloc
     extends Bloc<ProducerOrdersEvent, ProducerOrdersState> {
-  ProducerOrdersBloc(this._getProducerOrders)
-    : super(const ProducerOrdersInitial()) {
+  ProducerOrdersBloc(
+    this._getProducerOrders,
+    this._confirmProducerOrder,
+    this._refuseProducerOrder,
+    this._updateProducerOrderStatus,
+  ) : super(const ProducerOrdersInitial()) {
     on<ProducerOrdersStarted>(_onStarted);
     on<ProducerOrdersTabChanged>(_onTabChanged);
     on<ProducerOrdersRefreshed>(_onRefreshed);
+    on<ProducerOrderAccepted>(_onAccepted);
+    on<ProducerOrderCancelled>(_onCancelled);
+    on<ProducerOrderLocallyRefused>(_onLocallyRefused);
+    on<ProducerOrderMarkedInDelivery>(_onMarkedInDelivery);
+    on<ProducerOrderDeliveryConfirmed>(_onDeliveryConfirmed);
+    on<ProducerOrderLocallyDelivered>(_onLocallyDelivered);
   }
 
   final GetProducerOrders _getProducerOrders;
+  final ConfirmProducerOrder _confirmProducerOrder;
+  final RefuseProducerOrder _refuseProducerOrder;
+  final UpdateProducerOrderStatus _updateProducerOrderStatus;
   ProducerOrderStatus _activeTab = ProducerOrderStatus.pending;
 
   Future<void> _onStarted(
@@ -23,13 +39,7 @@ class ProducerOrdersBloc
     Emitter<ProducerOrdersState> emit,
   ) async {
     _activeTab = event.tab;
-    emit(ProducerOrdersLoading(_activeTab));
-    try {
-      final orders = await _getProducerOrders(status: _activeTab);
-      emit(ProducerOrdersLoaded(orders: orders, activeTab: _activeTab));
-    } on Exception catch (e) {
-      emit(ProducerOrdersFailure(e.toString()));
-    }
+    await _reload(emit);
   }
 
   Future<void> _onTabChanged(
@@ -37,22 +47,177 @@ class ProducerOrdersBloc
     Emitter<ProducerOrdersState> emit,
   ) async {
     _activeTab = event.tab;
-    emit(ProducerOrdersLoading(_activeTab));
-    try {
-      final orders = await _getProducerOrders(status: _activeTab);
-      emit(ProducerOrdersLoaded(orders: orders, activeTab: _activeTab));
-    } on Exception catch (e) {
-      emit(ProducerOrdersFailure(e.toString()));
+    final current = state;
+    if (current is ProducerOrdersLoaded) {
+      emit(ProducerOrdersLoaded(orders: current.orders, activeTab: _activeTab));
+      return;
     }
+    await _reload(emit);
   }
 
   Future<void> _onRefreshed(
     ProducerOrdersRefreshed event,
     Emitter<ProducerOrdersState> emit,
   ) async {
+    await _reload(emit);
+  }
+
+  Future<void> _onAccepted(
+    ProducerOrderAccepted event,
+    Emitter<ProducerOrdersState> emit,
+  ) async {
     emit(ProducerOrdersLoading(_activeTab));
     try {
-      final orders = await _getProducerOrders(status: _activeTab);
+      await _confirmProducerOrder(event.orderId);
+      final orders = await _getProducerOrders();
+      emit(ProducerOrdersActionSuccess(
+        message: 'Pedido aceito com sucesso.',
+        orders: orders,
+        activeTab: _activeTab,
+      ));
+      emit(ProducerOrdersLoaded(orders: orders, activeTab: _activeTab));
+    } on Exception catch (e) {
+      emit(ProducerOrdersFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onCancelled(
+    ProducerOrderCancelled event,
+    Emitter<ProducerOrdersState> emit,
+  ) async {
+    final currentOrders = switch (state) {
+      ProducerOrdersLoaded(:final orders) => orders,
+      ProducerOrdersActionSuccess(:final orders) => orders,
+      _ => null,
+    };
+    if (currentOrders == null) return;
+
+    emit(ProducerOrdersLoading(_activeTab));
+    try {
+      await _refuseProducerOrder(event.orderId);
+      final updated = currentOrders
+          .map(
+            (o) => o.id == event.orderId
+                ? o.copyWith(status: ProducerOrderStatus.cancelled)
+                : o,
+          )
+          .toList();
+      emit(ProducerOrdersActionSuccess(
+        message: 'Pedido recusado com sucesso.',
+        orders: updated,
+        activeTab: _activeTab,
+      ));
+      emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));
+    } on Exception catch (e) {
+      emit(ProducerOrdersLoaded(orders: currentOrders, activeTab: _activeTab));
+      emit(ProducerOrdersFailure(e.toString()));
+    }
+  }
+
+  void _onLocallyRefused(
+    ProducerOrderLocallyRefused event,
+    Emitter<ProducerOrdersState> emit,
+  ) {
+    final currentOrders = switch (state) {
+      ProducerOrdersLoaded(:final orders) => orders,
+      ProducerOrdersActionSuccess(:final orders) => orders,
+      _ => null,
+    };
+    if (currentOrders == null) return;
+
+    final updated = currentOrders
+        .map(
+          (o) => o.id == event.orderId
+              ? o.copyWith(status: ProducerOrderStatus.cancelled)
+              : o,
+        )
+        .toList();
+    emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));
+  }
+
+  Future<void> _onMarkedInDelivery(
+    ProducerOrderMarkedInDelivery event,
+    Emitter<ProducerOrdersState> emit,
+  ) async {
+    emit(ProducerOrdersLoading(_activeTab));
+    try {
+      await _updateProducerOrderStatus(
+        event.orderId,
+        ProducerOrderStatus.inDelivery,
+      );
+      final orders = await _getProducerOrders();
+      emit(ProducerOrdersActionSuccess(
+        message: 'Entrega iniciada com sucesso.',
+        orders: orders,
+        activeTab: _activeTab,
+      ));
+      emit(ProducerOrdersLoaded(orders: orders, activeTab: _activeTab));
+    } on Exception catch (e) {
+      emit(ProducerOrdersFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onDeliveryConfirmed(
+    ProducerOrderDeliveryConfirmed event,
+    Emitter<ProducerOrdersState> emit,
+  ) async {
+    final currentOrders = switch (state) {
+      ProducerOrdersLoaded(:final orders) => orders,
+      ProducerOrdersActionSuccess(:final orders) => orders,
+      _ => null,
+    };
+    if (currentOrders == null) return;
+
+    emit(ProducerOrdersLoading(_activeTab));
+    try {
+      await _updateProducerOrderStatus(
+        event.orderId,
+        ProducerOrderStatus.delivered,
+      );
+      final updated = currentOrders
+          .map(
+            (o) => o.id == event.orderId
+                ? o.copyWith(status: ProducerOrderStatus.delivered)
+                : o,
+          )
+          .toList();
+      emit(ProducerOrdersActionSuccess(
+        message: 'Entrega confirmada com sucesso.',
+        orders: updated,
+        activeTab: _activeTab,
+      ));
+      emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));
+    } on Exception catch (e) {
+      emit(ProducerOrdersLoaded(orders: currentOrders, activeTab: _activeTab));
+      emit(ProducerOrdersFailure(e.toString()));
+    }
+  }
+
+  void _onLocallyDelivered(
+    ProducerOrderLocallyDelivered event,
+    Emitter<ProducerOrdersState> emit,
+  ) {
+    final currentOrders = switch (state) {
+      ProducerOrdersLoaded(:final orders) => orders,
+      ProducerOrdersActionSuccess(:final orders) => orders,
+      _ => null,
+    };
+    if (currentOrders == null) return;
+
+    final updated = currentOrders
+        .map(
+          (o) => o.id == event.orderId
+              ? o.copyWith(status: ProducerOrderStatus.delivered)
+              : o,
+        )
+        .toList();
+    emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));
+  }
+
+  Future<void> _reload(Emitter<ProducerOrdersState> emit) async {
+    emit(ProducerOrdersLoading(_activeTab));
+    try {
+      final orders = await _getProducerOrders();
       emit(ProducerOrdersLoaded(orders: orders, activeTab: _activeTab));
     } on Exception catch (e) {
       emit(ProducerOrdersFailure(e.toString()));

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
@@ -24,3 +24,57 @@ class ProducerOrdersTabChanged extends ProducerOrdersEvent {
 class ProducerOrdersRefreshed extends ProducerOrdersEvent {
   const ProducerOrdersRefreshed();
 }
+
+class ProducerOrderAccepted extends ProducerOrdersEvent {
+  const ProducerOrderAccepted(this.orderId);
+
+  final String orderId;
+
+  @override
+  List<Object?> get props => [orderId];
+}
+
+class ProducerOrderCancelled extends ProducerOrdersEvent {
+  const ProducerOrderCancelled(this.orderId);
+
+  final String orderId;
+
+  @override
+  List<Object?> get props => [orderId];
+}
+
+class ProducerOrderLocallyRefused extends ProducerOrdersEvent {
+  const ProducerOrderLocallyRefused(this.orderId);
+
+  final String orderId;
+
+  @override
+  List<Object?> get props => [orderId];
+}
+
+class ProducerOrderMarkedInDelivery extends ProducerOrdersEvent {
+  const ProducerOrderMarkedInDelivery(this.orderId);
+
+  final String orderId;
+
+  @override
+  List<Object?> get props => [orderId];
+}
+
+class ProducerOrderDeliveryConfirmed extends ProducerOrdersEvent {
+  const ProducerOrderDeliveryConfirmed(this.orderId);
+
+  final String orderId;
+
+  @override
+  List<Object?> get props => [orderId];
+}
+
+class ProducerOrderLocallyDelivered extends ProducerOrdersEvent {
+  const ProducerOrderLocallyDelivered(this.orderId);
+
+  final String orderId;
+
+  @override
+  List<Object?> get props => [orderId];
+}

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
@@ -35,12 +35,14 @@ class ProducerOrderAccepted extends ProducerOrdersEvent {
 }
 
 class ProducerOrderCancelled extends ProducerOrdersEvent {
-  const ProducerOrderCancelled(this.orderId);
+  const ProducerOrderCancelled(this.orderId, {required this.reason, this.details});
 
   final String orderId;
+  final String reason;
+  final String? details;
 
   @override
-  List<Object?> get props => [orderId];
+  List<Object?> get props => [orderId, reason, details];
 }
 
 class ProducerOrderLocallyRefused extends ProducerOrdersEvent {

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_state.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_state.dart
@@ -33,3 +33,16 @@ class ProducerOrdersFailure extends ProducerOrdersState {
   @override
   List<Object?> get props => [message];
 }
+
+class ProducerOrdersActionSuccess extends ProducerOrdersState {
+  const ProducerOrdersActionSuccess({
+    required this.message,
+    required this.orders,
+    required this.activeTab,
+  });
+  final String message;
+  final List<ProducerOrder> orders;
+  final ProducerOrderStatus activeTab;
+  @override
+  List<Object?> get props => [message, orders, activeTab];
+}

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -1,51 +1,63 @@
 // Screen: Producer Order Detail (Detalhes do Pedido - Produtor)
-// User Story: US-21 — View and Manage Order Detail
-// Epic: EPIC 4 — Producer Features
+// User Story: US-21 - View and Manage Order Detail
+// Epic: EPIC 4 - Producer Features
 // Routes: GET /orders/producer/:id
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_item.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_event.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_state.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class ProducerOrderDetailPage extends StatelessWidget {
-  const ProducerOrderDetailPage({required this.orderId, super.key});
+  const ProducerOrderDetailPage({
+    required this.orderId,
+    this.initialOrder,
+    super.key,
+  });
 
   final String orderId;
+  final ProducerOrder? initialOrder;
 
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) =>
           getIt<ProducerOrderDetailBloc>()
-            ..add(ProducerOrderDetailStarted(orderId)),
+            ..add(
+              ProducerOrderDetailStarted(orderId, initialOrder: initialOrder),
+            ),
       child: BlocConsumer<ProducerOrderDetailBloc, ProducerOrderDetailState>(
         listener: (context, state) {
           if (state is ProducerOrderDetailSuccess) {
-            final msg = switch (state.action) {
-              'confirmed' => 'Pedido aceito com sucesso!',
-              'refused' => 'Pedido recusado.',
-              'status_updated' => 'Status atualizado!',
+            if (state.action == 'status_updated') {
+              if (state.order.status == ProducerOrderStatus.delivered) {
+                context.pop('delivered');
+              } else {
+                context.pop('in_delivery');
+              }
+              return;
+            }
+            if (state.action == 'refused') {
+              context.pop('cancelled');
+              return;
+            }
+            final message = switch (state.action) {
+              'confirmed' => 'Pedido aceito com sucesso.',
               _ => 'Ação concluída.',
             };
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text(msg),
+                content: Text(message),
                 backgroundColor: AppColors.darkGreen,
-              ),
-            );
-          }
-          if (state is ProducerOrderDetailFailure) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(state.message),
-                backgroundColor: AppColors.red,
               ),
             );
           }
@@ -54,13 +66,14 @@ class ProducerOrderDetailPage extends StatelessWidget {
           if (state is ProducerOrderDetailLoading ||
               state is ProducerOrderDetailInitial) {
             return const Scaffold(
-              body: Center(
-                child: CircularProgressIndicator(color: AppColors.darkGreen),
-              ),
+              body: Center(child: Text('Carregando detalhes do pedido...')),
             );
           }
           if (state is ProducerOrderDetailFailure) {
-            return Scaffold(body: Center(child: Text(state.message)));
+            return _ProducerOrderErrorView(
+              orderId: orderId,
+              message: state.message,
+            );
           }
 
           final order = switch (state) {
@@ -71,7 +84,6 @@ class ProducerOrderDetailPage extends StatelessWidget {
             ProducerOrderDetailSuccess(:final order) => order,
             _ => null,
           };
-
           if (order == null) return const Scaffold();
 
           final isProcessing =
@@ -89,6 +101,60 @@ class ProducerOrderDetailPage extends StatelessWidget {
   }
 }
 
+class _ProducerOrderErrorView extends StatelessWidget {
+  const _ProducerOrderErrorView({required this.orderId, required this.message});
+
+  final String orderId;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.receipt_long_outlined,
+                  size: 56,
+                  color: AppColors.placeholder,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  message.toLowerCase().contains('404')
+                      ? 'Pedido não encontrado.'
+                      : 'Não foi possível carregar os detalhes do pedido.',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 16,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () => context.read<ProducerOrderDetailBloc>().add(
+                    ProducerOrderDetailStarted(orderId),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.darkGreen,
+                    foregroundColor: AppColors.white,
+                  ),
+                  child: const Text('Tentar novamente'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _ProducerOrderDetailView extends StatelessWidget {
   const _ProducerOrderDetailView({
     required this.order,
@@ -98,17 +164,6 @@ class _ProducerOrderDetailView extends StatelessWidget {
   final ProducerOrder order;
   final bool isProcessing;
 
-  String _formatPrice(double price) =>
-      'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
-
-  Color _statusColor(ProducerOrderStatus status) => switch (status) {
-    ProducerOrderStatus.pending => const Color(0xFFFFC107),
-    ProducerOrderStatus.accepted => AppColors.lightGreen,
-    ProducerOrderStatus.inDelivery => const Color(0xFF2196F3),
-    ProducerOrderStatus.delivered => AppColors.darkGreen,
-    ProducerOrderStatus.cancelled => AppColors.red,
-  };
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -117,360 +172,25 @@ class _ProducerOrderDetailView extends StatelessWidget {
         child: Stack(
           children: [
             SingleChildScrollView(
-              padding: const EdgeInsets.only(bottom: 140),
+              padding: const EdgeInsets.only(bottom: 190),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // AppBar area
-                  Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Row(
-                      children: [
-                        GestureDetector(
-                          onTap: () => context.pop(),
-                          child: const Padding(
-                            padding: EdgeInsets.all(8),
-                            child: Icon(Icons.arrow_back, size: 20),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            'Detalhes do Pedido\n#${order.id}',
-                            style: const TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 18,
-                              color: AppColors.black,
-                            ),
-                          ),
-                        ),
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 10,
-                            vertical: 4,
-                          ),
-                          decoration: BoxDecoration(
-                            color: _statusColor(
-                              order.status,
-                            ).withValues(alpha: 0.15),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Text(
-                            order.status.label.toUpperCase(),
-                            style: TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 11,
-                              color: _statusColor(order.status),
-                              letterSpacing: 0.5,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  // CLIENTE
-                  const Padding(
-                    padding: EdgeInsets.fromLTRB(16, 8, 16, 12),
-                    child: Text(
-                      'CLIENTE',
-                      style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w700,
-                        fontSize: 13,
-                        color: AppColors.darkGreen,
-                        letterSpacing: 1.4,
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Row(
-                      children: [
-                        CircleAvatar(
-                          radius: 28,
-                          backgroundColor: AppColors.darkGreen.withValues(
-                            alpha: 0.1,
-                          ),
-                          child: Text(
-                            order.consumerName.isNotEmpty
-                                ? order.consumerName[0]
-                                : '?',
-                            style: const TextStyle(
-                              fontFamily: 'Figtree',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 22,
-                              color: AppColors.darkGreen,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              order.consumerName,
-                              style: const TextStyle(
-                                fontFamily: 'Figtree',
-                                fontWeight: FontWeight.w700,
-                                fontSize: 18,
-                                color: AppColors.black,
-                              ),
-                            ),
-                            Text(
-                              'Cliente desde ${order.consumerSince}',
-                              style: const TextStyle(
-                                fontFamily: 'Manrope',
-                                fontSize: 13,
-                                color: AppColors.placeholder,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  const SizedBox(height: 24),
-
-                  // ITENS DO PEDIDO
-                  const Padding(
-                    padding: EdgeInsets.fromLTRB(16, 0, 16, 12),
-                    child: Text(
-                      'ITENS DO PEDIDO',
-                      style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w700,
-                        fontSize: 13,
-                        color: AppColors.darkGreen,
-                        letterSpacing: 1.4,
-                      ),
-                    ),
-                  ),
-                  Container(
-                    margin: const EdgeInsets.symmetric(horizontal: 16),
-                    decoration: BoxDecoration(
-                      color: AppColors.white,
-                      borderRadius: BorderRadius.circular(24),
-                      border: Border.all(
-                        color: AppColors.lightGreen.withValues(alpha: 0.1),
-                      ),
-                      boxShadow: const [
-                        BoxShadow(
-                          color: Color(0x0D000000),
-                          blurRadius: 4,
-                          offset: Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: Column(
-                      children: [
-                        ...order.items.asMap().entries.map((entry) {
-                          final item = entry.value;
-                          final isLast = entry.key == order.items.length - 1;
-                          return Column(
-                            children: [
-                              Padding(
-                                padding: const EdgeInsets.all(16),
-                                child: Row(
-                                  children: [
-                                    Container(
-                                      width: 64,
-                                      height: 64,
-                                      decoration: BoxDecoration(
-                                        color: AppColors.darkGreen.withValues(
-                                          alpha: 0.05,
-                                        ),
-                                        borderRadius: BorderRadius.circular(12),
-                                      ),
-                                      child: const Icon(
-                                        Icons.eco_outlined,
-                                        color: AppColors.darkGreen,
-                                        size: 28,
-                                      ),
-                                    ),
-                                    const SizedBox(width: 12),
-                                    Expanded(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Text(
-                                            item.name,
-                                            style: const TextStyle(
-                                              fontFamily: 'Manrope',
-                                              fontWeight: FontWeight.w600,
-                                              fontSize: 15,
-                                              color: AppColors.black,
-                                            ),
-                                          ),
-                                          Text(
-                                            '${item.quantity} ${item.unityType}  ×  ${_formatPrice(item.unitPrice)}',
-                                            style: const TextStyle(
-                                              fontFamily: 'Manrope',
-                                              fontSize: 13,
-                                              color: AppColors.placeholder,
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                    Text(
-                                      _formatPrice(item.totalPrice),
-                                      style: const TextStyle(
-                                        fontFamily: 'Figtree',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 15,
-                                        color: AppColors.darkGreen,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              if (!isLast)
-                                Divider(
-                                  color: AppColors.lightGreen.withValues(
-                                    alpha: 0.1,
-                                  ),
-                                  height: 1,
-                                ),
-                            ],
-                          );
-                        }),
-                        // Total row
-                        Container(
-                          decoration: BoxDecoration(
-                            color: AppColors.darkGreen.withValues(alpha: 0.06),
-                            borderRadius: const BorderRadius.vertical(
-                              bottom: Radius.circular(24),
-                            ),
-                            border: Border(
-                              top: BorderSide(
-                                color: AppColors.lightGreen.withValues(
-                                  alpha: 0.15,
-                                ),
-                              ),
-                            ),
-                          ),
-                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              const Text(
-                                'Total',
-                                style: TextStyle(
-                                  fontFamily: 'Manrope',
-                                  fontWeight: FontWeight.w700,
-                                  fontSize: 17,
-                                  color: AppColors.black,
-                                ),
-                              ),
-                              Text(
-                                _formatPrice(order.totalPrice),
-                                style: const TextStyle(
-                                  fontFamily: 'Figtree',
-                                  fontWeight: FontWeight.w700,
-                                  fontSize: 17,
-                                  color: AppColors.darkGreen,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  const SizedBox(height: 24),
-
-                  // ENTREGA
-                  const Padding(
-                    padding: EdgeInsets.fromLTRB(16, 0, 16, 12),
-                    child: Text(
-                      'ENTREGA',
-                      style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w700,
-                        fontSize: 13,
-                        color: AppColors.darkGreen,
-                        letterSpacing: 1.4,
-                      ),
-                    ),
-                  ),
-                  Container(
-                    margin: const EdgeInsets.symmetric(horizontal: 16),
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: AppColors.white,
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color: AppColors.lightGreen.withValues(alpha: 0.1),
-                      ),
-                      boxShadow: const [
-                        BoxShadow(
-                          color: Color(0x0D000000),
-                          blurRadius: 4,
-                          offset: Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Icon(
-                          Icons.location_on_outlined,
-                          size: 20,
-                          color: AppColors.darkGreen,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                '${order.deliveryAddress}, ${order.deliveryNeighborhood}',
-                                style: const TextStyle(
-                                  fontFamily: 'Manrope',
-                                  fontWeight: FontWeight.w600,
-                                  fontSize: 15,
-                                  color: AppColors.black,
-                                ),
-                              ),
-                              Text(
-                                order.deliveryCityState,
-                                style: const TextStyle(
-                                  fontFamily: 'Manrope',
-                                  fontSize: 14,
-                                  color: AppColors.placeholder,
-                                ),
-                              ),
-                              if (order.deliveryComplement.isNotEmpty)
-                                Text(
-                                  order.deliveryComplement,
-                                  style: const TextStyle(
-                                    fontFamily: 'Manrope',
-                                    fontSize: 13,
-                                    color: AppColors.placeholder,
-                                  ),
-                                ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
+                  _Header(order: order),
+                  _CustomerHeader(order: order),
+                  const _SectionTitle('ITENS DO PEDIDO'),
+                  _ItemsCard(order: order),
+                  const SizedBox(height: 18),
+                  const _SectionTitle('ENTREGA'),
+                  _DeliveryCard(order: order),
                 ],
               ),
             ),
-
-            // Sticky bottom actions
             Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              child: _BottomActions(order: order, isProcessing: isProcessing),
+              left: 16,
+              right: 16,
+              bottom: 16,
+              child: _ActionFooter(order: order, isProcessing: isProcessing),
             ),
           ],
         ),
@@ -479,238 +199,629 @@ class _ProducerOrderDetailView extends StatelessWidget {
   }
 }
 
-class _BottomActions extends StatelessWidget {
-  const _BottomActions({required this.order, required this.isProcessing});
+class _Header extends StatelessWidget {
+  const _Header({required this.order});
+
+  final ProducerOrder order;
+
+  @override
+  Widget build(BuildContext context) {
+    final shortId = order.id.length > 4 ? order.id.substring(0, 4) : order.id;
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => context.pop(),
+            child: const Padding(
+              padding: EdgeInsets.all(8),
+              child: Icon(Icons.arrow_back, size: 18),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Detalhes do Pedido',
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 18,
+                    color: AppColors.black,
+                  ),
+                ),
+                Text(
+                  '#$shortId',
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          _StatusBadge(status: order.status),
+        ],
+      ),
+    );
+  }
+}
+
+class _CustomerHeader extends StatelessWidget {
+  const _CustomerHeader({required this.order});
+
+  final ProducerOrder order;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 24,
+            backgroundColor: AppColors.darkGreen.withValues(alpha: 0.1),
+            backgroundImage: order.consumerAvatarUrl.isNotEmpty
+                ? NetworkImage(order.consumerAvatarUrl)
+                : null,
+            child: order.consumerAvatarUrl.isEmpty
+                ? Text(
+                    order.consumerName.isNotEmpty ? order.consumerName[0] : '?',
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w700,
+                      fontSize: 18,
+                      color: AppColors.darkGreen,
+                    ),
+                  )
+                : null,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  order.consumerName,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                    color: AppColors.black,
+                  ),
+                ),
+                Text(
+                  order.consumerSince.isEmpty
+                      ? DateFormat(
+                          'dd/MM/yyyy, HH:mm',
+                          'pt_BR',
+                        ).format(order.createdAt)
+                      : 'Cliente desde ${order.consumerSince}',
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 12,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontFamily: 'Manrope',
+          fontWeight: FontWeight.w700,
+          fontSize: 14,
+          color: AppColors.darkGreen,
+          letterSpacing: 1.4,
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+
+  final ProducerOrderStatus status;
+
+  Color get _color => switch (status) {
+    ProducerOrderStatus.pending => const Color(0xFFFFB413),
+    ProducerOrderStatus.accepted => AppColors.lightGreen,
+    ProducerOrderStatus.inDelivery => AppColors.lightGreen,
+    ProducerOrderStatus.delivered => const Color(0xFF3B82F6),
+    ProducerOrderStatus.cancelled => AppColors.red,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: _color,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        status.label.toUpperCase(),
+        style: const TextStyle(
+          fontFamily: 'Manrope',
+          fontWeight: FontWeight.w700,
+          fontSize: 10,
+          color: AppColors.white,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _ItemsCard extends StatelessWidget {
+  const _ItemsCard({required this.order});
+
+  final ProducerOrder order;
+
+  static final _currency = NumberFormat.currency(
+    locale: 'pt_BR',
+    symbol: r'R$',
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.lightGreen.withValues(alpha: 0.08)),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0D000000),
+            blurRadius: 2,
+            offset: Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          ...order.items.asMap().entries.map((entry) {
+            final isLast = entry.key == order.items.length - 1;
+            return Column(
+              children: [
+                _ProducerOrderItemRow(item: entry.value),
+                if (!isLast)
+                  Divider(
+                    color: AppColors.lightGreen.withValues(alpha: 0.08),
+                    height: 1,
+                  ),
+              ],
+            );
+          }),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppColors.lightGreen.withValues(alpha: 0.05),
+              borderRadius: const BorderRadius.vertical(
+                bottom: Radius.circular(24),
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  'Total',
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 18,
+                    color: AppColors.black,
+                  ),
+                ),
+                Text(
+                  _currency.format(order.totalPrice),
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 18,
+                    color: AppColors.darkGreen,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProducerOrderItemRow extends StatelessWidget {
+  const _ProducerOrderItemRow({required this.item});
+
+  final ProducerOrderItem item;
+
+  static final _currency = NumberFormat.currency(
+    locale: 'pt_BR',
+    symbol: r'R$',
+  );
+
+  String get _quantity => 'Qtd: ${item.quantity}${item.unityType}';
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              width: 64,
+              height: 64,
+              color: AppColors.lightGreen.withValues(alpha: 0.05),
+              child: item.imageUrl.isNotEmpty
+                  ? Image.network(item.imageUrl, fit: BoxFit.cover)
+                  : const Icon(Icons.eco, color: AppColors.lightGreen),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.name,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _quantity,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 13,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+                Text(
+                  _currency.format(item.unitPrice),
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 13,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            _currency.format(item.totalPrice),
+            style: const TextStyle(
+              fontFamily: 'Manrope',
+              fontWeight: FontWeight.w700,
+              fontSize: 14,
+              color: AppColors.black,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeliveryCard extends StatelessWidget {
+  const _DeliveryCard({required this.order});
+
+  final ProducerOrder order;
+
+  @override
+  Widget build(BuildContext context) {
+    final lines = [
+      order.deliveryAddress,
+      [
+        order.deliveryNeighborhood,
+        order.deliveryCityState,
+      ].where((line) => line.isNotEmpty).join(', '),
+      order.deliveryComplement,
+    ].where((line) => line.isNotEmpty).toList();
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(17),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.lightGreen.withValues(alpha: 0.08)),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0D000000),
+            blurRadius: 2,
+            offset: Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.location_on_outlined,
+            size: 20,
+            color: AppColors.darkGreen,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Endereço',
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                ...lines.map(
+                  (line) => Text(
+                    line,
+                    style: const TextStyle(
+                      fontFamily: 'Manrope',
+                      fontSize: 15,
+                      color: AppColors.black,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionFooter extends StatelessWidget {
+  const _ActionFooter({required this.order, required this.isProcessing});
 
   final ProducerOrder order;
   final bool isProcessing;
 
   @override
   Widget build(BuildContext context) {
-    final bloc = context.read<ProducerOrderDetailBloc>();
+    final buttons = <Widget>[
+      if (order.status == ProducerOrderStatus.pending)
+        Row(
+          children: [
+            Expanded(
+              child: _ActionButton(
+                label: 'Recusar Pedido',
+                icon: Icons.cancel_outlined,
+                color: AppColors.red,
+                onTap: isProcessing ? null : () => _confirmCancel(context),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _ActionButton(
+                label: 'Confirmar Pedido',
+                icon: Icons.check_circle_outline,
+                color: AppColors.darkGreen,
+                onTap: isProcessing
+                    ? null
+                    : () => context.read<ProducerOrderDetailBloc>().add(
+                        ProducerOrderDetailConfirmed(order.id),
+                      ),
+              ),
+            ),
+          ],
+        ),
+      if (order.status == ProducerOrderStatus.accepted)
+        _ActionButton(
+          label: 'Iniciar Entrega',
+          icon: Icons.local_shipping_outlined,
+          color: AppColors.darkGreen,
+          onTap: isProcessing
+              ? null
+              : () => context.read<ProducerOrderDetailBloc>().add(
+                  ProducerOrderDetailStatusUpdated(
+                    order.id,
+                    ProducerOrderStatus.inDelivery,
+                  ),
+                ),
+        ),
+      if (order.status == ProducerOrderStatus.inDelivery)
+        _ActionButton(
+          label: 'Confirmar Entrega',
+          icon: Icons.check_circle_outline,
+          color: AppColors.darkGreen,
+          onTap: isProcessing
+              ? null
+              : () => _confirmDelivery(context),
+        ),
+      if (order.consumerPhone.isNotEmpty &&
+          order.status != ProducerOrderStatus.cancelled)
+        _ActionButton(
+          label: 'Contatar Cliente',
+          icon: Icons.chat,
+          color: const Color(0xFF25D366),
+          onTap: isProcessing ? null : () => _contactCustomer(context),
+        ),
+    ];
 
-    return Container(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
-      decoration: const BoxDecoration(
+    if (buttons.isEmpty) return const SizedBox.shrink();
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
         color: AppColors.white,
-        boxShadow: [
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: const [
           BoxShadow(
-            color: Color(0x14000000),
-            blurRadius: 12,
-            offset: Offset(0, -4),
+            color: Color(0x1A000000),
+            blurRadius: 18,
+            offset: Offset(0, 4),
           ),
         ],
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (order.status == ProducerOrderStatus.pending) ...[
-            Row(
-              children: [
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: isProcessing
-                        ? null
-                        : () => bloc.add(ProducerOrderDetailRefused(order.id)),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.red,
-                      foregroundColor: AppColors.white,
-                      disabledBackgroundColor: AppColors.red.withValues(
-                        alpha: 0.5,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(24),
-                      ),
-                      padding: const EdgeInsets.symmetric(vertical: 14),
-                    ),
-                    child: const Text(
-                      'Recusar pedido',
-                      style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w700,
-                        fontSize: 15,
-                      ),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: isProcessing
-                        ? null
-                        : () =>
-                              bloc.add(ProducerOrderDetailConfirmed(order.id)),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.darkGreen,
-                      foregroundColor: AppColors.white,
-                      disabledBackgroundColor: AppColors.darkGreen.withValues(
-                        alpha: 0.5,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(24),
-                      ),
-                      padding: const EdgeInsets.symmetric(vertical: 14),
-                    ),
-                    child: isProcessing
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: AppColors.white,
-                            ),
-                          )
-                        : const Text(
-                            'Confirmar Pedido',
-                            style: TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: FontWeight.w700,
-                              fontSize: 15,
-                            ),
-                          ),
-                  ),
-                ),
-              ],
-            ),
-          ] else if (order.status == ProducerOrderStatus.accepted) ...[
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: isProcessing
-                    ? null
-                    : () => bloc.add(
-                        ProducerOrderDetailStatusUpdated(
-                          order.id,
-                          ProducerOrderStatus.inDelivery,
-                        ),
-                      ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.darkGreen,
-                  foregroundColor: AppColors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(24),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 14),
-                ),
-                child: isProcessing
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: AppColors.white,
-                        ),
-                      )
-                    : const Text(
-                        'Marcar como A caminho',
-                        style: TextStyle(
-                          fontFamily: 'Manrope',
-                          fontWeight: FontWeight.w700,
-                          fontSize: 15,
-                        ),
-                      ),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isProcessing)
+              const Padding(
+                padding: EdgeInsets.only(bottom: 10),
+                child: LinearProgressIndicator(color: AppColors.darkGreen),
               ),
-            ),
-          ] else if (order.status == ProducerOrderStatus.inDelivery) ...[
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: isProcessing
-                    ? null
-                    : () => bloc.add(
-                        ProducerOrderDetailStatusUpdated(
-                          order.id,
-                          ProducerOrderStatus.delivered,
-                        ),
-                      ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.darkGreen,
-                  foregroundColor: AppColors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(24),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 14),
-                ),
-                child: isProcessing
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: AppColors.white,
-                        ),
-                      )
-                    : const Text(
-                        'Confirmar Entrega',
-                        style: TextStyle(
-                          fontFamily: 'Manrope',
-                          fontWeight: FontWeight.w700,
-                          fontSize: 15,
-                        ),
-                      ),
-              ),
-            ),
-          ] else if (order.status == ProducerOrderStatus.delivered) ...[
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.darkGreen.withValues(alpha: 0.4),
-                  foregroundColor: AppColors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(24),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 14),
-                ),
-                child: const Text(
-                  'Pedido entregue',
-                  style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 15,
-                  ),
-                ),
-              ),
-            ),
+            ...buttons
+                .expand((button) => [button, const SizedBox(height: 8)])
+                .take(buttons.length * 2 - 1),
           ],
+        ),
+      ),
+    );
+  }
 
-          // Contact button (not shown for cancelled/delivered)
-          if (order.status != ProducerOrderStatus.delivered &&
-              order.status != ProducerOrderStatus.cancelled) ...[
-            const SizedBox(height: 8),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Abrindo WhatsApp...'),
-                      backgroundColor: Color(0xFF25D366),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.chat, size: 18),
-                label: const Text(
-                  'Contatar Cliente',
-                  style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 15,
-                  ),
-                ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFF25D366),
-                  foregroundColor: AppColors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(24),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 14),
+  Future<void> _confirmCancel(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Cancelar pedido'),
+        content: const Text('Tem certeza que deseja cancelar este pedido?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Voltar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Cancelar pedido'),
+          ),
+        ],
+      ),
+    );
+
+    if ((confirmed ?? false) && context.mounted) {
+      context.read<ProducerOrderDetailBloc>().add(
+        ProducerOrderDetailRefused(order.id),
+      );
+    }
+  }
+
+  Future<void> _confirmDelivery(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Confirmar entrega'),
+        content: const Text(
+          'Tem certeza que deseja confirmar a entrega deste pedido?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Voltar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Confirmar entrega'),
+          ),
+        ],
+      ),
+    );
+
+    if ((confirmed ?? false) && context.mounted) {
+      context.read<ProducerOrderDetailBloc>().add(
+        ProducerOrderDetailStatusUpdated(
+          order.id,
+          ProducerOrderStatus.delivered,
+        ),
+      );
+    }
+  }
+
+  Future<void> _contactCustomer(BuildContext context) async {
+    final cleanPhone = order.consumerPhone.replaceAll(RegExp('[^0-9]'), '');
+    if (cleanPhone.isEmpty) return;
+
+    final uri = Uri.parse('https://wa.me/55$cleanPhone');
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!launched && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Não foi possível abrir o contato do cliente.'),
+          backgroundColor: AppColors.red,
+        ),
+      );
+    }
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.label,
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final Color color;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 52,
+        decoration: BoxDecoration(
+          color: onTap == null ? color.withValues(alpha: 0.6) : color,
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: AppColors.white, size: 20),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                label,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontFamily: 'Manrope',
+                  fontWeight: FontWeight.w700,
+                  fontSize: 15,
+                  color: AppColors.white,
                 ),
               ),
             ),
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -15,6 +15,7 @@ import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_o
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_event.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_state.dart';
+import 'package:ragro_mobile/shared/widgets/cancel_order_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class ProducerOrderDetailPage extends StatelessWidget {
@@ -640,7 +641,7 @@ class _ActionFooter extends StatelessWidget {
             ),
           ],
         ),
-      if (order.status == ProducerOrderStatus.accepted)
+      if (order.status == ProducerOrderStatus.accepted) ...[
         _ActionButton(
           label: 'Iniciar Entrega',
           icon: Icons.local_shipping_outlined,
@@ -654,6 +655,13 @@ class _ActionFooter extends StatelessWidget {
                   ),
                 ),
         ),
+        _ActionButton(
+          label: 'Cancelar Pedido',
+          icon: Icons.cancel_outlined,
+          color: AppColors.red,
+          onTap: isProcessing ? null : () => _confirmCancel(context),
+        ),
+      ],
       if (order.status == ProducerOrderStatus.inDelivery)
         _ActionButton(
           label: 'Confirmar Entrega',
@@ -707,27 +715,10 @@ class _ActionFooter extends StatelessWidget {
   }
 
   Future<void> _confirmCancel(BuildContext context) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Cancelar pedido'),
-        content: const Text('Tem certeza que deseja cancelar este pedido?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('Voltar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('Cancelar pedido'),
-          ),
-        ],
-      ),
-    );
-
-    if ((confirmed ?? false) && context.mounted) {
+    final result = await CancelOrderDialog.showForProducer(context);
+    if (result != null && context.mounted) {
       context.read<ProducerOrderDetailBloc>().add(
-        ProducerOrderDetailRefused(order.id),
+        ProducerOrderDetailRefused(order.id, reason: result.reason, details: result.details),
       );
     }
   }

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_bloc.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_event.dart';
@@ -36,6 +37,7 @@ class _ProducerOrdersView extends StatelessWidget {
     (ProducerOrderStatus.accepted, 'Aceitos'),
     (ProducerOrderStatus.inDelivery, 'A caminho'),
     (ProducerOrderStatus.delivered, 'Entregues'),
+    (ProducerOrderStatus.cancelled, 'Cancelados'),
   ];
 
   String get _todayLabel {
@@ -57,223 +59,356 @@ class _ProducerOrdersView extends StatelessWidget {
     return 'Hoje, ${now.day} de ${months[now.month - 1]}';
   }
 
+  ProducerOrderStatus _activeTabFrom(ProducerOrdersState state) =>
+      switch (state) {
+        ProducerOrdersLoading(:final activeTab) => activeTab,
+        ProducerOrdersLoaded(:final activeTab) => activeTab,
+        ProducerOrdersActionSuccess(:final activeTab) => activeTab,
+        _ => ProducerOrderStatus.pending,
+      };
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFFFAFAFA),
-      body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Title
-            const Padding(
-              padding: EdgeInsets.fromLTRB(20, 16, 20, 4),
-              child: Text(
-                'Pedidos',
-                style: TextStyle(
-                  fontFamily: 'Figtree',
-                  fontWeight: FontWeight.w700,
-                  fontSize: 34,
-                  color: AppColors.darkGreen,
-                ),
-              ),
+    return BlocListener<ProducerOrdersBloc, ProducerOrdersState>(
+      listener: (context, state) {
+        if (state is ProducerOrdersActionSuccess) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: AppColors.darkGreen,
             ),
-            // Date subtitle
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
-              child: Text(
-                _todayLabel,
-                style: const TextStyle(
-                  fontFamily: 'Manrope',
-                  fontSize: 14,
-                  color: AppColors.placeholder,
-                ),
-              ),
-            ),
-            const SizedBox(height: 8),
-
-            // Tab bar
-            BlocBuilder<ProducerOrdersBloc, ProducerOrdersState>(
-              builder: (context, state) {
-                final activeTab = state is ProducerOrdersLoading
-                    ? state.activeTab
-                    : state is ProducerOrdersLoaded
-                    ? state.activeTab
-                    : ProducerOrderStatus.pending;
-                return SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.only(left: 16),
-                  child: Row(
-                    children: _tabs.map((tab) {
-                      final isActive = activeTab == tab.$1;
-                      return GestureDetector(
-                        onTap: () => context.read<ProducerOrdersBloc>().add(
-                          ProducerOrdersTabChanged(tab.$1),
-                        ),
-                        child: Container(
-                          padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
-                          decoration: BoxDecoration(
-                            border: isActive
-                                ? const Border(
-                                    bottom: BorderSide(
-                                      color: AppColors.darkGreen,
-                                      width: 3,
-                                    ),
-                                  )
-                                : null,
-                          ),
-                          child: Text(
-                            tab.$2,
-                            style: TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: isActive
-                                  ? FontWeight.w700
-                                  : FontWeight.w500,
-                              fontSize: 14,
-                              color: isActive
-                                  ? AppColors.darkGreen
-                                  : AppColors.placeholder,
-                            ),
-                          ),
-                        ),
-                      );
-                    }).toList(),
+          );
+        }
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFFAFAFA),
+        body: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Title
+              const Padding(
+                padding: EdgeInsets.fromLTRB(20, 16, 20, 4),
+                child: Text(
+                  'Pedidos',
+                  style: TextStyle(
+                    fontFamily: 'Figtree',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 34,
+                    color: AppColors.darkGreen,
                   ),
-                );
-              },
-            ),
+                ),
+              ),
+              // Date subtitle
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
+                child: Text(
+                  _todayLabel,
+                  style: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 14,
+                    color: AppColors.placeholder,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
 
-            // Content
-            Expanded(
-              child: BlocBuilder<ProducerOrdersBloc, ProducerOrdersState>(
+              // Tab bar
+              BlocBuilder<ProducerOrdersBloc, ProducerOrdersState>(
                 builder: (context, state) {
-                  if (state is ProducerOrdersLoading) {
-                    return const Center(
-                      child: CircularProgressIndicator(
-                        color: AppColors.darkGreen,
-                      ),
-                    );
-                  }
-                  if (state is ProducerOrdersFailure) {
-                    return Center(child: Text(state.message));
-                  }
-                  if (state is! ProducerOrdersLoaded) {
-                    return const SizedBox.shrink();
-                  }
-                  if (state.orders.isEmpty) {
-                    return Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(
-                            Icons.shopping_bag_outlined,
-                            size: 64,
-                            color: AppColors.placeholder,
-                          ),
-                          const SizedBox(height: 16),
-                          Text(
-                            'Nenhum pedido ${state.activeTab.label.toLowerCase()}',
-                            style: const TextStyle(
-                              fontFamily: 'Manrope',
-                              fontSize: 16,
-                              color: AppColors.placeholder,
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }
-                  final newCount = state.orders.where((o) => o.isNew).length;
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (state.activeTab == ProducerOrderStatus.inDelivery)
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-                          child: GestureDetector(
-                            onTap: () => context.push('/producer/home/route'),
-                            child: Container(
-                              height: 44,
-                              decoration: BoxDecoration(
-                                color: AppColors.darkGreen,
-                                borderRadius: BorderRadius.circular(22),
+                  final activeTab = _activeTabFrom(state);
+                  return SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.only(left: 16),
+                    child: Row(
+                      children: _tabs.map((tab) {
+                        final isActive = activeTab == tab.$1;
+                        return GestureDetector(
+                          onTap: () =>
+                              context.read<ProducerOrdersBloc>().add(
+                                ProducerOrdersTabChanged(tab.$1),
                               ),
-                              child: const Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Icon(
-                                    Icons.route_outlined,
-                                    color: AppColors.white,
-                                    size: 18,
-                                  ),
-                                  SizedBox(width: 8),
-                                  Text(
-                                    'Calcular Rota',
-                                    style: TextStyle(
-                                      fontFamily: 'Figtree',
-                                      fontWeight: FontWeight.w700,
-                                      fontSize: 14,
-                                      color: AppColors.white,
-                                    ),
-                                  ),
-                                ],
+                          child: Container(
+                            padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+                            decoration: BoxDecoration(
+                              border: isActive
+                                  ? const Border(
+                                      bottom: BorderSide(
+                                        color: AppColors.darkGreen,
+                                        width: 3,
+                                      ),
+                                    )
+                                  : null,
+                            ),
+                            child: Text(
+                              tab.$2,
+                              style: TextStyle(
+                                fontFamily: 'Manrope',
+                                fontWeight: isActive
+                                    ? FontWeight.w700
+                                    : FontWeight.w500,
+                                fontSize: 14,
+                                color: isActive
+                                    ? AppColors.darkGreen
+                                    : AppColors.placeholder,
                               ),
                             ),
                           ),
-                        ),
-                      if (newCount > 0)
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
-                          child: Text(
-                            '$newCount ${newCount == 1 ? 'pedido novo' : 'pedidos novos'}',
-                            style: const TextStyle(
-                              fontFamily: 'Manrope',
-                              fontWeight: FontWeight.w600,
-                              fontSize: 14,
-                              color: AppColors.darkGreen,
-                            ),
-                          ),
-                        ),
-                      Expanded(
-                        child: ListView.separated(
-                          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                          itemCount: state.orders.length,
-                          separatorBuilder: (_, __) =>
-                              const SizedBox(height: 12),
-                          itemBuilder: (context, index) {
-                            final order = state.orders[index];
-                            return ProducerOrderCard(
-                              order: order,
-                              onDetailTap: () => context.push(
-                                '/producer/home/orders/${order.id}',
-                              ),
-                              onActionTap: () {
-                                if (order.status ==
-                                        ProducerOrderStatus.delivered ||
-                                    order.status ==
-                                        ProducerOrderStatus.cancelled) {
-                                  context.push(
-                                    '/producer/home/orders/${order.id}',
-                                  );
-                                  return;
-                                }
-                                // Quick action via detail BLoC
-                                context.push(
-                                  '/producer/home/orders/${order.id}',
-                                );
-                              },
-                            );
-                          },
-                        ),
-                      ),
-                    ],
+                        );
+                      }).toList(),
+                    ),
                   );
                 },
               ),
-            ),
-          ],
+
+              // Content
+              Expanded(
+                child: BlocBuilder<ProducerOrdersBloc, ProducerOrdersState>(
+                  builder: (context, state) {
+                    if (state is ProducerOrdersLoading) {
+                      return const Center(
+                        child: CircularProgressIndicator(
+                          color: AppColors.darkGreen,
+                        ),
+                      );
+                    }
+                    if (state is ProducerOrdersFailure) {
+                      return Center(child: Text(state.message));
+                    }
+
+                    final List<ProducerOrder> allOrders;
+                    final ProducerOrderStatus activeTab;
+                    if (state is ProducerOrdersLoaded) {
+                      allOrders = state.orders;
+                      activeTab = state.activeTab;
+                    } else if (state is ProducerOrdersActionSuccess) {
+                      allOrders = state.orders;
+                      activeTab = state.activeTab;
+                    } else {
+                      return const SizedBox.shrink();
+                    }
+
+                    final orders = allOrders
+                        .where((o) => o.status == activeTab)
+                        .toList();
+
+                    if (orders.isEmpty) {
+                      return Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(
+                              Icons.shopping_bag_outlined,
+                              size: 64,
+                              color: AppColors.placeholder,
+                            ),
+                            const SizedBox(height: 16),
+                            Text(
+                              'Nenhum pedido ${activeTab.label.toLowerCase()}',
+                              style: const TextStyle(
+                                fontFamily: 'Manrope',
+                                fontSize: 16,
+                                color: AppColors.placeholder,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    }
+                    final newCount = orders.where((o) => o.isNew).length;
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (activeTab == ProducerOrderStatus.inDelivery)
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                            child: GestureDetector(
+                              onTap: () =>
+                                  context.push('/producer/home/route'),
+                              child: Container(
+                                height: 44,
+                                decoration: BoxDecoration(
+                                  color: AppColors.darkGreen,
+                                  borderRadius: BorderRadius.circular(22),
+                                ),
+                                child: const Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(
+                                      Icons.route_outlined,
+                                      color: AppColors.white,
+                                      size: 18,
+                                    ),
+                                    SizedBox(width: 8),
+                                    Text(
+                                      'Calcular Rota',
+                                      style: TextStyle(
+                                        fontFamily: 'Figtree',
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 14,
+                                        color: AppColors.white,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        if (newCount > 0)
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+                            child: Text(
+                              '$newCount ${newCount == 1 ? 'pedido novo' : 'pedidos novos'}',
+                              style: const TextStyle(
+                                fontFamily: 'Manrope',
+                                fontWeight: FontWeight.w600,
+                                fontSize: 14,
+                                color: AppColors.darkGreen,
+                              ),
+                            ),
+                          ),
+                        Expanded(
+                          child: ListView.separated(
+                            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                            itemCount: orders.length,
+                            separatorBuilder: (_, __) =>
+                                const SizedBox(height: 12),
+                            itemBuilder: (context, index) {
+                              final order = orders[index];
+                              return ProducerOrderCard(
+                                order: order,
+                                onDetailTap: () async {
+                                  final result =
+                                      await context.push<String?>(
+                                        '/producer/home/orders/${order.id}',
+                                        extra: order,
+                                      );
+                                  if (!context.mounted) return;
+                                  if (result == 'in_delivery') {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Entrega iniciada com sucesso.',
+                                        ),
+                                        backgroundColor: AppColors.darkGreen,
+                                      ),
+                                    );
+                                    context.read<ProducerOrdersBloc>().add(
+                                      const ProducerOrdersStarted(
+                                        ProducerOrderStatus.inDelivery,
+                                      ),
+                                    );
+                                  } else if (result == 'cancelled') {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Pedido recusado com sucesso.',
+                                        ),
+                                        backgroundColor: AppColors.darkGreen,
+                                      ),
+                                    );
+                                    context.read<ProducerOrdersBloc>().add(
+                                      ProducerOrderLocallyRefused(order.id),
+                                    );
+                                  } else if (result == 'delivered') {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Entrega confirmada com sucesso.',
+                                        ),
+                                        backgroundColor: AppColors.darkGreen,
+                                      ),
+                                    );
+                                    context.read<ProducerOrdersBloc>().add(
+                                      ProducerOrderLocallyDelivered(order.id),
+                                    );
+                                  }
+                                },
+                                onCancelTap:
+                                    order.status == ProducerOrderStatus.pending
+                                    ? () => _confirmCancel(context, order.id)
+                                    : null,
+                                onActionTap:
+                                    order.status == ProducerOrderStatus.pending
+                                    ? () =>
+                                          context
+                                              .read<ProducerOrdersBloc>()
+                                              .add(
+                                                ProducerOrderAccepted(order.id),
+                                              )
+                                    : null,
+                                onDeliveryConfirmTap: order.status ==
+                                        ProducerOrderStatus.inDelivery
+                                    ? () => _confirmDelivery(
+                                        context,
+                                        order.id,
+                                      )
+                                    : null,
+                              );
+                            },
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  Future<void> _confirmCancel(BuildContext context, String orderId) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Recusar pedido'),
+        content: const Text('Tem certeza que deseja recusar este pedido?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Voltar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Recusar pedido'),
+          ),
+        ],
+      ),
+    );
+
+    if ((confirmed ?? false) && context.mounted) {
+      context.read<ProducerOrdersBloc>().add(ProducerOrderCancelled(orderId));
+    }
+  }
+
+  Future<void> _confirmDelivery(BuildContext context, String orderId) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Confirmar entrega'),
+        content: const Text(
+          'Tem certeza que deseja confirmar a entrega deste pedido?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Voltar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Confirmar entrega'),
+          ),
+        ],
+      ),
+    );
+
+    if ((confirmed ?? false) && context.mounted) {
+      context
+          .read<ProducerOrdersBloc>()
+          .add(ProducerOrderDeliveryConfirmed(orderId));
+    }
   }
 }

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -14,6 +14,7 @@ import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_event.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_state.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/widgets/producer_order_card.dart';
+import 'package:ragro_mobile/shared/widgets/cancel_order_dialog.dart';
 
 class ProducerOrdersPage extends StatelessWidget {
   const ProducerOrdersPage({super.key});
@@ -361,26 +362,11 @@ class _ProducerOrdersView extends StatelessWidget {
   }
 
   Future<void> _confirmCancel(BuildContext context, String orderId) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Recusar pedido'),
-        content: const Text('Tem certeza que deseja recusar este pedido?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('Voltar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('Recusar pedido'),
-          ),
-        ],
-      ),
-    );
-
-    if ((confirmed ?? false) && context.mounted) {
-      context.read<ProducerOrdersBloc>().add(ProducerOrderCancelled(orderId));
+    final result = await CancelOrderDialog.showForProducer(context);
+    if (result != null && context.mounted) {
+      context.read<ProducerOrdersBloc>().add(
+        ProducerOrderCancelled(orderId, reason: result.reason, details: result.details),
+      );
     }
   }
 

--- a/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
+++ b/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
@@ -7,21 +8,19 @@ class ProducerOrderCard extends StatelessWidget {
   const ProducerOrderCard({
     required this.order,
     required this.onDetailTap,
-    required this.onActionTap,
+    this.onActionTap,
+    this.onCancelTap,
+    this.onDeliveryConfirmTap,
     super.key,
   });
 
   final ProducerOrder order;
   final VoidCallback onDetailTap;
-  final VoidCallback onActionTap;
+  final VoidCallback? onActionTap;
+  final VoidCallback? onCancelTap;
+  final VoidCallback? onDeliveryConfirmTap;
 
-  String get _actionLabel => switch (order.status) {
-    ProducerOrderStatus.pending => 'Aceitar',
-    ProducerOrderStatus.accepted => 'A caminho',
-    ProducerOrderStatus.inDelivery => 'Entregue',
-    ProducerOrderStatus.delivered => 'Ver',
-    ProducerOrderStatus.cancelled => 'Ver',
-  };
+  static final _dateFormat = DateFormat('dd/MM/yyyy, HH:mm', 'pt_BR');
 
   String get _subtitleLabel => switch (order.status) {
     ProducerOrderStatus.pending => 'Pedido pendente',
@@ -31,8 +30,16 @@ class ProducerOrderCard extends StatelessWidget {
     ProducerOrderStatus.cancelled => 'Pedido cancelado',
   };
 
+  Color get _statusColor => switch (order.status) {
+    ProducerOrderStatus.pending => AppColors.yellow,
+    ProducerOrderStatus.accepted => AppColors.darkGreen,
+    ProducerOrderStatus.inDelivery => AppColors.lightGreen,
+    ProducerOrderStatus.delivered => AppColors.darkGreen,
+    ProducerOrderStatus.cancelled => AppColors.red,
+  };
+
   String _formatPrice(double price) =>
-      'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
+      r'R$ ' + price.toStringAsFixed(2).replaceAll('.', ',');
 
   @override
   Widget build(BuildContext context) {
@@ -95,7 +102,24 @@ class ProducerOrderCard extends StatelessWidget {
                   ],
                 ),
               ),
-              // NOVO badge
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: _statusColor.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  order.status.label.toUpperCase(),
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 11,
+                    color: _statusColor,
+                    letterSpacing: 0.5,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
               if (order.isNew)
                 Container(
                   padding: const EdgeInsets.symmetric(
@@ -123,6 +147,28 @@ class ProducerOrderCard extends StatelessWidget {
           const SizedBox(height: 12),
           const Divider(color: Color(0xFFE2E8F0), height: 1),
           const SizedBox(height: 12),
+
+          // Date
+          Row(
+            children: [
+              const Icon(
+                Icons.access_time,
+                size: 14,
+                color: AppColors.placeholder,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                _dateFormat.format(order.createdAt),
+                style: const TextStyle(
+                  fontFamily: 'Manrope',
+                  fontSize: 12,
+                  color: AppColors.placeholder,
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 8),
 
           // Total
           Row(
@@ -174,28 +220,80 @@ class ProducerOrderCard extends StatelessWidget {
                   ),
                 ),
               ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: ElevatedButton(
-                  onPressed: onActionTap,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.darkGreen,
-                    foregroundColor: AppColors.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(24),
+              if (order.status == ProducerOrderStatus.pending &&
+                  onCancelTap != null) ...[
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: onCancelTap,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.red,
+                      foregroundColor: AppColors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 10),
                     ),
-                    padding: const EdgeInsets.symmetric(vertical: 10),
-                  ),
-                  child: Text(
-                    _actionLabel,
-                    style: const TextStyle(
-                      fontFamily: 'Manrope',
-                      fontWeight: FontWeight.w600,
-                      fontSize: 14,
+                    child: const Text(
+                      'Recusar',
+                      style: TextStyle(
+                        fontFamily: 'Manrope',
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
                     ),
                   ),
                 ),
-              ),
+              ],
+              if (onActionTap != null) ...[
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: onActionTap,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.darkGreen,
+                      foregroundColor: AppColors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                    ),
+                    child: const Text(
+                      'Aceitar',
+                      style: TextStyle(
+                        fontFamily: 'Manrope',
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+              if (order.status == ProducerOrderStatus.inDelivery &&
+                  onDeliveryConfirmTap != null) ...[
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: onDeliveryConfirmTap,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.darkGreen,
+                      foregroundColor: AppColors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                    ),
+                    child: const Text(
+                      'Entregue',
+                      style: TextStyle(
+                        fontFamily: 'Manrope',
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ],
           ),
         ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,11 +4,13 @@
 // 3. Roda o app
 
 import 'package:flutter/material.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:ragro_mobile/app.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await initializeDateFormatting('pt_BR');
   await configureDependencies();
   runApp(const App());
 }

--- a/lib/shared/widgets/cancel_order_dialog.dart
+++ b/lib/shared/widgets/cancel_order_dialog.dart
@@ -1,0 +1,353 @@
+import 'package:flutter/material.dart';
+import 'package:ragro_mobile/core/theme/app_colors.dart';
+
+const _customerReasons = [
+  'Não consigo receber o pedido',
+  'Demorou mais do que o esperado',
+  'Informei o endereço errado',
+  'Mudei de ideia',
+  'Problema no pagamento',
+  'Outro',
+];
+
+const _producerReasons = [
+  'Estoque insuficiente',
+  'Endereço inválido',
+  'Tempo de entrega muito grande',
+  'Sem contato com cliente',
+  'Cliente solicitou cancelamento',
+  'Problema no pagamento',
+  'Outro',
+];
+
+typedef CancelResult = ({String reason, String? details});
+
+class CancelOrderDialog extends StatefulWidget {
+  const CancelOrderDialog._({required this.reasons});
+
+  final List<String> reasons;
+
+  static Future<CancelResult?> showForCustomer(BuildContext context) =>
+      _show(context, _customerReasons);
+
+  static Future<CancelResult?> showForProducer(BuildContext context) =>
+      _show(context, _producerReasons);
+
+  static Future<CancelResult?> _show(
+    BuildContext context,
+    List<String> reasons,
+  ) {
+    return showDialog<CancelResult>(
+      context: context,
+      barrierDismissible: false,
+      barrierColor: Colors.black.withValues(alpha: 0.4),
+      builder: (_) => CancelOrderDialog._(reasons: reasons),
+    );
+  }
+
+  @override
+  State<CancelOrderDialog> createState() => _CancelOrderDialogState();
+}
+
+class _CancelOrderDialogState extends State<CancelOrderDialog> {
+  String? _selectedReason;
+  final _detailsController = TextEditingController();
+
+  bool get _isOther => _selectedReason == 'Outro';
+
+  @override
+  void dispose() {
+    _detailsController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_selectedReason == null) return;
+    final details = _isOther && _detailsController.text.trim().isNotEmpty
+        ? _detailsController.text.trim()
+        : null;
+    Navigator.of(context).pop<CancelResult>(
+      (reason: _selectedReason!, details: details),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: AppColors.lightGreen.withValues(alpha: 0.15),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.warning_amber_rounded,
+                  size: 28,
+                  color: AppColors.darkGreen,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Center(
+              child: Text(
+                'Cancelar Pedido',
+                style: TextStyle(
+                  fontFamily: 'Figtree',
+                  fontWeight: FontWeight.w700,
+                  fontSize: 18,
+                  color: AppColors.black,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'Motivo do Cancelamento',
+              style: TextStyle(
+                fontFamily: 'Manrope',
+                fontWeight: FontWeight.w600,
+                fontSize: 13,
+                color: AppColors.black,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _ReasonDropdown(
+              reasons: widget.reasons,
+              selected: _selectedReason,
+              onChanged: (value) => setState(() {
+                _selectedReason = value;
+                if (value != 'Outro') _detailsController.clear();
+              }),
+            ),
+            if (_isOther) ...[
+              const SizedBox(height: 16),
+              const Text(
+                'Detalhes',
+                style: TextStyle(
+                  fontFamily: 'Manrope',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13,
+                  color: AppColors.black,
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _detailsController,
+                maxLines: 3,
+                style: const TextStyle(
+                  fontFamily: 'Manrope',
+                  fontSize: 14,
+                  color: AppColors.black,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'Detalhes do cancelamento',
+                  hintStyle: const TextStyle(
+                    fontFamily: 'Manrope',
+                    fontSize: 14,
+                    color: AppColors.placeholder,
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: AppColors.darkGreen),
+                  ),
+                  contentPadding: const EdgeInsets.all(12),
+                ),
+              ),
+            ],
+            const SizedBox(height: 24),
+            _DialogButton(
+              label: 'Confirmar cancelamento',
+              color: _selectedReason != null
+                  ? AppColors.darkGreen
+                  : AppColors.darkGreen.withValues(alpha: 0.5),
+              textColor: AppColors.white,
+              onTap: _selectedReason != null ? _submit : null,
+            ),
+            const SizedBox(height: 10),
+            _DialogButton(
+              label: 'Voltar',
+              color: AppColors.white,
+              textColor: AppColors.black,
+              border: Border.all(color: const Color(0xFFE2E8F0)),
+              onTap: () => Navigator.of(context).pop(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReasonDropdown extends StatefulWidget {
+  const _ReasonDropdown({
+    required this.reasons,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final List<String> reasons;
+  final String? selected;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  State<_ReasonDropdown> createState() => _ReasonDropdownState();
+}
+
+class _ReasonDropdownState extends State<_ReasonDropdown> {
+  bool _isOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        GestureDetector(
+          onTap: () => setState(() => _isOpen = !_isOpen),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              border: Border.all(color: const Color(0xFFE2E8F0)),
+              borderRadius: BorderRadius.only(
+                topLeft: const Radius.circular(12),
+                topRight: const Radius.circular(12),
+                bottomLeft: Radius.circular(_isOpen ? 0 : 12),
+                bottomRight: Radius.circular(_isOpen ? 0 : 12),
+              ),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    widget.selected ?? 'Selecione um motivo',
+                    style: TextStyle(
+                      fontFamily: 'Manrope',
+                      fontSize: 14,
+                      color: widget.selected != null
+                          ? AppColors.black
+                          : AppColors.placeholder,
+                    ),
+                  ),
+                ),
+                Icon(
+                  _isOpen ? Icons.expand_less : Icons.expand_more,
+                  color: AppColors.placeholder,
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (_isOpen)
+          Container(
+            decoration: const BoxDecoration(
+              border: Border(
+                left: BorderSide(color: Color(0xFFE2E8F0)),
+                right: BorderSide(color: Color(0xFFE2E8F0)),
+                bottom: BorderSide(color: Color(0xFFE2E8F0)),
+              ),
+              borderRadius: BorderRadius.only(
+                bottomLeft: Radius.circular(12),
+                bottomRight: Radius.circular(12),
+              ),
+            ),
+            child: Column(
+              children: widget.reasons.asMap().entries.map((entry) {
+                final isLast = entry.key == widget.reasons.length - 1;
+                return Column(
+                  children: [
+                    InkWell(
+                      onTap: () {
+                        widget.onChanged(entry.value);
+                        setState(() => _isOpen = false);
+                      },
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 14,
+                          vertical: 12,
+                        ),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            entry.value,
+                            style: const TextStyle(
+                              fontFamily: 'Manrope',
+                              fontSize: 14,
+                              color: AppColors.black,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (!isLast)
+                      const Divider(height: 1, color: Color(0xFFE2E8F0)),
+                  ],
+                );
+              }).toList(),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _DialogButton extends StatelessWidget {
+  const _DialogButton({
+    required this.label,
+    required this.color,
+    required this.textColor,
+    required this.onTap,
+    this.border,
+  });
+
+  final String label;
+  final Color color;
+  final Color textColor;
+  final BoxBorder? border;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: color,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 13),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            border: border,
+          ),
+          alignment: Alignment.center,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontFamily: 'Manrope',
+              fontWeight: FontWeight.w700,
+              fontSize: 15,
+              color: textColor,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   flutter_svg: ^2.0.10
   http_parser: ^4.1.2
   intl: ^0.20.0
-  url_launcher: ^6.3.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:

--- a/test/features/orders/data/models/order_detail_model_test.dart
+++ b/test/features/orders/data/models/order_detail_model_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ragro_mobile/features/orders/data/models/order_detail_model.dart';
+
+void main() {
+  group('OrderDetailModel.fromJson', () {
+    test('parses backend CustomerOrderResponse payload (canonical names)', () {
+      final json = <String, dynamic>{
+        'id': 'order-1',
+        'status': 'PENDING',
+        'createdAt': '2025-05-01T10:00:00Z',
+        'producerId': 'producer-1',
+        'producerName': 'Sítio Boa Vista',
+        'producerPhone': '+5511999998888',
+        'producerPicture': 'https://cdn/photo.jpg',
+        'totalAmount': 150.50,
+        'deliveryAddress': {
+          'street': 'Rua A',
+          'number': '100',
+          'complement': 'Apto 2',
+          'neighborhood': 'Centro',
+          'city': 'São Paulo',
+          'state': 'SP',
+          'zipCode': '01000-000',
+        },
+        'items': [
+          {
+            'id': 'item-1',
+            'productId': 'p-1',
+            'productName': 'Tomate',
+            'quantity': 2,
+            'unityType': 'kg',
+            'unitPrice': 10.0,
+            'subtotal': 20.0,
+          },
+        ],
+      };
+
+      final model = OrderDetailModel.fromJson(json);
+
+      expect(model.id, 'order-1');
+      expect(model.producerPicture, 'https://cdn/photo.jpg');
+      expect(model.producerPhone, '+5511999998888');
+      expect(model.totalAmount, 150.50);
+      expect(model.deliveryAddress.street, 'Rua A');
+      expect(model.deliveryAddress.city, 'São Paulo');
+      expect(model.deliveryAddress.zipCode, '01000-000');
+      expect(model.items, hasLength(1));
+      expect(model.items.first.productName, 'Tomate');
+    });
+
+    test('falls back to alternative field names (price/total, snake_case)', () {
+      final json = <String, dynamic>{
+        'id': 'order-2',
+        'status': 'CONFIRMED',
+        'producerName': 'Fazenda X',
+        'producerPhotoUrl': 'https://cdn/alt.jpg',
+        'price': 99.9,
+        'deliveryAddress': {
+          'street': 'Rua B',
+          'number': '50',
+          'neighborhood': 'Jardim',
+          'city': 'Campinas',
+          'state': 'SP',
+          'zip_code': '13000-000',
+        },
+        'items': const <Map<String, dynamic>>[],
+      };
+
+      final model = OrderDetailModel.fromJson(json);
+
+      expect(model.producerPicture, 'https://cdn/alt.jpg');
+      expect(model.totalAmount, 99.9);
+      expect(model.deliveryAddress.zipCode, '13000-000');
+      expect(model.deliveryAddress.city, 'Campinas');
+    });
+
+    test('returns safe defaults when fields are missing or null', () {
+      final json = <String, dynamic>{
+        'id': 'order-3',
+        'status': 'PENDING',
+      };
+
+      final model = OrderDetailModel.fromJson(json);
+
+      expect(model.producerPicture, isNull);
+      expect(model.producerPhone, isNull);
+      expect(model.totalAmount, 0.0);
+      expect(model.deliveryAddress.street, '');
+      expect(model.deliveryAddress.zipCode, '');
+      expect(model.items, isEmpty);
+    });
+  });
+}

--- a/test/features/orders/domain/usecases/cancel_customer_order_test.dart
+++ b/test/features/orders/domain/usecases/cancel_customer_order_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/cancel_customer_order.dart';
+
+class MockOrdersRepository extends Mock implements OrdersRepository {}
+
+void main() {
+  late CancelCustomerOrder useCase;
+  late MockOrdersRepository repo;
+
+  setUp(() {
+    repo = MockOrdersRepository();
+    useCase = CancelCustomerOrder(repo);
+  });
+
+  group('CancelCustomerOrder', () {
+    test('repassa orderId, reason e details para o repository', () async {
+      when(
+        () => repo.cancelCustomerOrder(
+          any(),
+          reason: any(named: 'reason'),
+          details: any(named: 'details'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await useCase('order-1', reason: 'Mudei de ideia', details: 'extra');
+
+      verify(
+        () => repo.cancelCustomerOrder(
+          'order-1',
+          reason: 'Mudei de ideia',
+          details: 'extra',
+        ),
+      ).called(1);
+    });
+
+    test('omite details quando não é fornecido (passa null)', () async {
+      when(
+        () => repo.cancelCustomerOrder(
+          any(),
+          reason: any(named: 'reason'),
+          details: any(named: 'details'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await useCase('order-2', reason: 'Outro');
+
+      verify(
+        () => repo.cancelCustomerOrder(
+          'order-2',
+          reason: 'Outro',
+          details: null,
+        ),
+      ).called(1);
+    });
+
+    test('propaga NotFoundException do repository (bug C1: endpoint pode não existir)', () async {
+      when(
+        () => repo.cancelCustomerOrder(
+          any(),
+          reason: any(named: 'reason'),
+          details: any(named: 'details'),
+        ),
+      ).thenThrow(const NotFoundException());
+
+      expect(
+        () => useCase('order-3', reason: 'Mudei de ideia'),
+        throwsA(isA<NotFoundException>()),
+      );
+    });
+  });
+
+  // Sanity-check para evitar warning de import não usado quando entidades
+  // forem necessárias em testes futuros (ex.: validar tipo de retorno).
+  test('entidades de orders permanecem importáveis', () {
+    expect(Order, isNotNull);
+    expect(OrderDetail, isNotNull);
+    expect(OrderStatus.pending, isA<OrderStatus>());
+  });
+}

--- a/test/features/orders/domain/usecases/confirm_customer_delivery_test.dart
+++ b/test/features/orders/domain/usecases/confirm_customer_delivery_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/confirm_customer_delivery.dart';
+
+class MockOrdersRepository extends Mock implements OrdersRepository {}
+
+void main() {
+  late ConfirmCustomerDelivery useCase;
+  late MockOrdersRepository repo;
+
+  setUp(() {
+    repo = MockOrdersRepository();
+    useCase = ConfirmCustomerDelivery(repo);
+  });
+
+  final OrderDetail tConfirmed = OrderDetail(
+    id: 'order-1',
+    orderNumber: '#0001',
+    status: 'DELIVERED',
+    statusLabel: 'Entregue',
+    createdAt: DateTime(2026, 5, 5),
+    producerId: 'p1',
+    producerName: 'Fazenda Teste',
+    producerPhone: '5199999',
+    producerPicture: null,
+    items: const [],
+    totalAmount: 0,
+    deliveryAddress: const OrderDetailAddress(
+      street: 'Rua A',
+      number: '1',
+      complement: '',
+      neighborhood: 'Centro',
+      city: 'Porto Alegre',
+      state: 'RS',
+      reference: '',
+    ),
+    actions: const OrderDetailActions(
+      canConfirmDelivery: false,
+      canCancel: false,
+      canContactProducer: true,
+    ),
+  );
+
+  group('ConfirmCustomerDelivery', () {
+    test('repassa orderId para o repository e devolve OrderDetail', () async {
+      when(
+        () => repo.confirmCustomerDelivery(any()),
+      ).thenAnswer((_) async => tConfirmed);
+
+      final result = await useCase('order-1');
+
+      expect(result.id, 'order-1');
+      expect(result.status, 'DELIVERED');
+      expect(result.canConfirmDelivery, isFalse);
+      verify(() => repo.confirmCustomerDelivery('order-1')).called(1);
+    });
+
+    test('propaga NotFoundException quando endpoint backend ainda não existe (bug C2)', () async {
+      when(
+        () => repo.confirmCustomerDelivery(any()),
+      ).thenThrow(const NotFoundException());
+
+      expect(
+        () => useCase('order-x'),
+        throwsA(isA<NotFoundException>()),
+      );
+    });
+  });
+}

--- a/test/features/orders/domain/usecases/confirm_order_test.dart
+++ b/test/features/orders/domain/usecases/confirm_order_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/confirm_order.dart';
+
+class MockOrdersRepository extends Mock implements OrdersRepository {}
+
+void main() {
+  late ConfirmOrder useCase;
+  late MockOrdersRepository repo;
+
+  final tOrder = Order(
+    id: 'order-new-1',
+    producerId: 'p1',
+    producerPhone: '5199999999',
+    farmName: 'Fazenda Teste',
+    farmAvatarUrl: 'http://example.com/avatar.jpg',
+    ownerName: 'Maria Silva',
+    items: const [],
+    totalAmount: 200.0,
+    status: OrderStatus.pending,
+    createdAt: DateTime(2026, 5, 5),
+    deliveryAddress: const DeliveryAddress(
+      street: 'Rua B',
+      neighborhood: 'Bom Fim',
+      city: 'Porto Alegre',
+      state: 'RS',
+      zipCode: '90000-000',
+    ),
+    bankInfo: const ProducerBankInfo(
+      bank: '001',
+      agency: '1234',
+      account: '123456',
+      pixKey: 'chave-pix@example.com',
+    ),
+  );
+
+  setUp(() {
+    repo = MockOrdersRepository();
+    useCase = ConfirmOrder(repo);
+  });
+
+  group('ConfirmOrder', () {
+    test('chama createOrderFromCart e retorna nova Order', () async {
+      when(
+        () => repo.createOrderFromCart(),
+      ).thenAnswer((_) async => tOrder);
+
+      final result = await useCase();
+
+      expect(result.id, 'order-new-1');
+      expect(result.status, OrderStatus.pending);
+      expect(result.farmName, 'Fazenda Teste');
+      verify(() => repo.createOrderFromCart()).called(1);
+    });
+
+    test('ignora cartId quando fornecido (parâmetro opcional não usado)', () async {
+      when(
+        () => repo.createOrderFromCart(),
+      ).thenAnswer((_) async => tOrder);
+
+      final result = await useCase('cart-123');
+
+      expect(result.id, 'order-new-1');
+      verify(() => repo.createOrderFromCart()).called(1);
+    });
+
+    test('propaga ConflictException quando carrinho vazio ou inválido', () async {
+      when(
+        () => repo.createOrderFromCart(),
+      ).thenThrow(const ConflictException());
+
+      expect(
+        () => useCase(),
+        throwsA(isA<ConflictException>()),
+      );
+    });
+
+    test('propaga UnauthorizedException quando usuário não autenticado', () async {
+      when(
+        () => repo.createOrderFromCart(),
+      ).thenThrow(const UnauthorizedException());
+
+      expect(
+        () => useCase(),
+        throwsA(isA<UnauthorizedException>()),
+      );
+    });
+
+    test('propaga ServerException em erro do servidor', () async {
+      when(
+        () => repo.createOrderFromCart(),
+      ).thenThrow(const ServerException());
+
+      expect(
+        () => useCase(),
+        throwsA(isA<ServerException>()),
+      );
+    });
+  });
+}

--- a/test/features/orders/domain/usecases/get_customer_order_by_id_test.dart
+++ b/test/features/orders/domain/usecases/get_customer_order_by_id_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/get_customer_order_by_id.dart';
+
+class MockOrdersRepository extends Mock implements OrdersRepository {}
+
+void main() {
+  late GetCustomerOrderById useCase;
+  late MockOrdersRepository repo;
+
+  final tOrderDetail = OrderDetail(
+    id: 'order-detail-1',
+    orderNumber: '#0001',
+    status: 'PENDING',
+    statusLabel: 'Pendente',
+    createdAt: DateTime(2026, 5, 5),
+    producerId: 'p1',
+    producerName: 'Fazenda Teste',
+    producerPhone: '5199999999',
+    producerPicture: null,
+    items: const [],
+    totalAmount: 150.0,
+    deliveryAddress: const OrderDetailAddress(
+      street: 'Rua A',
+      number: '123',
+      complement: 'Apt 101',
+      neighborhood: 'Centro',
+      city: 'Porto Alegre',
+      state: 'RS',
+      reference: 'Próximo ao banco',
+    ),
+    actions: const OrderDetailActions(
+      canConfirmDelivery: false,
+      canCancel: true,
+      canContactProducer: true,
+    ),
+  );
+
+  setUp(() {
+    repo = MockOrdersRepository();
+    useCase = GetCustomerOrderById(repo);
+  });
+
+  group('GetCustomerOrderById', () {
+    test('repassa orderId para o repository e retorna OrderDetail completo', () async {
+      when(
+        () => repo.getCustomerOrderById(any()),
+      ).thenAnswer((_) async => tOrderDetail);
+
+      final result = await useCase('order-detail-1');
+
+      expect(result.id, 'order-detail-1');
+      expect(result.orderNumber, '#0001');
+      expect(result.status, 'PENDING');
+      expect(result.producerName, 'Fazenda Teste');
+      expect(result.deliveryAddress.city, 'Porto Alegre');
+      expect(result.actions?.canCancel, isTrue);
+      verify(() => repo.getCustomerOrderById('order-detail-1')).called(1);
+    });
+
+    test('retorna OrderDetail com items quando houver itens no pedido', () async {
+      final orderWithItems = OrderDetail(
+        id: 'order-detail-2',
+        orderNumber: '#0002',
+        status: 'PENDING',
+        statusLabel: 'Pendente',
+        createdAt: DateTime(2026, 5, 5),
+        producerId: 'p1',
+        producerName: 'Fazenda Teste',
+        producerPhone: '5199999999',
+        producerPicture: null,
+        items: const [
+          OrderDetailItem(
+            id: 'item-1',
+            productId: 'prod-1',
+            productName: 'Tomate',
+            productPhoto: 'http://example.com/tomate.jpg',
+            quantity: 2.5,
+            unityType: 'kg',
+            unitPrice: 5.0,
+            subtotal: 12.5,
+          ),
+        ],
+        totalAmount: 12.5,
+        deliveryAddress: const OrderDetailAddress(
+          street: 'Rua A',
+          number: '123',
+          complement: 'Apt 101',
+          neighborhood: 'Centro',
+          city: 'Porto Alegre',
+          state: 'RS',
+          reference: 'Próximo ao banco',
+        ),
+        actions: const OrderDetailActions(
+          canConfirmDelivery: false,
+          canCancel: true,
+          canContactProducer: true,
+        ),
+      );
+
+      when(
+        () => repo.getCustomerOrderById(any()),
+      ).thenAnswer((_) async => orderWithItems);
+
+      final result = await useCase('order-detail-2');
+
+      expect(result.items, isNotEmpty);
+      expect(result.items.first.productName, 'Tomate');
+      expect(result.items.first.quantity, 2.5);
+    });
+
+    test('propaga NotFoundException quando order não existe', () async {
+      when(
+        () => repo.getCustomerOrderById(any()),
+      ).thenThrow(const NotFoundException());
+
+      expect(
+        () => useCase('order-nonexistent'),
+        throwsA(isA<NotFoundException>()),
+      );
+    });
+
+    test('propaga UnauthorizedException quando ordem pertence a outro cliente', () async {
+      when(
+        () => repo.getCustomerOrderById(any()),
+      ).thenThrow(const UnauthorizedException());
+
+      expect(
+        () => useCase('order-other-user'),
+        throwsA(isA<UnauthorizedException>()),
+      );
+    });
+
+    test('propaga NetworkException em caso de erro de conectividade', () async {
+      when(
+        () => repo.getCustomerOrderById(any()),
+      ).thenThrow(const NetworkException());
+
+      expect(
+        () => useCase('order-detail-1'),
+        throwsA(isA<NetworkException>()),
+      );
+    });
+  });
+}

--- a/test/features/orders/domain/usecases/repeat_order_test.dart
+++ b/test/features/orders/domain/usecases/repeat_order_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
+import 'package:ragro_mobile/features/orders/domain/repositories/orders_repository.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/repeat_order.dart';
+
+class MockOrdersRepository extends Mock implements OrdersRepository {}
+
+void main() {
+  late RepeatOrder useCase;
+  late MockOrdersRepository repo;
+
+  final tOrder = Order(
+    id: 'order-1',
+    producerId: 'p1',
+    producerPhone: '5199999999',
+    farmName: 'Fazenda Teste',
+    farmAvatarUrl: 'http://example.com/avatar.jpg',
+    ownerName: 'João Silva',
+    items: const [],
+    totalAmount: 150.0,
+    status: OrderStatus.pending,
+    createdAt: DateTime(2026, 5, 5),
+    deliveryAddress: const DeliveryAddress(
+      street: 'Rua A',
+      neighborhood: 'Centro',
+      city: 'Porto Alegre',
+      state: 'RS',
+      zipCode: '90000-000',
+    ),
+    bankInfo: const ProducerBankInfo(
+      bank: '001',
+      agency: '1234',
+      account: '123456',
+      pixKey: 'chave-pix@email.com',
+    ),
+  );
+
+  setUp(() {
+    repo = MockOrdersRepository();
+    useCase = RepeatOrder(repo);
+  });
+
+  group('RepeatOrder', () {
+    test('repassa orderId para o repository e retorna nova Order', () async {
+      when(
+        () => repo.repeatOrder(any()),
+      ).thenAnswer((_) async => tOrder);
+
+      final result = await useCase('order-1');
+
+      expect(result.id, 'order-1');
+      expect(result.farmName, 'Fazenda Teste');
+      expect(result.producerId, 'p1');
+      expect(result.status, OrderStatus.pending);
+      verify(() => repo.repeatOrder('order-1')).called(1);
+    });
+
+    test('propaga NotFoundException quando order não existe', () async {
+      when(
+        () => repo.repeatOrder(any()),
+      ).thenThrow(const NotFoundException());
+
+      expect(
+        () => useCase('order-nonexistent'),
+        throwsA(isA<NotFoundException>()),
+      );
+    });
+
+    test('propaga UnauthorizedException quando usuário não tem permissão', () async {
+      when(
+        () => repo.repeatOrder(any()),
+      ).thenThrow(const UnauthorizedException());
+
+      expect(
+        () => useCase('order-forbidden'),
+        throwsA(isA<UnauthorizedException>()),
+      );
+    });
+
+    test('propaga NetworkException quando há erro de rede', () async {
+      when(
+        () => repo.repeatOrder(any()),
+      ).thenThrow(const NetworkException());
+
+      expect(
+        () => useCase('order-1'),
+        throwsA(isA<NetworkException>()),
+      );
+    });
+  });
+}

--- a/test/features/producer_orders/domain/usecases/update_producer_order_status_test.dart
+++ b/test/features/producer_orders/domain/usecases/update_producer_order_status_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/repositories/producer_orders_repository.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/usecases/update_producer_order_status.dart';
+
+class MockProducerOrdersRepository extends Mock
+    implements ProducerOrdersRepository {}
+
+void main() {
+  late UpdateProducerOrderStatus useCase;
+  late MockProducerOrdersRepository repo;
+
+  setUpAll(() {
+    registerFallbackValue(ProducerOrderStatus.pending);
+  });
+
+  setUp(() {
+    repo = MockProducerOrdersRepository();
+    useCase = UpdateProducerOrderStatus(repo);
+  });
+
+  group('UpdateProducerOrderStatus', () {
+    test('repassa orderId e status (in_delivery) para o repository', () async {
+      when(
+        () => repo.updateStatus(any(), any()),
+      ).thenAnswer((_) async {});
+
+      await useCase('order-1', ProducerOrderStatus.inDelivery);
+
+      verify(
+        () => repo.updateStatus('order-1', ProducerOrderStatus.inDelivery),
+      ).called(1);
+    });
+
+    test('repassa status (delivered) corretamente', () async {
+      when(
+        () => repo.updateStatus(any(), any()),
+      ).thenAnswer((_) async {});
+
+      await useCase('order-2', ProducerOrderStatus.delivered);
+
+      verify(
+        () => repo.updateStatus('order-2', ProducerOrderStatus.delivered),
+      ).called(1);
+    });
+
+    test('propaga ForbiddenException do repository (producer sem permissão)', () async {
+      when(
+        () => repo.updateStatus(any(), any()),
+      ).thenThrow(const ForbiddenException());
+
+      expect(
+        () => useCase('order-3', ProducerOrderStatus.delivered),
+        throwsA(isA<ForbiddenException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Pedidos do produtor: confirmar, recusar, iniciar entrega e confirmar entrega
- Pedidos do cliente: listar, cancelar e confirmar recebimento
- Carrinho: limpar localmente após confirmação do pedido (sem erro de 404)
- Correção de endpoints de status (PATCH /orders/{id}/status com valor uppercase)
- Novos use cases: cancelOrder, confirmCustomerDelivery, repeatOrder, updateOrderStatus, etc.
- Modelos de dados para OrderDetail, OrderItem e ProducerOrder

## O que mudou?
Pedidos do Produtor:
Confirmação e recusa de pedidos pendentes (via PATCH /orders/{id}/status)
Início de entrega: transição de accepted → inDelivery
Confirmação de entrega: transição de inDelivery → delivered
Atualização otimista de estado local após cada ação (sem re-fetch)
Navegação por resultado entre tela de detalhe e lista (context.pop('in_delivery' | 'cancelled' | 'delivered'))
Correção do endpoint de cancelamento: substituído PATCH /orders/{id}/cancel (retornava 500) por PATCH /orders/{id}/status com {"status": "CANCELLED"}
Valores de status enviados em uppercase para o backend (IN_DELIVERY, DELIVERED, CANCELLED)

Pedidos do Cliente:
Listagem de pedidos integrada ao backend (GET /orders/consumer)
Cancelamento de pedido (PATCH /orders/customer/{id}/cancel)
Confirmação de recebimento pelo cliente (PATCH /orders/customer/{id}/confirm-delivery)
Tela de detalhe do pedido com dados reais (GET /orders/customer/{id})
Carrinho
Após confirmação do pedido, o carrinho é limpo localmente via evento CartOrderPlaced (sem chamada de API)
Corrige erro de "Carrinho não encontrado" que aparecia após o pedido ser finalizado (o backend já invalida o carrinho ao criar o pedido, causando 404 no DELETE anterior)
Corrige barra inferior do carrinho que permanecia visível após confirmação


## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

Pedidos do Produtor

Fazer login como produtor
Na aba Pedidos, verificar tab "Pendentes" — aceitar um pedido e confirmar que ele some da aba e aparece em "Aceitos"
Em "Aceitos", abrir o detalhe e clicar em Iniciar Entrega — pedido deve mover para "A caminho"
Em "A caminho", abrir o detalhe e clicar em Confirmar Entrega (ou usar o botão "Entregue" direto no card) — pedido deve mover para "Entregues"
Em um pedido pendente, clicar em Recusar (no card ou no detalhe) — pedido deve mover para "Cancelados"
Pedidos do Cliente

Fazer login como cliente
Acessar a tela de pedidos e verificar que os pedidos reais aparecem
Abrir o detalhe de um pedido com status pending ou accepted e cancelar — status deve atualizar
Em um pedido com status inDelivery, confirmar o recebimento — status deve mudar para delivered
Carrinho

Adicionar produtos ao carrinho — barra inferior deve aparecer
Ir para confirmação do pedido e confirmar
Verificar que a barra do carrinho desaparece imediatamente após a confirmação, sem exibir erro de "Carrinho não encontrado"



## Screenshots / Gravações

Producer: 

<img width="532" height="912" alt="image" src="https://github.com/user-attachments/assets/ba22c39c-b129-4df8-97e3-789901baeb04" />
<img width="548" height="916" alt="image" src="https://github.com/user-attachments/assets/db0f68eb-100e-4db0-96cb-0f5a538df4cd" />
<img width="539" height="912" alt="image" src="https://github.com/user-attachments/assets/6fa10cda-067f-4095-8eca-1036ffade3cc" />
<img width="502" height="890" alt="image" src="https://github.com/user-attachments/assets/e57dc1c1-8b1c-4260-8566-debd80b38fd9" />
<img width="523" height="906" alt="image" src="https://github.com/user-attachments/assets/178c76db-d479-4906-9118-9459c97bb4ff" />


Customer: 
<img width="525" height="832" alt="image" src="https://github.com/user-attachments/assets/868a9c4b-c89d-4748-b5d7-34a5a284a808" />
<img width="542" height="901" alt="image" src="https://github.com/user-attachments/assets/7e439af9-9a1a-4908-9138-1a8013224046" />
<img width="528" height="826" alt="image" src="https://github.com/user-attachments/assets/601b16bb-f0c8-443f-a8c9-1dff4bf98e8f" />
<img width="505" height="838" alt="image" src="https://github.com/user-attachments/assets/654b9b3d-37ca-4396-877e-63ea44621a0d" />


<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto
