### PR TITLE
Ajustes em confirmar pedido

### DIFF
--- a/lib/features/cart/data/models/cart_model.dart
+++ b/lib/features/cart/data/models/cart_model.dart
@@ -28,13 +28,18 @@ class CartModel extends Cart {
         .whereType<Map<String, dynamic>>()
         .toList();
 
-    final producer =
-        json['producer'] as Map<String, dynamic>? ??
-        json['farmer'] as Map<String, dynamic>?;
-    final bankJson =
-        json['bankInfo'] as Map<String, dynamic>? ??
-        producer?['bankInfo'] as Map<String, dynamic>? ??
-        const <String, dynamic>{};
+    final paymentMethods = (json['paymentMethods'] as List<dynamic>? ?? [])
+        .whereType<Map<String, dynamic>>()
+        .toList();
+
+    final bankMethod = paymentMethods.firstWhere(
+      (m) => (m['type'] as String? ?? '') == 'bank_account',
+      orElse: () => const <String, dynamic>{},
+    );
+    final pixMethod = paymentMethods.firstWhere(
+      (m) => (m['type'] as String? ?? '') == 'pix',
+      orElse: () => const <String, dynamic>{},
+    );
 
     return CartModel(
       id: json['id'] as String? ?? '',
@@ -43,19 +48,10 @@ class CartModel extends Cart {
       farmName: json['farmName'] as String? ?? '',
       items: itemsJson.map(CartItemModel.fromJson).toList(),
       totalAmount: (json['totalAmount'] as num?)?.toDouble() ?? 0.0,
-      // Backend BankInfoResponse envia `bankName`. Fallback p/ `bank` mantém
-      // compat com payloads antigos.
-      bankName:
-          bankJson['bankName'] as String? ??
-          bankJson['bank'] as String? ??
-          '',
-      bankAgency: bankJson['agency'] as String? ?? '',
-      bankAccount:
-          bankJson['account'] as String? ??
-          bankJson['accountNumber'] as String? ??
-          '',
-      bankPixKey:
-          bankJson['pixKey'] as String? ?? bankJson['pix_key'] as String? ?? '',
+      bankName: bankMethod['bankName'] as String? ?? '',
+      bankAgency: bankMethod['agency'] as String? ?? '',
+      bankAccount: bankMethod['accountNumber'] as String? ?? '',
+      bankPixKey: pixMethod['pixKey'] as String? ?? '',
     );
   }
 }

--- a/lib/features/cart/presentation/pages/cart_page.dart
+++ b/lib/features/cart/presentation/pages/cart_page.dart
@@ -18,6 +18,7 @@ import 'package:ragro_mobile/features/cart/presentation/bloc/cart_state.dart';
 import 'package:ragro_mobile/features/cart/presentation/widgets/cart_item_tile.dart';
 import 'package:ragro_mobile/features/cart/presentation/widgets/producer_cart_header.dart';
 import 'package:ragro_mobile/shared/widgets/app_notification.dart';
