### PR TITLE
feat: implement automatic address lookup via BrasilAPI across all forms

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -16,6 +16,7 @@ import 'package:ragro_mobile/core/di/network_module.dart' as _i1002;
 import 'package:ragro_mobile/core/di/shared_preferences_module.dart' as _i55;
 import 'package:ragro_mobile/core/network/api_client.dart' as _i873;
 import 'package:ragro_mobile/core/router/app_router.dart' as _i419;
+import 'package:ragro_mobile/core/services/cep_service.dart' as _i305;
 import 'package:ragro_mobile/features/admin/data/datasources/admin_remote_datasource.dart'
     as _i16;
 import 'package:ragro_mobile/features/admin/data/repositories/admin_repository_impl.dart'
@@ -238,6 +239,7 @@ extension GetItInjectableX on _i174.GetIt {
       preResolve: true,
     );
     gh.lazySingleton<_i361.Dio>(() => networkModule.dio);
+    gh.lazySingleton<_i305.CepService>(() => _i305.CepService());
     gh.lazySingleton<_i870.InventoryRemoteDataSource>(
       () => _i870.InventoryRemoteDataSource(),
     );

--- a/lib/core/services/cep_service.dart
+++ b/lib/core/services/cep_service.dart
@@ -1,0 +1,61 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+
+class CepAddress {
+  CepAddress({
+    required this.cep,
+    required this.state,
+    required this.city,
+    required this.neighborhood,
+    required this.street,
+  });
+
+  factory CepAddress.fromJson(Map<String, dynamic> json) {
+    return CepAddress(
+      cep: (json['cep'] as String?) ?? '',
+      state: (json['state'] as String?) ?? '',
+      city: (json['city'] as String?) ?? '',
+      neighborhood: (json['neighborhood'] as String?) ?? '',
+      street: (json['street'] as String?) ?? '',
+    );
+  }
+
+  final String cep;
+  final String state;
+  final String city;
+  final String neighborhood;
+  final String street;
+
+  @override
+  String toString() {
+    return 'CepAddress(cep: $cep, state: $state, city: $city, neighborhood: $neighborhood, street: $street)';
+  }
+}
+
+@lazySingleton
+class CepService {
+  final Dio _dio = Dio();
+
+  Future<CepAddress?> fetchAddress(String cep) async {
+    final cleanCep = cep.replaceAll(RegExp(r'\D'), '');
+    if (cleanCep.length != 8) return null;
+
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        'https://brasilapi.com.br/api/cep/v1/$cleanCep',
+        options: Options(
+          sendTimeout: const Duration(seconds: 5),
+          receiveTimeout: const Duration(seconds: 5),
+        ),
+      );
+
+      final data = response.data;
+      if (response.statusCode == 200 && data != null) {
+        return CepAddress.fromJson(data);
+      }
+    } catch (e) {
+      return null;
+    }
+    return null;
+  }
+}

--- a/lib/features/admin/presentation/pages/admin_create_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_create_producer_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/formatters/input_masks.dart';
+import 'package:ragro_mobile/core/services/cep_service.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/core/validators/cnpj_validator.dart';
 import 'package:ragro_mobile/core/validators/cpf_validator.dart';
@@ -93,7 +94,7 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
   final _numberController = TextEditingController();
   final _neighborhoodController = TextEditingController();
   final _cityController = TextEditingController();
-  String? _selectedState;
+  final _stateController = TextEditingController();
 
   // ── Horário ────────────────────────────────────────────────────────────
   final _scheduleStartController = TextEditingController(text: '08:00');
@@ -113,6 +114,12 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
   final _bankFiscalController = TextEditingController();
 
   bool _termsAccepted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _cepController.addListener(_onCepChanged);
+  }
 
   static const _weekdayLabels = [
     'Seg',
@@ -140,6 +147,25 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
     }
   }
 
