### PR TITLE
implementacao para tag novo e pendente

### DIFF
--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -60,6 +60,7 @@ abstract final class ApiEndpoints {
   static String orderConfirm(String id) => '$_base/orders/$id/confirm';
   static String orderRepeat(String id) => '$_base/orders/$id/repeat';
   static String orderRating(String id) => '$_base/orders/$id/rating';
+  static String orderSeen(String id) => '$_base/orders/$id/seen';
   static String get reviews => '$_base/reviews';
 
   // Customer cart

--- a/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
+++ b/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
@@ -70,6 +70,14 @@ class ProducerOrdersRemoteDataSource {
     }
   }
 
+  Future<void> markAsSeen(String id) async {
+    try {
+      await _apiClient.dio.patch<void>(ApiEndpoints.orderSeen(id));
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
   List<Map<String, dynamic>> _readList(dynamic data) {
     final rawList = switch (data) {
       final List<dynamic> list => list,

--- a/lib/features/producer_orders/data/repositories/producer_orders_repository_impl.dart
+++ b/lib/features/producer_orders/data/repositories/producer_orders_repository_impl.dart
@@ -27,4 +27,7 @@ class ProducerOrdersRepositoryImpl implements ProducerOrdersRepository {
   @override
   Future<void> updateStatus(String id, ProducerOrderStatus status) =>
       _dataSource.updateStatus(id, status);
+
+    @override
+    Future<void> markAsSeen(String id) => _dataSource.markAsSeen(id);
 }

--- a/lib/features/producer_orders/domain/repositories/producer_orders_repository.dart
+++ b/lib/features/producer_orders/domain/repositories/producer_orders_repository.dart
@@ -7,4 +7,5 @@ abstract class ProducerOrdersRepository {
   Future<void> confirmOrder(String id);
   Future<void> refuseOrder(String id, {required String reason, String? details});
   Future<void> updateStatus(String id, ProducerOrderStatus status);
+  Future<void> markAsSeen(String id);
 }

--- a/lib/features/producer_orders/domain/usecases/mark_producer_order_seen.dart
+++ b/lib/features/producer_orders/domain/usecases/mark_producer_order_seen.dart
@@ -1,0 +1,11 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/repositories/producer_orders_repository.dart';
+
+@lazySingleton
+class MarkProducerOrderSeen {
+  const MarkProducerOrderSeen(this._repository);
+
+  final ProducerOrdersRepository _repository;
+
+  Future<void> call(String id) => _repository.markAsSeen(id);
+}

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
@@ -5,6 +5,8 @@ import 'package:ragro_mobile/features/producer_orders/domain/usecases/confirm_pr
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/get_producer_order_detail.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/refuse_producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/update_producer_order_status.dart';
+import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/features/producer_orders/domain/repositories/producer_orders_repository.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_event.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_order_detail_state.dart';
 
@@ -33,13 +35,30 @@ class ProducerOrderDetailBloc
     Emitter<ProducerOrderDetailState> emit,
   ) async {
     if (event.initialOrder != null) {
-      emit(ProducerOrderDetailLoaded(event.initialOrder!));
+      final initial = event.initialOrder!;
+      emit(ProducerOrderDetailLoaded(initial));
+      // Mark as seen when producer opened the detail and update local view
+      try {
+        await getIt<ProducerOrdersRepository>().markAsSeen(event.orderId);
+        final updated = initial.copyWith(isNew: false);
+        emit(ProducerOrderDetailLoaded(updated));
+      } catch (_) {
+        // swallow: non-critical
+      }
       return;
     }
+
     emit(const ProducerOrderDetailLoading());
     try {
       final order = await _getDetail(event.orderId);
-      emit(ProducerOrderDetailLoaded(order));
+      // Mark as seen after loading details and update view
+      try {
+        await getIt<ProducerOrdersRepository>().markAsSeen(event.orderId);
+        final updated = order.copyWith(isNew: false);
+        emit(ProducerOrderDetailLoaded(updated));
+      } catch (_) {
+        emit(ProducerOrderDetailLoaded(order));
+      }
     } on Exception catch (e) {
       emit(ProducerOrderDetailFailure(e.toString()));
     }
@@ -89,6 +108,7 @@ class ProducerOrderDetailBloc
   ) async {
     final current = state;
     if (current is! ProducerOrderDetailLoaded) return;
+
     emit(ProducerOrderDetailUpdatingStatus(current.order));
     try {
       await _updateStatus(event.orderId, event.status);
@@ -96,7 +116,14 @@ class ProducerOrderDetailBloc
       emit(
         ProducerOrderDetailSuccess(order: updated, action: 'status_updated'),
       );
-      emit(ProducerOrderDetailLoaded(updated));
+      
+      try {
+        await getIt<ProducerOrdersRepository>().markAsSeen(event.orderId);
+        final updatedSeen = updated.copyWith(isNew: false);
+        emit(ProducerOrderDetailLoaded(updatedSeen));
+      } catch (_) {
+        emit(ProducerOrderDetailLoaded(updated));
+      }
     } on Exception catch (e) {
       emit(ProducerOrderDetailFailure(e.toString()));
     }

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
@@ -23,6 +23,7 @@ class ProducerOrdersBloc
     on<ProducerOrderAccepted>(_onAccepted);
     on<ProducerOrderCancelled>(_onCancelled);
     on<ProducerOrderLocallyRefused>(_onLocallyRefused);
+    on<ProducerOrderLocallySeen>(_onLocallySeen);
     on<ProducerOrderMarkedInDelivery>(_onMarkedInDelivery);
     on<ProducerOrderDeliveryConfirmed>(_onDeliveryConfirmed);
     on<ProducerOrderLocallyDelivered>(_onLocallyDelivered);
@@ -130,6 +131,25 @@ class ProducerOrdersBloc
           (o) => o.id == event.orderId
               ? o.copyWith(status: ProducerOrderStatus.cancelled)
               : o,
+        )
+        .toList();
+    emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));
+  }
+
+  void _onLocallySeen(
+    ProducerOrderLocallySeen event,
+    Emitter<ProducerOrdersState> emit,
+  ) {
+    final currentOrders = switch (state) {
+      ProducerOrdersLoaded(:final orders) => orders,
+      ProducerOrdersActionSuccess(:final orders) => orders,
+      _ => null,
+    };
+    if (currentOrders == null) return;
+
+    final updated = currentOrders
+        .map(
+          (o) => o.id == event.orderId ? o.copyWith(isNew: false) : o,
         )
         .toList();
     emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
@@ -80,3 +80,12 @@ class ProducerOrderLocallyDelivered extends ProducerOrdersEvent {
   @override
   List<Object?> get props => [orderId];
 }
+
+class ProducerOrderLocallySeen extends ProducerOrdersEvent {
+  const ProducerOrderLocallySeen(this.orderId);
+
+  final String orderId;
+
+  @override
+  List<Object?> get props => [orderId];
+}

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -52,6 +52,12 @@ class ProducerOrderDetailPage extends StatelessWidget {
               context.pop('cancelled');
               return;
             }
+            // When the producer performed actions except status updates, we still
+            // want to signal that the order was seen so the list updates.
+            if (state.action == 'confirmed' || state.action == 'refused' || state.action == 'viewed') {
+              context.pop('seen');
+              return;
+            }
             final message = switch (state.action) {
               'confirmed' => 'Pedido aceito com sucesso.',
               _ => 'Ação concluída.',
@@ -93,9 +99,17 @@ class ProducerOrderDetailPage extends StatelessWidget {
               state is ProducerOrderDetailRefusing ||
               state is ProducerOrderDetailUpdatingStatus;
 
-          return _ProducerOrderDetailView(
-            order: order,
-            isProcessing: isProcessing,
+          return WillPopScope(
+            onWillPop: () async {
+              // When user navigates back (system or app), return 'seen' if the
+              // order was previously new so the list can update immediately.
+              context.pop(order.isNew ? 'seen' : null);
+              return false;
+            },
+            child: _ProducerOrderDetailView(
+              order: order,
+              isProcessing: isProcessing,
+            ),
           );
         },
       ),
@@ -215,7 +229,7 @@ class _Header extends StatelessWidget {
       child: Row(
         children: [
           GestureDetector(
-            onTap: () => context.pop(),
+            onTap: () => context.pop(order.isNew ? 'seen' : null),
             child: const Padding(
               padding: EdgeInsets.all(8),
               child: Icon(Icons.arrow_back, size: 18),

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -323,6 +323,10 @@ class _ProducerOrdersView extends StatelessWidget {
                                     context.read<ProducerOrdersBloc>().add(
                                       ProducerOrderLocallyDelivered(order.id),
                                     );
+                                  } else if (result == 'seen') {
+                                    context.read<ProducerOrdersBloc>().add(
+                                      ProducerOrderLocallySeen(order.id),
+                                    );
                                   }
                                 },
                                 onCancelTap:

--- a/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
+++ b/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
@@ -102,23 +102,24 @@ class ProducerOrderCard extends StatelessWidget {
                   ],
                 ),
               ),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: _statusColor.withValues(alpha: 0.12),
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: Text(
-                  order.status.label.toUpperCase(),
-                  style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 11,
-                    color: _statusColor,
-                    letterSpacing: 0.5,
+              if (order.status != ProducerOrderStatus.pending)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: _statusColor.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Text(
+                    order.status.label.toUpperCase(),
+                    style: TextStyle(
+                      fontFamily: 'Manrope',
+                      fontWeight: FontWeight.w700,
+                      fontSize: 11,
+                      color: _statusColor,
+                      letterSpacing: 0.5,
+                    ),
                   ),
                 ),
-              ),
               const SizedBox(width: 6),
               if (order.isNew)
                 Container(


### PR DESCRIPTION
## O que mudou?

Este pr faz a integracao com as rotas de orderSeen, quando o produtor clica em detalhes do pedido, na aba pedidos pendentes, a tag "novo" desaparecera (precisa deslogar e logar de novo). Alem disso, foi retirado a tag "pendente" na aba de pedidos pendentes, objetivando maior aproximacao visual com a tela prototipada no Figma.

## Tipo de mudança

- [X] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?

Basta fazer um pedido como produtor, e entrar como produtor e entrar nos detalhes do pedido pendente. Ao logar de novo a tag "novo" desaperecera

## Screenshots / Gravações

<img width="631" height="656" alt="image" src="https://github.com/user-attachments/assets/66430967-9964-4613-835a-be2086cc49f5" />

<img width="629" height="506" alt="image" src="https://github.com/user-attachments/assets/613cf096-7fe7-4527-93cb-b91362a5a628" />


## Checklist

- [ ] Código formatado (`dart format .`)
- [ ] Sem warnings no analyze (`dart analyze`)
- [ ] Testes passando (`flutter test`)
- [ ] Segue o padrão de arquitetura do projeto