+import 'package:ragro_mobile/shared/widgets/confirm_dialog.dart';
 
 class CartPage extends StatelessWidget {
   const CartPage({super.key});
@@ -133,9 +134,22 @@ class CartPage extends StatelessWidget {
                         GestureDetector(
                           onTap: isEmpty || isMutating
                               ? null
-                              : () => context.read<CartBloc>().add(
-                                  const CartCleared(),
-                                ),
+                              : () async {
+                                  final confirmed = await ConfirmDialog.show(
+                                    context: context,
+                                    title: 'Tem certeza que deseja excluir ',
+                                    highlight: 'todo o carrinho',
+                                    highlightColor: AppColors.red,
+                                    trailingTitle: '?',
+                                    confirmLabel: 'Excluir',
+                                    confirmColor: AppColors.red,
+                                  );
+                                  if ((confirmed ?? false) && context.mounted) {
+                                    context
+                                        .read<CartBloc>()
+                                        .add(const CartCleared());
+                                  }
+                                },
                           child: Text(
                             'Limpar',
                             style: TextStyle(

--- a/lib/features/cart/presentation/widgets/cart_item_tile.dart
+++ b/lib/features/cart/presentation/widgets/cart_item_tile.dart
@@ -6,13 +6,10 @@ import 'package:ragro_mobile/features/cart/domain/entities/cart_item.dart';
 import 'package:ragro_mobile/features/cart/presentation/bloc/cart_bloc.dart';
 import 'package:ragro_mobile/features/cart/presentation/bloc/cart_event.dart';
 import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
+import 'package:ragro_mobile/shared/widgets/confirm_dialog.dart';
 
 class CartItemTile extends StatelessWidget {
-  const CartItemTile({
-    required this.item,
-    required this.producerId,
-    super.key,
-  });
+  const CartItemTile({required this.item, required this.producerId, super.key});
 
   final CartItem item;
   final String producerId;
@@ -182,9 +179,22 @@ class CartItemTile extends StatelessWidget {
                       const Spacer(),
                       // Delete
                       GestureDetector(
-                        onTap: () => context.read<CartBloc>().add(
-                          CartItemRemoved(item.id),
-                        ),
+                        onTap: () async {
+                          final confirmed = await ConfirmDialog.show(
+                            context: context,
+                            title: 'Tem certeza que deseja excluir ',
+                            highlight: item.productName,
+                            highlightColor: AppColors.red,
+                            trailingTitle: '?',
+                            confirmLabel: 'Excluir',
+                            confirmColor: AppColors.red,
+                          );
+                          if ((confirmed ?? false) && context.mounted) {
+                            context
+                                .read<CartBloc>()
+                                .add(CartItemRemoved(item.id));
+                          }
+                        },
                         child: const Icon(
                           Icons.delete_outline,
                           color: AppColors.red,

--- a/lib/features/orders/domain/entities/order.dart
+++ b/lib/features/orders/domain/entities/order.dart
@@ -76,9 +76,28 @@ class Order extends Equatable {
     if (items.isEmpty) return '';
     return items
             .take(3)
-            .map((i) => '${i.name} ${i.quantity}${i.unityType}')
+            .map((i) => '${i.name} ${i.quantity} ${_localUnit(i.unityType)}')
             .join(' | ') +
         (items.length > 3 ? ' ...' : '');
+  }
+
+  static String _localUnit(String u) {
+    switch (u.toLowerCase().trim()) {
+      case 'unit':
+      case 'un':
+        return 'un';
+      case 'box':
+      case 'cx':
+        return 'caixa';
+      case 'liter':
+      case 'l':
+        return 'L';
+      case 'dozen':
+      case 'dz':
+        return 'dz';
+      default:
+        return u;
+    }
   }
 
   @override

--- a/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -19,6 +19,7 @@ import 'package:ragro_mobile/features/customer_profile/presentation/bloc/custome
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_bloc.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_state.dart';
+import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
 
 class OrderConfirmationPage extends StatelessWidget {
   const OrderConfirmationPage({super.key});
@@ -512,27 +513,14 @@ class _CheckoutView extends StatelessWidget {
                               Icon(Icons.local_shipping_outlined, size: 22),
                               SizedBox(width: 16),
                               Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      'Frete RAGRO Logística',
-                                      style: TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontWeight: FontWeight.w700,
-                                        fontSize: 14,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                    Text(
-                                      'Previsão: 3 a 5 dias úteis',
-                                      style: TextStyle(
-                                        fontFamily: 'Manrope',
-                                        fontSize: 12,
-                                        color: AppColors.placeholder,
-                                      ),
-                                    ),
-                                  ],
+                                child: Text(
+                                  'Frete RAGRO Logística',
+                                  style: TextStyle(
+                                    fontFamily: 'Manrope',
+                                    fontWeight: FontWeight.w700,
+                                    fontSize: 14,
+                                    color: AppColors.black,
+                                  ),
                                 ),
                               ),
                               Text(
@@ -752,7 +740,7 @@ class _CartItemRow extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Qtd: ${_formatQuantity(item.quantity)}${item.unityType}',
+                  'Qtd: ${_formatQuantity(item.quantity)} ${localizeUnityType(item.unityType)}',
                   style: const TextStyle(
                     fontFamily: 'Manrope',
                     fontSize: 14,

--- a/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -20,6 +20,7 @@ import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_bloc.dar
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_state.dart';
 import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
+import 'package:ragro_mobile/shared/widgets/confirm_dialog.dart';
 
 class OrderConfirmationPage extends StatelessWidget {
   const OrderConfirmationPage({super.key});
@@ -36,15 +37,23 @@ class OrderConfirmationPage extends StatelessWidget {
         // instância no subtree, então context.read<CustomerProfileBloc>() em
         // callbacks (ex.: botão "Alterar") referencia o mesmo bloc do BlocBuilder.
         BlocProvider(
-          create: (_) => getIt<CustomerProfileBloc>()
-            ..add(const CustomerProfileStarted()),
+          create: (_) =>
+              getIt<CustomerProfileBloc>()..add(const CustomerProfileStarted()),
         ),
       ],
       child: BlocListener<CheckoutBloc, CheckoutState>(
-        listener: (context, state) {
+        listener: (context, state) async {
           if (state is CheckoutSuccess) {
             getIt<CartBloc>().add(const CartOrderPlaced());
-            context.go('/customer/orders/${state.order.id}');
+            await showDialog<void>(
+              context: context,
+
+              barrierColor: Colors.black.withValues(alpha: 0.55),
+              builder: (_) => const _OrderSuccessDialog(),
+            );
+            if (context.mounted) {
+              context.go('/customer/orders/${state.order.id}');
+            }
           }
           if (state is CheckoutFailure) {
             ScaffoldMessenger.of(context).showSnackBar(
@@ -58,7 +67,9 @@ class OrderConfirmationPage extends StatelessWidget {
         },
         child: BlocBuilder<CheckoutBloc, CheckoutState>(
           builder: (context, state) {
-            if (state is CheckoutLoading || state is CheckoutInitial) {
+            if (state is CheckoutLoading ||
+                state is CheckoutInitial ||
+                state is CheckoutSuccess) {
               return const Scaffold(
                 body: Center(
                   child: CircularProgressIndicator(color: AppColors.darkGreen),
@@ -100,9 +111,9 @@ class OrderConfirmationPage extends StatelessWidget {
                           ),
                           const SizedBox(height: 16),
                           ElevatedButton(
-                            onPressed: () => context
-                                .read<CheckoutBloc>()
-                                .add(const CheckoutStarted('cart')),
+                            onPressed: () => context.read<CheckoutBloc>().add(
+                              const CheckoutStarted('cart'),
+                            ),
                             style: ElevatedButton.styleFrom(
                               backgroundColor: AppColors.darkGreen,
                               foregroundColor: AppColors.white,
@@ -635,9 +646,53 @@ class _CheckoutView extends StatelessWidget {
                   GestureDetector(
                     onTap: isConfirming
                         ? null
-                        : () => context.read<CheckoutBloc>().add(
-                            const CheckoutConfirmed('cart'),
-                          ),
+                        : () async {
+                            // Step 1 — confirm delivery data
+                            final profileState =
+                                context.read<CustomerProfileBloc>().state;
+                            final profile = switch (profileState) {
+                              CustomerProfileLoaded(:final profile) => profile,
+                              CustomerProfileUpdating(:final profile) =>
+                                profile,
+                              CustomerProfileUpdateSuccess(:final profile) =>
+                                profile,
+                              CustomerProfileUpdateFailure(:final profile) =>
+                                profile,
+                              _ => null,
+                            };
+
+                            if (profile != null) {
+                              final destOk = await ConfirmDialog.show(
+                                context: context,
+                                title: 'Os seus dados estão corretos?',
+                                description:
+                                    '${profile.name}\n'
+                                    '${profile.formattedPrimaryAddress}\n'
+                                    '${profile.phone}',
+                                confirmLabel: 'Sim',
+                                confirmColor: AppColors.lightGreen,
+                              );
+                              if (!(destOk ?? false) || !context.mounted) {
+                                return;
+                              }
+                            }
+
+                            // Step 2 — confirm order value
+                            final confirmed = await ConfirmDialog.show(
+                              context: context,
+                              title: 'Confirmar pedido de ',
+                              highlight: _formatPrice(cart.totalAmount),
+                              highlightColor: AppColors.lightGreen,
+                              trailingTitle: '?',
+                              confirmLabel: 'Sim',
+                              confirmColor: AppColors.lightGreen,
+                            );
+                            if ((confirmed ?? false) && context.mounted) {
+                              context
+                                  .read<CheckoutBloc>()
+                                  .add(const CheckoutConfirmed('cart'));
+                            }
+                          },
                     child: Container(
                       height: 56,
                       decoration: BoxDecoration(
@@ -777,9 +832,7 @@ class _DeliveryAddressCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.lightGreen.withValues(alpha: 0.05),
         borderRadius: BorderRadius.circular(24),
-        border: Border.all(
-          color: AppColors.lightGreen.withValues(alpha: 0.1),
-        ),
+        border: Border.all(color: AppColors.lightGreen.withValues(alpha: 0.1)),
       ),
       child: Row(
         children: [
@@ -896,5 +949,66 @@ class _DeliveryAddressCard extends StatelessWidget {
     return neighborhood.isEmpty
         ? '$cityState • $cep'
         : '$neighborhood • $cityState • $cep';
+  }
+}
+
+class _OrderSuccessDialog extends StatelessWidget {
+  const _OrderSuccessDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 40),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: GestureDetector(
+                onTap: () => Navigator.of(context).pop(),
+                child: Container(
+                  width: 32,
+                  height: 32,
+                  decoration: const BoxDecoration(
+                    color: AppColors.lightGreen,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.close,
+                    color: AppColors.white,
+                    size: 18,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            RichText(
+              textAlign: TextAlign.center,
+              text: const TextSpan(
+                style: TextStyle(
+                  fontFamily: 'Figtree',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 20,
+                  color: AppColors.black,
+                  height: 1.4,
+                ),
+                children: [
+                  TextSpan(text: 'Seu pedido foi realizado com '),
+                  TextSpan(
+                    text: 'sucesso',
+                    style: TextStyle(color: AppColors.lightGreen),
+                  ),
+                  TextSpan(text: '!'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/orders/presentation/pages/order_detail_page.dart
+++ b/lib/features/orders/presentation/pages/order_detail_page.dart
@@ -13,6 +13,7 @@ import 'package:ragro_mobile/features/orders/domain/entities/order_detail.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_bloc.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_event.dart';
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_state.dart';
+import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
 import 'package:ragro_mobile/shared/widgets/cancel_order_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -473,7 +474,7 @@ class _OrderDetailItemRow extends StatelessWidget {
     final value = item.quantity % 1 == 0
         ? item.quantity.toInt().toString()
         : item.quantity.toStringAsFixed(2).replaceAll('.', ',');
-    return 'Qtd: $value${item.unityType}';
+    return 'Qtd: $value ${localizeUnityType(item.unityType)}';
   }
 
   @override

--- a/lib/features/orders/presentation/pages/order_detail_page.dart
+++ b/lib/features/orders/presentation/pages/order_detail_page.dart
@@ -22,30 +22,6 @@ class OrderDetailPage extends StatelessWidget {
 
   final String orderId;
 
-  String _formatPrice(double price) =>
-      'R\$ ${price.toStringAsFixed(2).replaceAll('.', ',')}';
-
-  Future<void> _openWhatsApp(BuildContext context, String phoneNumber) async {
-    final cleanPhone = phoneNumber.replaceAll(RegExp(r'[^\d+]'), '');
-    final formattedPhone = cleanPhone.startsWith('+')
-        ? cleanPhone.replaceFirst('+', '')
-        : cleanPhone;
-    final uri = Uri.parse('https://wa.me/$formattedPhone');
-
-    try {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    } on Object {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Não foi possível abrir o WhatsApp'),
-            duration: Duration(seconds: 2),
-          ),
-        );
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
@@ -868,7 +844,11 @@ class _ActionFooter extends StatelessWidget {
     final result = await CancelOrderDialog.showForCustomer(context);
     if (result != null && context.mounted) {
       context.read<OrderDetailBloc>().add(
-        OrderDetailCancelled(order.id, reason: result.reason, details: result.details),
+        OrderDetailCancelled(
+          order.id,
+          reason: result.reason,
+          details: result.details,
+        ),
       );
     }
   }

--- a/lib/features/orders/presentation/widgets/order_item_row.dart
+++ b/lib/features/orders/presentation/widgets/order_item_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order_item.dart';
+import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
 
 class OrderItemRow extends StatelessWidget {
   const OrderItemRow({required this.item, super.key});
@@ -50,7 +51,7 @@ class OrderItemRow extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Qtd: ${item.quantity}${item.unityType}',
+                  'Qtd: ${item.quantity} ${localizeUnityType(item.unityType)}',
                   style: const TextStyle(
                     fontFamily: 'Manrope',
                     fontSize: 14,

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -15,6 +15,7 @@ import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_o
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_event.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_state.dart';
+import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
 import 'package:ragro_mobile/shared/widgets/cancel_order_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -465,7 +466,7 @@ class _ProducerOrderItemRow extends StatelessWidget {
     symbol: r'R$',
   );
 
-  String get _quantity => 'Qtd: ${item.quantity}${item.unityType}';
+  String get _quantity => 'Qtd: ${item.quantity} ${localizeUnityType(item.unityType)}';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/shared/utils/unity_type_label.dart
+++ b/lib/shared/utils/unity_type_label.dart
@@ -22,13 +22,17 @@ String localizeUnityType(String unityType) {
     case 'ml':
       return 'ml';
     case 'unit':
-      return 'unidade';
+    case 'un':
+      return 'un';
     case 'box':
+    case 'cx':
       return 'caixa';
     case 'liter':
-      return 'litro';
+    case 'l':
+      return 'L';
     case 'dozen':
-      return 'dúzia';
+    case 'dz':
+      return 'dz';
     default:
       return unityType;
   }

--- a/test/features/cart/presentation/widgets/cart_item_tile_test.dart
+++ b/test/features/cart/presentation/widgets/cart_item_tile_test.dart
@@ -126,25 +126,22 @@ void main() {
       },
     );
 
-    testWidgets(
-      'tap fica desabilitado quando producerId vier vazio (evita URL '
-      'quebrada /producers//products/:id)',
-      (tester) async {
-        String? pushedLocation;
-        await tester.pumpWidget(
-          buildSubject(
-            item: buildItem(),
-            producerId: '',
-            onPush: (loc, _) => pushedLocation = loc,
-          ),
-        );
+    testWidgets('tap fica desabilitado quando producerId vier vazio (evita URL '
+        'quebrada /producers//products/:id)', (tester) async {
+      String? pushedLocation;
+      await tester.pumpWidget(
+        buildSubject(
+          item: buildItem(),
+          producerId: '',
+          onPush: (loc, _) => pushedLocation = loc,
+        ),
+      );
 
-        await tester.tap(find.text('Morango Orgânico'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Morango Orgânico'));
+      await tester.pumpAndSettle();
 
-        expect(pushedLocation, isNull);
-      },
-    );
+      expect(pushedLocation, isNull);
+    });
   });
 
   group('mutações', () {
@@ -192,13 +189,36 @@ void main() {
       },
     );
 
-    testWidgets('ícone de lixeira dispara CartItemRemoved', (tester) async {
-      await tester.pumpWidget(buildSubject(item: buildItem()));
+    testWidgets(
+      'ícone de lixeira abre confirmação e dispara CartItemRemoved ao confirmar',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(item: buildItem()));
 
-      await tester.tap(find.byIcon(Icons.delete_outline));
-      await tester.pump();
+        await tester.tap(find.byIcon(Icons.delete_outline));
+        await tester.pumpAndSettle();
 
-      verify(() => bloc.add(const CartItemRemoved('item-1'))).called(1);
-    });
+        expect(find.text('Excluir'), findsOneWidget);
+
+        await tester.tap(find.text('Excluir'));
+        await tester.pumpAndSettle();
+
+        verify(() => bloc.add(const CartItemRemoved('item-1'))).called(1);
+      },
+    );
+
+    testWidgets(
+      'ícone de lixeira NÃO dispara CartItemRemoved ao cancelar',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(item: buildItem()));
+
+        await tester.tap(find.byIcon(Icons.delete_outline));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Cancelar'));
+        await tester.pumpAndSettle();
+
+        verifyNever(() => bloc.add(const CartItemRemoved('item-1')));
+      },
+    );
   });
 }

--- a/test/shared/utils/unity_type_label_test.dart
+++ b/test/shared/utils/unity_type_label_test.dart
@@ -4,10 +4,17 @@ import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
 void main() {
   group('localizeUnityType', () {
     test('traduz unidades em inglês para abreviações pt-BR', () {
-      expect(localizeUnityType('unit'), 'unidade');
+      expect(localizeUnityType('unit'), 'un');
       expect(localizeUnityType('box'), 'caixa');
-      expect(localizeUnityType('liter'), 'litro');
-      expect(localizeUnityType('dozen'), 'dúzia');
+      expect(localizeUnityType('liter'), 'L');
+      expect(localizeUnityType('dozen'), 'dz');
+    });
+
+    test('aceita variantes já abreviadas', () {
+      expect(localizeUnityType('un'), 'un');
+      expect(localizeUnityType('cx'), 'caixa');
+      expect(localizeUnityType('l'), 'L');
+      expect(localizeUnityType('dz'), 'dz');
     });
 
     test('mantém unidades já universais', () {
@@ -17,13 +24,13 @@ void main() {
     });
 
     test('é case-insensitive', () {
-      expect(localizeUnityType('UNIT'), 'unidade');
+      expect(localizeUnityType('UNIT'), 'un');
       expect(localizeUnityType('Box'), 'caixa');
-      expect(localizeUnityType('LITER'), 'litro');
+      expect(localizeUnityType('LITER'), 'L');
     });
 
     test('ignora espaços ao redor', () {
-      expect(localizeUnityType('  unit  '), 'unidade');
+      expect(localizeUnityType('  unit  '), 'un');
     });
 
     test('retorna vazio para entrada vazia', () {


### PR DESCRIPTION
## O que mudou?
Modal de confirmação ao limpar o carrinho — ao tocar em "Limpar", exibe o modal "Tem certeza que deseja excluir todo o carrinho?" antes de executar a ação.

Modal de confirmação ao remover um item — ao tocar no ícone de lixeira de um item, exibe o modal "Tem certeza que deseja excluir [nome do produto]?" antes de remover.

Modais de confirmação de pedido em dois passos — ao tocar em "Confirmar Pedido":

Passo 1: "Os seus dados estão corretos?" exibindo nome, endereço e telefone do perfil do comprador
Passo 2: "Confirmar pedido de R$ [valor]?"
Modal de pedido realizado com sucesso — após a confirmação, exibe "Seu pedido foi realizado com sucesso!" com botão X verde; ao fechar navega para o detalhe do pedido.

Fix: botão X do modal de sucesso não funcionava — o botão estava posicionado fora dos bounds do Dialog (Positioned top/right: -14), onde Flutter não registra toques. Reestruturado com layout interno (Column + Align).

Fix: fundo do modal de sucesso exibia "Tentar novamente" — quando o estado CheckoutSuccess era emitido, o BlocBuilder caía no fallback de erro (cart nulo). Corrigido tratando CheckoutSuccess como estado de loading no builder.


## Tipo de mudança

- [x] Nova feature
- [x] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?
Limpar carrinho: Adicionar itens ao carrinho → tocar em "Limpar" no topo → confirmar que o modal aparece → tocar "Excluir" e verificar que o carrinho é esvaziado; tocar "Cancelar" e verificar que nada muda.

Remover item: No carrinho, tocar no ícone de lixeira de um item → confirmar que o modal aparece com o nome do produto destacado em vermelho → confirmar remoção e cancelamento.

Fluxo de confirmação de pedido: Ir até a tela de confirmação → tocar "Confirmar Pedido" → verificar que aparece primeiro o modal de dados de entrega (nome, endereço, telefone) → tocar "Sim" → verificar que aparece o modal com o valor total → tocar "Sim" → verificar que o modal de sucesso aparece com botão X verde funcional → ao fechar, confirmar navegação para o detalhe do pedido.

Cancelar em qualquer etapa: Em qualquer modal da etapa 3, tocar "Cancelar" e verificar que o pedido não é enviado e a tela de confirmação continua aberta.


## Screenshots / Gravações
<img width="562" height="495" alt="image" src="https://github.com/user-attachments/assets/de861af4-3c72-4841-a215-9fc8657e56dd" />

<img width="542" height="483" alt="image" src="https://github.com/user-attachments/assets/1508e491-9964-46d2-90ff-301c7b9158c8" />
<img width="536" height="362" alt="image" src="https://github.com/user-attachments/assets/133096a4-be2d-4ea8-a331-97a5e48cef69" />
<img width="521" height="337" alt="image" src="https://github.com/user-attachments/assets/156b19ea-a150-4dca-abd0-f15935494247" />
<img width="508" height="312" alt="image" src="https://github.com/user-attachments/assets/77e2f66f-f906-4455-9371-72f345c4f88e" />
<img width="490" height="240" alt="image" src="https://github.com/user-attachments/assets/406dda8d-9ee4-41a1-8156-c3c840ca21b0" />


<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist

- [x] Código formatado (`dart format .`) 338 arquivos verificados, 0 alterados
- [x] Sem warnings no analyze (`dart analyze`) 0 warnings nos arquivos da branch (8 warnings pré-existentes em arquivos não tocados)
- [x] Testes passando (`flutter test`) 140/140
- [x] Segue o padrão de arquitetura do projeto