+  void _onCepChanged() {
+    final cep = _digitsOnly(_cepController.text);
+    if (cep.length == 8) {
+      _lookupCep(cep);
+    }
+  }
+
+  Future<void> _lookupCep(String cep) async {
+    final address = await getIt<CepService>().fetchAddress(cep);
+    if (address != null && mounted) {
+      setState(() {
+        _addressController.text = address.street;
+        _neighborhoodController.text = address.neighborhood;
+        _cityController.text = address.city;
+        _stateController.text = address.state;
+      });
+    }
+  }
+
   @override
   void dispose() {
     _nameController.dispose();
@@ -154,6 +180,7 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
     _numberController.dispose();
     _neighborhoodController.dispose();
     _cityController.dispose();
+    _stateController.dispose();
     _scheduleStartController.dispose();
     _scheduleEndController.dispose();
     _pixKeyController.dispose();
@@ -233,7 +260,7 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
             ? _neighborhoodController.text.trim()
             : null,
         city: _cityController.text.trim(),
-        state: _selectedState ?? '',
+        state: _stateController.text.trim(),
         fiscalNumber: cleanFiscal,
         fiscalNumberType: fiscalType,
         farmName: _farmNameController.text.trim(),
@@ -568,11 +595,19 @@ class _AdminCreateProducerViewState extends State<_AdminCreateProducerView> {
                           children: [
                             const _FieldLabel('Estado'),
                             const SizedBox(height: 8),
-                            _UfAutocomplete(
-                              initialValue: _selectedState,
-                              onSelected: (uf) =>
-                                  setState(() => _selectedState = uf),
-                              enabled: !isLoading,
+                            _TextField(
+                              controller: _stateController,
+                              hint: 'UF',
+                              inputFormatters: [
+                                LengthLimitingTextInputFormatter(2),
+                                _UppercaseFormatter(),
+                              ],
+                              validator: (v) {
+                                if ((v ?? '').trim().isEmpty) {
+                                  return 'UF';
+                                }
+                                return null;
+                              },
                             ),
                           ],
                         ),
@@ -1080,6 +1115,7 @@ class _TextField extends StatelessWidget {
 
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
+    super.key,
     required this.initialValue,
     required this.onSelected,
     this.enabled = true,

--- a/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/formatters/input_masks.dart';
+import 'package:ragro_mobile/core/services/cep_service.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/admin/domain/entities/admin_producer.dart';
 import 'package:ragro_mobile/features/admin/presentation/bloc/admin_edit_producer_bloc.dart';
@@ -95,7 +96,7 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
   final _numberController = TextEditingController();
   final _neighborhoodController = TextEditingController();
   final _cityController = TextEditingController();
-  String? _selectedState;
+  final _stateController = TextEditingController();
 
   // ── PIX (opcional no update — partial) ────────────────────────────────
   String? _pixKeyType;
@@ -118,6 +119,12 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
   late AdminProducer _original;
   bool _controllersInitialized = false;
 
+  @override
+  void initState() {
+    super.initState();
+    _cepController.addListener(_onCepChanged);
+  }
+
   static const _weekdayLabels = [
     'Seg',
     'Ter',
@@ -135,6 +142,25 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
     return formatter
         .formatEditUpdate(TextEditingValue.empty, TextEditingValue(text: val))
         .text;
+  }
+
+  void _onCepChanged() {
+    final cep = _digitsOnly(_cepController.text);
+    if (cep.length == 8) {
+      _lookupCep(cep);
+    }
+  }
+
+  Future<void> _lookupCep(String cep) async {
+    final address = await getIt<CepService>().fetchAddress(cep);
+    if (address != null && mounted) {
+      setState(() {
+        _addressController.text = address.street;
+        _neighborhoodController.text = address.neighborhood;
+        _cityController.text = address.city;
+        _stateController.text = address.state;
+      });
+    }
   }
 
   List<TextInputFormatter> _pixKeyFormatters() {
@@ -162,6 +188,7 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
     _numberController.dispose();
     _neighborhoodController.dispose();
     _cityController.dispose();
+    _stateController.dispose();
     _pixKeyController.dispose();
     _bankNameController.dispose();
     _bankCodeController.dispose();
@@ -194,7 +221,7 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
     _numberController.text = producer.producerAddress?.number ?? '';
     _neighborhoodController.text = producer.producerAddress?.neighborhood ?? '';
     _cityController.text = producer.producerAddress?.city ?? '';
-    _selectedState = producer.producerAddress?.state;
+    _stateController.text = producer.producerAddress?.state ?? '';
 
     // Pre-fill PIX
     final pix = producer.paymentMethods
@@ -271,7 +298,7 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
         _neighborhoodController.text !=
             (_original.producerAddress?.neighborhood ?? '') ||
         _cityController.text != (_original.producerAddress?.city ?? '') ||
-        _selectedState != _original.producerAddress?.state ||
+        _stateController.text != (_original.producerAddress?.state ?? '') ||
         _pixKeyType != pix?.pixKeyType ||
         _pixKeyController.text != (pix?.pixKey ?? '') ||
         _bankNameController.text != (bank?.bankName ?? '') ||
@@ -374,7 +401,7 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
         number: _numberController.text.trim(),
         neighborhood: _neighborhoodController.text.trim(),
         city: _cityController.text.trim(),
-        state: _selectedState ?? '',
+        state: _stateController.text.trim(),
         cpfCnpj: _cpfCnpjController.text.trim(),
         farmName: _farmNameController.text.trim(),
         description: _descriptionController.text.trim(),
@@ -677,10 +704,19 @@ class _AdminEditProducerViewState extends State<_AdminEditProducerView> {
                     children: [
                       const _FieldLabel('Estado'),
                       const SizedBox(height: 8),
-                      _UfAutocomplete(
-                        initialValue: _selectedState,
-                        onSelected: (uf) => setState(() => _selectedState = uf),
-                        enabled: !isSaving,
+                      _TextField(
+                        controller: _stateController,
+                        hint: 'UF',
+                        inputFormatters: [
+                          LengthLimitingTextInputFormatter(2),
+                          _UppercaseFormatter(),
+                        ],
+                        validator: (v) {
+                          if ((v ?? '').trim().isEmpty) {
+                            return 'UF';
+                          }
+                          return null;
+                        },
                       ),
                     ],
                   ),
@@ -1161,6 +1197,7 @@ class _TextField extends StatelessWidget {
 
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
+    super.key,
     required this.initialValue,
     required this.onSelected,
     this.enabled = true,

--- a/lib/features/auth/presentation/pages/customer_register_page.dart
+++ b/lib/features/auth/presentation/pages/customer_register_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/formatters/input_masks.dart';
+import 'package:ragro_mobile/core/services/cep_service.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/core/theme/app_text_styles.dart';
 import 'package:ragro_mobile/core/validators/cpf_validator.dart';
@@ -83,7 +84,13 @@ class _CustomerRegisterViewState extends State<_CustomerRegisterView> {
   final _complementController = TextEditingController();
   final _neighborhoodController = TextEditingController();
   final _cityController = TextEditingController();
-  String? _selectedState;
+  final _stateController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _zipCodeController.addListener(_onZipCodeChanged);
+  }
 
   bool _termsAccepted = false;
 
@@ -103,7 +110,27 @@ class _CustomerRegisterViewState extends State<_CustomerRegisterView> {
     _complementController.dispose();
     _neighborhoodController.dispose();
     _cityController.dispose();
+    _stateController.dispose();
     super.dispose();
+  }
+
+  void _onZipCodeChanged() {
+    final cep = _digitsOnly(_zipCodeController.text);
+    if (cep.length == 8) {
+      _lookupZipCode(cep);
+    }
+  }
+
+  Future<void> _lookupZipCode(String cep) async {
+    final address = await getIt<CepService>().fetchAddress(cep);
+    if (address != null && mounted) {
+      setState(() {
+        _streetController.text = address.street;
+        _neighborhoodController.text = address.neighborhood;
+        _cityController.text = address.city;
+        _stateController.text = address.state;
+      });
+    }
   }
 
   void _submit() {
@@ -124,12 +151,12 @@ class _CustomerRegisterViewState extends State<_CustomerRegisterView> {
         phone: _digitsOnly(_phoneController.text),
         email: _emailController.text.trim(),
         fiscalNumber: _digitsOnly(_cpfController.text),
-        password: _passwordController.text,
+        password: _passwordController.text.trim(),
         zipCode: _digitsOnly(_zipCodeController.text),
         street: _streetController.text.trim(),
         number: _numberController.text.trim(),
         city: _cityController.text.trim(),
-        state: _selectedState!,
+        state: _stateController.text.trim(),
         complement: _complementController.text.trim(),
         neighborhood: _neighborhoodController.text.trim(),
       ),
@@ -339,9 +366,24 @@ class _CustomerRegisterViewState extends State<_CustomerRegisterView> {
                     const SizedBox(width: 12),
                     SizedBox(
                       width: 110,
-                      child: _UfAutocomplete(
-                        initialValue: _selectedState,
-                        onSelected: (uf) => setState(() => _selectedState = uf),
+                      child: AuthTextField(
+                        label: 'UF',
+                        icon: Icons.map_outlined,
+                        controller: _stateController,
+                        textCapitalization: TextCapitalization.characters,
+                        inputFormatters: [
+                          LengthLimitingTextInputFormatter(2),
+                          _UppercaseFormatter(),
+                        ],
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return 'Informe a UF';
+                          }
+                          if (!_brazilianStates.contains(value.trim().toUpperCase())) {
+                            return 'UF inválida';
+                          }
+                          return null;
+                        },
                       ),
                     ),
                   ],
@@ -436,7 +478,11 @@ class _TermsCheckboxState extends State<_TermsCheckbox> {
 }
 
 class _UfAutocomplete extends StatelessWidget {
-  const _UfAutocomplete({required this.initialValue, required this.onSelected});
+  const _UfAutocomplete({
+    super.key,
+    required this.initialValue,
+    required this.onSelected,
+  });
 
   final String? initialValue;
   final ValueChanged<String> onSelected;

--- a/lib/features/customer_profile/presentation/pages/customer_edit_profile_page.dart
+++ b/lib/features/customer_profile/presentation/pages/customer_edit_profile_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/core/services/cep_service.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_bloc.dart';
 import 'package:ragro_mobile/features/customer_profile/presentation/bloc/customer_profile_event.dart';
@@ -42,6 +44,7 @@ class _CustomerEditProfilePageState extends State<CustomerEditProfilePage> {
     _neighborhoodController = TextEditingController();
     _cityController = TextEditingController();
     _stateController = TextEditingController();
+    _zipCodeController.addListener(_onZipCodeChanged);
 
     _hydrateControllers(context.read<CustomerProfileBloc>().state);
   }
@@ -404,6 +407,25 @@ class _CustomerEditProfilePageState extends State<CustomerEditProfilePage> {
         ),
       ],
     );
+  }
+
+  void _onZipCodeChanged() {
+    final cep = _zipCodeController.text.replaceAll(RegExp(r'\D'), '');
+    if (cep.length == 8) {
+      _lookupZipCode(cep);
+    }
+  }
+
+  Future<void> _lookupZipCode(String cep) async {
+    final address = await getIt<CepService>().fetchAddress(cep);
+    if (address != null && mounted) {
+      setState(() {
+        _streetController.text = address.street;
+        _neighborhoodController.text = address.neighborhood;
+        _cityController.text = address.city;
+        _stateController.text = address.state;
+      });
+    }
   }
 
   String? _requiredValidator(String? value) {

--- a/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_edit_profile_page.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/formatters/input_masks.dart';
+import 'package:ragro_mobile/core/services/cep_service.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/auth/data/datasources/auth_local_datasource.dart';
 import 'package:ragro_mobile/features/producer_profile/domain/entities/public_producer.dart';
@@ -100,7 +101,7 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
   final _numberController = TextEditingController();
   final _neighborhoodController = TextEditingController();
   final _cityController = TextEditingController();
-  String? _selectedState;
+  final _stateController = TextEditingController();
 
   // ── Forma de Recebimento ──────────────────────────────────────────────
   String? _pixKeyType;
@@ -124,6 +125,12 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
   bool _hydrated = false;
   bool _isPicking = false;
 
+  @override
+  void initState() {
+    super.initState();
+    _cepController.addListener(_onCepChanged);
+  }
+
   static const _weekdayLabels = [
     'Seg',
     'Ter',
@@ -141,6 +148,25 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
     return formatter
         .formatEditUpdate(TextEditingValue.empty, TextEditingValue(text: val))
         .text;
+  }
+
+  void _onCepChanged() {
+    final cep = _digitsOnly(_cepController.text);
+    if (cep.length == 8) {
+      _lookupCep(cep);
+    }
+  }
+
+  Future<void> _lookupCep(String cep) async {
+    final address = await getIt<CepService>().fetchAddress(cep);
+    if (address != null && mounted) {
+      setState(() {
+        _addressController.text = address.street;
+        _neighborhoodController.text = address.neighborhood;
+        _cityController.text = address.city;
+        _stateController.text = address.state;
+      });
+    }
   }
 
   List<TextInputFormatter> _pixKeyFormatters() {
@@ -166,6 +192,7 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
     _numberController.dispose();
     _neighborhoodController.dispose();
     _cityController.dispose();
+    _stateController.dispose();
     _pixKeyController.dispose();
     _bankNameController.dispose();
     _bankCodeController.dispose();
@@ -194,7 +221,7 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
       _numberController.text = addr.number;
       _neighborhoodController.text = addr.neighborhood ?? '';
       _cityController.text = addr.city;
-      _selectedState = addr.state;
+      _stateController.text = addr.state;
     }
 
     // Payment Methods
@@ -268,7 +295,7 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
         'street': _addressController.text.trim(),
         'number': _numberController.text.trim(),
         'city': _cityController.text.trim(),
-        'state': _selectedState ?? '',
+        'state': _stateController.text.trim(),
         'zipCode': _digitsOnly(_cepController.text),
         if (_neighborhoodController.text.trim().isNotEmpty)
           'neighborhood': _neighborhoodController.text.trim(),
@@ -765,10 +792,20 @@ class _ProducerEditProfileViewState extends State<_ProducerEditProfileView> {
                                 children: [
                                   const _FieldLabel('Estado'),
                                   const SizedBox(height: 8),
-                                  _UfAutocomplete(
-                                    initialValue: _selectedState,
-                                    onSelected: (uf) =>
-                                        setState(() => _selectedState = uf),
+                                  _FormField(
+                                    controller: _stateController,
+                                    hint: 'UF',
+                                    prefixIcon: Icons.map_outlined,
+                                    inputFormatters: [
+                                      LengthLimitingTextInputFormatter(2),
+                                      _UppercaseFormatter(),
+                                    ],
+                                    validator: (v) {
+                                      if ((v ?? '').trim().isEmpty) {
+                                        return 'UF';
+                                      }
+                                      return null;
+                                    },
                                   ),
                                 ],
                               ),
@@ -1256,7 +1293,11 @@ class _UppercaseFormatter extends TextInputFormatter {
 }
 
 class _UfAutocomplete extends StatelessWidget {
-  const _UfAutocomplete({required this.onSelected, this.initialValue});
+  const _UfAutocomplete({
+    super.key,
+    required this.onSelected,
+    this.initialValue,
+  });
   final String? initialValue;
   final ValueChanged<String> onSelected;
 


### PR DESCRIPTION
## O que mudou?

- **Implementação do `CepService`**: Criado serviço centralizado que consome a [BrasilAPI](https://brasilapi.com.br/) para buscar dados de endereço a partir do CEP.
- **Integração em Massa**: O preenchimento automático foi adicionado aos formulários de:
    - Cadastro de Consumidor.
    - Edição de Perfil de Consumidor.
    - Edição de Perfil de Produtor.
    - Criação e Edição de Produtor (Admin).
- **Refatoração do campo UF**: Alteração de um componente customizado de *autocomplete* para um `TextFormField` com `TextEditingController`. Isso resolveu o problema de sincronização de estado, garantindo que a UF seja preenchida instantaneamente assim que o CEP é validado.
- **UX Aprimorada**: Adicionado gatilho automático quando o campo de CEP atinge 8 dígitos.

## Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [x] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

1.  Acesse a tela de **Cadastro de Consumidor** ou qualquer tela de **Edição de Perfil**.
2.  No campo de CEP, insira um CEP válido (apenas números ou com máscara). Ex: `01001000`.
3.  Verifique se os campos de **Rua**, **Bairro**, **Cidade** e **UF** são preenchidos automaticamente assim que o oitavo dígito é inserido.
4.  Tente apagar o CEP e inserir um novo para garantir que os campos limpam ou atualizam conforme a nova busca.
5.  Valide se a UF está sendo exibida em letras maiúsculas e limitada a 2 caracteres.

## Screenshots / Gravações

preenchimento automático assim que coloca um cep válido:
<img width="498" height="437" alt="image" src="https://github.com/user-attachments/assets/239d7a74-afec-4fb3-94b9-c961ad2a1ea1" />
cep inválido não preenche nada:
<img width="496" height="492" alt="image" src="https://github.com/user-attachments/assets/42361296-1171-4ad9-95d8-190a2c4e6225" />


## Checklist

- [x] Código formatado (`dart format .`)
- [x] Sem warnings no analyze (`dart analyze`)
- [x] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto (DI via Injectable, Services desacoplados).
