### PR TITLE
Ajustes pedidos produtor

### DIFF
--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -55,7 +55,9 @@ class _ErrorInterceptor extends Interceptor {
       exception = switch (statusCode) {
         400 => UnknownApiException(responseMessage ?? 'Dados invalidos'),
         401 => _map401(err.response?.data),
-        403 => ForbiddenException(responseMessage ?? 'Sem permissao para esta acao'),
+        403 => ForbiddenException(
+          responseMessage ?? 'Sem permissao para esta acao',
+        ),
         404 => NotFoundException(responseMessage ?? 'Recurso nao encontrado'),
         409 => ConflictException(responseMessage ?? 'Recurso ja existe'),
         429 => const RateLimitedException(),

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -112,12 +112,12 @@ class AppRouter {
                             return ReviewsPage(
                               producerId: state.pathParameters['producerId']!,
                               producerName:
-                              extra['producerName'] as String? ?? '',
+                                  extra['producerName'] as String? ?? '',
                               producerLocation:
-                              extra['producerLocation'] as String? ?? '',
+                                  extra['producerLocation'] as String? ?? '',
                               averageRating:
-                              (extra['averageRating'] as num?)
-                                  ?.toDouble() ??
+                                  (extra['averageRating'] as num?)
+                                      ?.toDouble() ??
                                   0.0,
                               totalReviews: extra['totalReviews'] as int? ?? 0,
                             );
@@ -297,7 +297,7 @@ class AppRouter {
                           productName: extra['productName'] as String? ?? '',
                           unit: extra['unit'] as String? ?? 'un',
                           currentStock:
-                          (extra['currentStock'] as num?)?.toDouble() ??
+                              (extra['currentStock'] as num?)?.toDouble() ??
                               0.0,
                         );
                       },
@@ -340,9 +340,9 @@ class AppRouter {
                           producerId: extra['producerId'] as String? ?? '',
                           producerName: extra['producerName'] as String? ?? '',
                           producerLocation:
-                          extra['producerLocation'] as String? ?? '',
+                              extra['producerLocation'] as String? ?? '',
                           averageRating:
-                          (extra['averageRating'] as num?)?.toDouble() ??
+                              (extra['averageRating'] as num?)?.toDouble() ??
                               0.0,
                           totalReviews: extra['totalReviews'] as int? ?? 0,
                         );

--- a/lib/features/auth/presentation/pages/customer_register_page.dart
+++ b/lib/features/auth/presentation/pages/customer_register_page.dart
@@ -379,7 +379,9 @@ class _CustomerRegisterViewState extends State<_CustomerRegisterView> {
                           if (value == null || value.trim().isEmpty) {
                             return 'Informe a UF';
                           }
-                          if (!_brazilianStates.contains(value.trim().toUpperCase())) {
+                          if (!_brazilianStates.contains(
+                            value.trim().toUpperCase(),
+                          )) {
                             return 'UF inválida';
                           }
                           return null;

--- a/lib/features/home/data/datasources/home_remote_datasource.dart
+++ b/lib/features/home/data/datasources/home_remote_datasource.dart
@@ -53,27 +53,21 @@ class HomeRemoteDataSource {
         if (raw is List) {
           list = raw.cast<Map<String, dynamic>>();
         } else if (raw is Map) {
-          list =
-              (raw['content'] as List?)?.cast<Map<String, dynamic>>() ?? [];
+          list = (raw['content'] as List?)?.cast<Map<String, dynamic>>() ?? [];
         } else {
           list = [];
         }
         products.addAll(
-          list
-              .cast<Map<String, dynamic>>()
-              .map(
-                (json) => HomeProductModel.fromJson(
-                  json,
-                  fallbackFarmName: producer.name,
-                ),
-              ),
+          list.cast<Map<String, dynamic>>().map(
+            (json) => HomeProductModel.fromJson(
+              json,
+              fallbackFarmName: producer.name,
+            ),
+          ),
         );
       }
 
-      return (
-        products: products,
-        hasMore: producerPage < paged.totalPages - 1,
-      );
+      return (products: products, hasMore: producerPage < paged.totalPages - 1);
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();
     }

--- a/lib/features/home/data/models/home_product_model.dart
+++ b/lib/features/home/data/models/home_product_model.dart
@@ -30,10 +30,11 @@ class HomeProductModel extends HomeProduct {
           '',
       price: (json['price'] as num?)?.toDouble() ?? 0,
       imageUrl: ApiEndpoints.resolveMediaUrl(
-          json['imageS3'] as String? ??
-          json['image_s3'] as String? ??
-          json['imageUrl'] as String? ??
-          ''),
+        json['imageS3'] as String? ??
+            json['image_s3'] as String? ??
+            json['imageUrl'] as String? ??
+            '',
+      ),
       farmName:
           json['farmName'] as String? ??
           json['farm_name'] as String? ??
@@ -45,5 +46,4 @@ class HomeProductModel extends HomeProduct {
           '',
     );
   }
-
 }

--- a/lib/features/home/data/models/producer_model.dart
+++ b/lib/features/home/data/models/producer_model.dart
@@ -18,9 +18,13 @@ class ProducerModel extends Producer {
       name: json['farm_name'] as String? ?? 'Fazenda sem nome',
       description: json['description'] as String? ?? '',
       avatarUrl: ApiEndpoints.resolveMediaUrl(
-          json['avatar_s3'] as String? ?? json['avatarUrl'] as String? ?? ''),
+        json['avatar_s3'] as String? ?? json['avatarUrl'] as String? ?? '',
+      ),
       coverUrl: ApiEndpoints.resolveMediaUrl(
-          json['display_photo_s3'] as String? ?? json['coverUrl'] as String? ?? ''),
+        json['display_photo_s3'] as String? ??
+            json['coverUrl'] as String? ??
+            '',
+      ),
       averageRating: (json['average_rating'] as num?)?.toDouble() ?? 0.0,
       ownerName: json['owner_name'] as String? ?? '',
     );

--- a/lib/features/home/domain/usecases/get_home_data.dart
+++ b/lib/features/home/domain/usecases/get_home_data.dart
@@ -10,11 +10,13 @@ class GetHomeData {
 
   final HomeRepository _repository;
 
-  Future<({
-    PaginatedResponse<Producer> producers,
-    List<HomeProduct> products,
-    bool hasMoreProducts,
-  })>
+  Future<
+    ({
+      PaginatedResponse<Producer> producers,
+      List<HomeProduct> products,
+      bool hasMoreProducts,
+    })
+  >
   call() async {
     final (producersResponse, productsResult) = await (
       _repository.getProducers(),

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -31,13 +31,10 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   Future<void> _onStarted(HomeEvent event, Emitter<HomeState> emit) async {
     emit(const HomeLoading());
     try {
-      final results = await Future.wait([
+      final (data, favorites) = await (
         _getHomeData(),
         _favoriteRepository.getFavorites(),
-      ]);
-
-      final data = results[0] as dynamic;
-      final favorites = results[1] as dynamic;
+      ).wait;
 
       emit(
         HomeLoaded(
@@ -58,9 +55,9 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   Future<void> _onFavoriteToggled(
-      HomeFavoriteToggled event,
-      Emitter<HomeState> emit,
-      ) async {
+    HomeFavoriteToggled event,
+    Emitter<HomeState> emit,
+  ) async {
     final current = state;
     if (current is! HomeLoaded) return;
 
@@ -88,10 +85,12 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         await _favoriteRepository.favoriteProducer(event.producerId);
       }
       final favorites = await _favoriteRepository.getFavorites();
-      emit(current.copyWith(
-        favorites: favorites,
-        favoriteIds: {for (final f in favorites) f.producerId},
-      ));
+      emit(
+        current.copyWith(
+          favorites: favorites,
+          favoriteIds: {for (final f in favorites) f.producerId},
+        ),
+      );
     } on Object {
       emit(current.copyWith(favoriteIds: current.favoriteIds));
     }

--- a/lib/features/inventory/data/datasources/inventory_remote_datasource.dart
+++ b/lib/features/inventory/data/datasources/inventory_remote_datasource.dart
@@ -56,9 +56,7 @@ class InventoryRemoteDataSource {
 
   Future<void> deleteProduct(String id) async {
     try {
-      await _apiClient.dio.delete<void>(
-        ApiEndpoints.producerInventoryItem(id),
-      );
+      await _apiClient.dio.delete<void>(ApiEndpoints.producerInventoryItem(id));
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();
     }
@@ -75,7 +73,10 @@ class InventoryRemoteDataSource {
     }
   }
 
-  Future<InventoryProduct> uploadProductPhoto(String productId, XFile file) async {
+  Future<InventoryProduct> uploadProductPhoto(
+    String productId,
+    XFile file,
+  ) async {
     try {
       final formData = FormData.fromMap({
         'file': await multipartFromXFile(file),

--- a/lib/features/inventory/domain/entities/inventory_product.dart
+++ b/lib/features/inventory/domain/entities/inventory_product.dart
@@ -32,7 +32,9 @@ class InventoryProduct extends Equatable {
         producerId: (json['farmerId'] as String?) ?? '',
         name: (json['name'] as String?) ?? '',
         description: (json['description'] as String?) ?? '',
-        imageUrl: ApiEndpoints.resolveMediaUrl((json['imageS3'] as String?) ?? ''),
+        imageUrl: ApiEndpoints.resolveMediaUrl(
+          (json['imageS3'] as String?) ?? '',
+        ),
         price: (json['price'] as num?)?.toDouble() ?? 0.0,
         unit: (json['unityType'] as String?) ?? 'un',
         stock: (json['stockQuantity'] as num?)?.toDouble() ?? 0.0,

--- a/lib/features/inventory/domain/entities/stock_movement.dart
+++ b/lib/features/inventory/domain/entities/stock_movement.dart
@@ -17,7 +17,8 @@ class StockMovement extends Equatable {
   final String productId;
   final String productName;
   final String type; // 'ENTRY' | 'EXIT'
-  final String reason; // 'SALE' | 'LOSS' | 'DISPOSAL' | 'MANUAL_ENTRY' | 'CANCELED_SALE'
+  final String
+  reason; // 'SALE' | 'LOSS' | 'DISPOSAL' | 'MANUAL_ENTRY' | 'CANCELED_SALE'
   final double quantity;
   final String? notes;
   final DateTime createdAt;

--- a/lib/features/inventory/presentation/bloc/product_form_event.dart
+++ b/lib/features/inventory/presentation/bloc/product_form_event.dart
@@ -34,7 +34,15 @@ class ProductFormSaved extends ProductFormEvent {
   final XFile? photo;
 
   @override
-  List<Object?> get props => [name, description, price, unit, stock, categoryIds, photo];
+  List<Object?> get props => [
+    name,
+    description,
+    price,
+    unit,
+    stock,
+    categoryIds,
+    photo,
+  ];
 }
 
 class ProductFormPhotoPicked extends ProductFormEvent {

--- a/lib/features/inventory/presentation/bloc/stock_movements_bloc.dart
+++ b/lib/features/inventory/presentation/bloc/stock_movements_bloc.dart
@@ -7,7 +7,8 @@ import 'package:ragro_mobile/features/inventory/presentation/bloc/stock_movement
 @injectable
 class StockMovementsBloc
     extends Bloc<StockMovementsEvent, StockMovementsState> {
-  StockMovementsBloc(this._getMovements) : super(const StockMovementsInitial()) {
+  StockMovementsBloc(this._getMovements)
+    : super(const StockMovementsInitial()) {
     on<StockMovementsStarted>(_onStarted);
   }
 

--- a/lib/features/inventory/presentation/pages/inventory_page.dart
+++ b/lib/features/inventory/presentation/pages/inventory_page.dart
@@ -64,15 +64,14 @@ class _InventoryView extends StatelessWidget {
                       ),
                       if (state is InventoryLoaded)
                         GestureDetector(
-                          onTap: () => context
-                              .push('/producer/stock/new')
-                              .then((_) {
-                            if (context.mounted) {
-                              context
-                                  .read<InventoryBloc>()
-                                  .add(const InventoryRefreshed());
-                            }
-                          }),
+                          onTap: () =>
+                              context.push('/producer/stock/new').then((_) {
+                                if (context.mounted) {
+                                  context.read<InventoryBloc>().add(
+                                    const InventoryRefreshed(),
+                                  );
+                                }
+                              }),
                           child: Container(
                             padding: const EdgeInsets.symmetric(
                               horizontal: 16,
@@ -237,47 +236,46 @@ class _InventoryView extends StatelessWidget {
                               return InventoryProductCard(
                                 product: product,
                                 onEditTap: () => context
-                                    .push(
-                                  '/producer/stock/${product.id}/edit',
-                                )
+                                    .push('/producer/stock/${product.id}/edit')
                                     .then((_) {
-                                  if (context.mounted) {
-                                    context.read<InventoryBloc>().add(
-                                      const InventoryRefreshed(),
-                                    );
-                                  }
-                                }),
+                                      if (context.mounted) {
+                                        context.read<InventoryBloc>().add(
+                                          const InventoryRefreshed(),
+                                        );
+                                      }
+                                    }),
                                 onEntryTap: () => context
                                     .push(
-                                  '/producer/stock/${product.id}/entry',
-                                  extra: {
-                                    'productName': product.name,
-                                    'unit': product.unit,
-                                  },
-                                )
+                                      '/producer/stock/${product.id}/entry',
+                                      extra: {
+                                        'productName': product.name,
+                                        'unit': product.unit,
+                                      },
+                                    )
                                     .then((result) {
-                                  if (result == true && context.mounted) {
-                                    context.read<InventoryBloc>().add(
-                                      const InventoryRefreshed(),
-                                    );
-                                  }
-                                }),
+                                      if (result == true && context.mounted) {
+                                        context.read<InventoryBloc>().add(
+                                          const InventoryRefreshed(),
+                                        );
+                                      }
+                                    }),
                                 onExitTap: () => context
                                     .push(
-                                  '/producer/stock/${product.id}/exit',
-                                  extra: {
-                                    'productName': product.name,
-                                    'unit': product.unit,
-                                    'currentStock': product.stock.toDouble(),
-                                  },
-                                )
+                                      '/producer/stock/${product.id}/exit',
+                                      extra: {
+                                        'productName': product.name,
+                                        'unit': product.unit,
+                                        'currentStock': product.stock
+                                            .toDouble(),
+                                      },
+                                    )
                                     .then((result) {
-                                  if (result == true && context.mounted) {
-                                    context.read<InventoryBloc>().add(
-                                      const InventoryRefreshed(),
-                                    );
-                                  }
-                                }),
+                                      if (result == true && context.mounted) {
+                                        context.read<InventoryBloc>().add(
+                                          const InventoryRefreshed(),
+                                        );
+                                      }
+                                    }),
                                 onHistoryTap: () => context.push(
                                   '/producer/stock/${product.id}/history',
                                   extra: {'productName': product.name},

--- a/lib/features/inventory/presentation/pages/product_form_page.dart
+++ b/lib/features/inventory/presentation/pages/product_form_page.dart
@@ -54,7 +54,17 @@ class _ProductFormViewState extends State<_ProductFormView> {
   List<int> _selectedCategoryIds = [];
   List<Map<String, dynamic>> _availableCategories = [];
 
-  static const _units = ['kg', 'g', 'un', 'maço', 'pacote', 'box', 'liter', 'ml', 'dozen'];
+  static const _units = [
+    'kg',
+    'g',
+    'un',
+    'maço',
+    'pacote',
+    'box',
+    'liter',
+    'ml',
+    'dozen',
+  ];
 
   @override
   void dispose() {
@@ -221,7 +231,7 @@ class _ProductFormViewState extends State<_ProductFormView> {
                                 image: kIsWeb
                                     ? NetworkImage(_pickedPhoto!.path)
                                     : FileImage(File(_pickedPhoto!.path))
-                                        as ImageProvider,
+                                          as ImageProvider,
                                 width: double.infinity,
                                 height: 210,
                                 fit: BoxFit.cover,
@@ -234,27 +244,27 @@ class _ProductFormViewState extends State<_ProductFormView> {
                                 ),
                               )
                             : (_existingImageUrl != null &&
-                                    _existingImageUrl!.isNotEmpty)
-                                ? Image.network(
-                                    _existingImageUrl!,
-                                    width: double.infinity,
-                                    height: 210,
-                                    fit: BoxFit.cover,
-                                    errorBuilder: (_, __, ___) => const Center(
-                                      child: Icon(
-                                        Icons.eco_outlined,
-                                        size: 64,
-                                        color: AppColors.darkGreen,
-                                      ),
-                                    ),
-                                  )
-                                : const Center(
-                                    child: Icon(
-                                      Icons.eco_outlined,
-                                      size: 64,
-                                      color: AppColors.darkGreen,
-                                    ),
+                                  _existingImageUrl!.isNotEmpty)
+                            ? Image.network(
+                                _existingImageUrl!,
+                                width: double.infinity,
+                                height: 210,
+                                fit: BoxFit.cover,
+                                errorBuilder: (_, __, ___) => const Center(
+                                  child: Icon(
+                                    Icons.eco_outlined,
+                                    size: 64,
+                                    color: AppColors.darkGreen,
                                   ),
+                                ),
+                              )
+                            : const Center(
+                                child: Icon(
+                                  Icons.eco_outlined,
+                                  size: 64,
+                                  color: AppColors.darkGreen,
+                                ),
+                              ),
                       ),
                       Positioned(
                         bottom: 12,
@@ -428,7 +438,9 @@ class _ProductFormViewState extends State<_ProductFormView> {
                             fontFamily: 'Manrope',
                             fontSize: 13,
                             fontWeight: FontWeight.w600,
-                            color: selected ? AppColors.white : AppColors.darkGreen,
+                            color: selected
+                                ? AppColors.white
+                                : AppColors.darkGreen,
                           ),
                         ),
                         selected: selected,
@@ -444,7 +456,9 @@ class _ProductFormViewState extends State<_ProductFormView> {
                                 });
                               },
                         selectedColor: AppColors.darkGreen,
-                        backgroundColor: AppColors.darkGreen.withValues(alpha: 0.08),
+                        backgroundColor: AppColors.darkGreen.withValues(
+                          alpha: 0.08,
+                        ),
                         checkmarkColor: AppColors.white,
                         side: BorderSide(
                           color: selected
@@ -455,7 +469,10 @@ class _ProductFormViewState extends State<_ProductFormView> {
                           borderRadius: BorderRadius.circular(20),
                         ),
                         showCheckmark: false,
-                        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 4,
+                          vertical: 2,
+                        ),
                       );
                     }).toList(),
                   ),

--- a/lib/features/inventory/presentation/pages/stock_entry_page.dart
+++ b/lib/features/inventory/presentation/pages/stock_entry_page.dart
@@ -195,13 +195,15 @@ class _StockEntryViewState extends State<_StockEntryView> {
                       ),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -242,13 +244,15 @@ class _StockEntryViewState extends State<_StockEntryView> {
                       ),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -274,8 +278,8 @@ class _StockEntryViewState extends State<_StockEntryView> {
                       style: ElevatedButton.styleFrom(
                         backgroundColor: AppColors.lightGreen,
                         foregroundColor: AppColors.white,
-                        disabledBackgroundColor:
-                            AppColors.lightGreen.withValues(alpha: 0.5),
+                        disabledBackgroundColor: AppColors.lightGreen
+                            .withValues(alpha: 0.5),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(24),
                         ),

--- a/lib/features/inventory/presentation/pages/stock_exit_page.dart
+++ b/lib/features/inventory/presentation/pages/stock_exit_page.dart
@@ -58,10 +58,7 @@ class _StockExitViewState extends State<_StockExitView> {
   final _notesController = TextEditingController();
   String _selectedReason = 'LOSS';
 
-  static const _reasons = [
-    ('LOSS', 'Perda'),
-    ('DISPOSAL', 'Descarte'),
-  ];
+  static const _reasons = [('LOSS', 'Perda'), ('DISPOSAL', 'Descarte')];
 
   @override
   void dispose() {
@@ -191,8 +188,9 @@ class _StockExitViewState extends State<_StockExitView> {
                                 style: TextStyle(
                                   fontFamily: 'Manrope',
                                   fontSize: 13,
-                                  color:
-                                      AppColors.darkGreen.withValues(alpha: 0.8),
+                                  color: AppColors.darkGreen.withValues(
+                                    alpha: 0.8,
+                                  ),
                                 ),
                               ),
                             ],
@@ -231,13 +229,15 @@ class _StockExitViewState extends State<_StockExitView> {
                       ),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -318,13 +318,15 @@ class _StockExitViewState extends State<_StockExitView> {
                       ),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            const BorderSide(color: AppColors.inputBorder),
+                        borderSide: const BorderSide(
+                          color: AppColors.inputBorder,
+                        ),
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),

--- a/lib/features/inventory/presentation/pages/stock_movements_page.dart
+++ b/lib/features/inventory/presentation/pages/stock_movements_page.dart
@@ -161,9 +161,7 @@ class _MovementCard extends StatelessWidget {
               borderRadius: BorderRadius.circular(8),
             ),
             child: Icon(
-              isExit
-                  ? Icons.remove_circle_outline
-                  : Icons.add_circle_outline,
+              isExit ? Icons.remove_circle_outline : Icons.add_circle_outline,
               color: color,
               size: 20,
             ),

--- a/lib/features/orders/domain/usecases/cancel_customer_order.dart
+++ b/lib/features/orders/domain/usecases/cancel_customer_order.dart
@@ -7,6 +7,13 @@ class CancelCustomerOrder {
 
   final OrdersRepository _repository;
 
-  Future<void> call(String orderId, {required String reason, String? details}) =>
-      _repository.cancelCustomerOrder(orderId, reason: reason, details: details);
+  Future<void> call(
+    String orderId, {
+    required String reason,
+    String? details,
+  }) => _repository.cancelCustomerOrder(
+    orderId,
+    reason: reason,
+    details: details,
+  );
 }

--- a/lib/features/orders/presentation/bloc/checkout_bloc.dart
+++ b/lib/features/orders/presentation/bloc/checkout_bloc.dart
@@ -28,7 +28,9 @@ class CheckoutBloc extends Bloc<CheckoutEvent, CheckoutState> {
     } on ApiException catch (e) {
       emit(CheckoutFailure(message: e.message));
     } on Exception catch (_) {
-      emit(const CheckoutFailure(message: 'Não foi possível carregar o carrinho.'));
+      emit(
+        const CheckoutFailure(message: 'Não foi possível carregar o carrinho.'),
+      );
     }
   }
 

--- a/lib/features/orders/presentation/bloc/order_detail_bloc.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_bloc.dart
@@ -48,7 +48,11 @@ class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
     if (current is! OrderDetailLoaded) return;
     emit(OrderDetailUpdating(current.order));
     try {
-      await _cancelOrder(event.orderId, reason: event.reason, details: event.details);
+      await _cancelOrder(
+        event.orderId,
+        reason: event.reason,
+        details: event.details,
+      );
       final cancelled = current.order.copyWith(
         status: OrderStatus.cancelled.backendValue,
         actions: const OrderDetailActions(
@@ -65,12 +69,7 @@ class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
       );
       emit(OrderDetailLoaded(cancelled));
     } on ApiException catch (e) {
-      emit(
-        OrderDetailActionFailure(
-          order: current.order,
-          message: e.message,
-        ),
-      );
+      emit(OrderDetailActionFailure(order: current.order, message: e.message));
       emit(OrderDetailLoaded(current.order));
     } on Exception catch (_) {
       emit(
@@ -100,12 +99,7 @@ class OrderDetailBloc extends Bloc<OrderDetailEvent, OrderDetailState> {
       );
       emit(OrderDetailLoaded(order));
     } on ApiException catch (e) {
-      emit(
-        OrderDetailActionFailure(
-          order: current.order,
-          message: e.message,
-        ),
-      );
+      emit(OrderDetailActionFailure(order: current.order, message: e.message));
       emit(OrderDetailLoaded(current.order));
     } on Exception catch (_) {
       emit(

--- a/lib/features/orders/presentation/bloc/order_detail_event.dart
+++ b/lib/features/orders/presentation/bloc/order_detail_event.dart
@@ -14,7 +14,11 @@ class OrderDetailStarted extends OrderDetailEvent {
 }
 
 class OrderDetailCancelled extends OrderDetailEvent {
-  const OrderDetailCancelled(this.orderId, {required this.reason, this.details});
+  const OrderDetailCancelled(
+    this.orderId, {
+    required this.reason,
+    this.details,
+  });
   final String orderId;
   final String reason;
   final String? details;

--- a/lib/features/orders/presentation/pages/order_confirmation_page.dart
+++ b/lib/features/orders/presentation/pages/order_confirmation_page.dart
@@ -409,7 +409,7 @@ class _CheckoutView extends StatelessWidget {
                                         Text(
                                           cart.bankPixKey.isNotEmpty
                                               ? cart.bankPixKey
-                                              : 'Disponível nos detalhes do pedido',
+                                              : 'Não cadastrada',
                                           style: const TextStyle(
                                             fontFamily: 'Manrope',
                                             fontWeight: FontWeight.w700,
@@ -648,8 +648,9 @@ class _CheckoutView extends StatelessWidget {
                         ? null
                         : () async {
                             // Step 1 — confirm delivery data
-                            final profileState =
-                                context.read<CustomerProfileBloc>().state;
+                            final profileState = context
+                                .read<CustomerProfileBloc>()
+                                .state;
                             final profile = switch (profileState) {
                               CustomerProfileLoaded(:final profile) => profile,
                               CustomerProfileUpdating(:final profile) =>
@@ -688,9 +689,9 @@ class _CheckoutView extends StatelessWidget {
                               confirmColor: AppColors.lightGreen,
                             );
                             if ((confirmed ?? false) && context.mounted) {
-                              context
-                                  .read<CheckoutBloc>()
-                                  .add(const CheckoutConfirmed('cart'));
+                              context.read<CheckoutBloc>().add(
+                                const CheckoutConfirmed('cart'),
+                              );
                             }
                           },
                     child: Container(

--- a/lib/features/producer_management/data/datasources/producer_management_remote_datasource.dart
+++ b/lib/features/producer_management/data/datasources/producer_management_remote_datasource.dart
@@ -7,7 +7,6 @@ import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/auth/data/datasources/auth_local_datasource.dart';
 import 'package:ragro_mobile/features/producer_management/domain/entities/producer_dashboard.dart';
 
-
 @lazySingleton
 class ProducerManagementRemoteDataSource {
   final ApiClient _apiClient = getIt<ApiClient>();
@@ -37,11 +36,13 @@ class ProducerManagementRemoteDataSource {
       if (rawAvailability is List) {
         for (final item in rawAvailability) {
           if (item is Map<String, dynamic>) {
-            availability.add(DashboardAvailabilitySlot(
-              weekday: (item['weekday'] as num?)?.toInt() ?? 0,
-              opensAt: item['opensAt'] as String? ?? '',
-              closesAt: item['closesAt'] as String? ?? '',
-            ));
+            availability.add(
+              DashboardAvailabilitySlot(
+                weekday: (item['weekday'] as num?)?.toInt() ?? 0,
+                opensAt: item['opensAt'] as String? ?? '',
+                closesAt: item['closesAt'] as String? ?? '',
+              ),
+            );
           }
         }
       }
@@ -51,9 +52,13 @@ class ProducerManagementRemoteDataSource {
         producerName: (data['name'] as String? ?? '').trim(),
         producerTitle: farmName.isNotEmpty ? farmName : 'Produtor',
         avatarUrl: ApiEndpoints.resolveMediaUrl(
-            data['avatarS3'] as String? ?? data['avatar_s3'] as String? ?? ''),
+          data['avatarS3'] as String? ?? data['avatar_s3'] as String? ?? '',
+        ),
         coverUrl: ApiEndpoints.resolveMediaUrl(
-            data['displayPhotoS3'] as String? ?? data['display_photo_s3'] as String? ?? ''),
+          data['displayPhotoS3'] as String? ??
+              data['display_photo_s3'] as String? ??
+              '',
+        ),
         averageRating: (data['averageRating'] as num?)?.toDouble() ?? 0.0,
         totalReviews: (data['totalReviews'] as num?)?.toInt() ?? 0,
         totalSales: 0,

--- a/lib/features/producer_management/presentation/pages/producer_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_profile_page.dart
@@ -136,7 +136,8 @@ class _ProducerProfileView extends StatelessWidget {
                             backgroundImage: dashboard.avatarUrl.isNotEmpty
                                 ? NetworkImage(dashboard.avatarUrl)
                                 : null,
-                            onBackgroundImageError: dashboard.avatarUrl.isNotEmpty
+                            onBackgroundImageError:
+                                dashboard.avatarUrl.isNotEmpty
                                 ? (_, __) {}
                                 : null,
                             child: dashboard.avatarUrl.isEmpty
@@ -218,7 +219,11 @@ class _ProducerProfileView extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const Icon(Icons.star, size: 16, color: AppColors.darkGreen),
+                        const Icon(
+                          Icons.star,
+                          size: 16,
+                          color: AppColors.darkGreen,
+                        ),
                         const SizedBox(width: 4),
                         Text(
                           '${dashboard.averageRating.toStringAsFixed(1)} (${dashboard.totalReviews} Avaliações)',
@@ -230,7 +235,11 @@ class _ProducerProfileView extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(width: 4),
-                        const Icon(Icons.chevron_right, size: 16, color: AppColors.darkGreen),
+                        const Icon(
+                          Icons.chevron_right,
+                          size: 16,
+                          color: AppColors.darkGreen,
+                        ),
                       ],
                     ),
                   ),
@@ -478,9 +487,7 @@ class _ScheduleSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final slotByWeekday = {
-      for (final s in availability) s.weekday: s,
-    };
+    final slotByWeekday = {for (final s in availability) s.weekday: s};
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
+++ b/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
@@ -29,15 +29,13 @@ class ProducerOrdersRemoteDataSource {
   }
 
   Future<ProducerOrder> getOrderById(String id) async {
-    try {
-      final response = await _apiClient.dio.get<Map<String, dynamic>>(
-        ApiEndpoints.producerOrder(id),
-      );
-
-      return ProducerOrderModel.fromJson(response.data!);
-    } on DioException catch (e) {
-      throw e.error as ApiException? ?? const UnknownApiException();
-    }
+    final orders = await getOrders();
+    final order = orders.cast<ProducerOrder?>().firstWhere(
+      (o) => o?.id == id,
+      orElse: () => null,
+    );
+    if (order == null) throw const UnknownApiException();
+    return order;
   }
 
   Future<void> confirmOrder(String id) async {
@@ -48,11 +46,15 @@ class ProducerOrdersRemoteDataSource {
     }
   }
 
-  Future<void> refuseOrder(String id, {required String reason, String? details}) async {
+  Future<void> refuseOrder(
+    String id, {
+    required String reason,
+    String? details,
+  }) async {
     try {
       await _apiClient.dio.patch<void>(
-        ApiEndpoints.producerOrderCancel(id),
-        data: {'reason': reason, if (details != null) 'details': details},
+        ApiEndpoints.producerOrderStatus(id),
+        data: {'status': _statusQueryValue(ProducerOrderStatus.cancelled)},
       );
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();

--- a/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
+++ b/lib/features/producer_orders/data/datasources/producer_orders_remote_datasource.dart
@@ -53,8 +53,8 @@ class ProducerOrdersRemoteDataSource {
   }) async {
     try {
       await _apiClient.dio.patch<void>(
-        ApiEndpoints.producerOrderStatus(id),
-        data: {'status': _statusQueryValue(ProducerOrderStatus.cancelled)},
+        ApiEndpoints.producerOrderCancel(id),
+        data: {'reason': reason, if (details != null) 'details': details},
       );
     } on DioException catch (e) {
       throw e.error as ApiException? ?? const UnknownApiException();

--- a/lib/features/producer_orders/data/models/producer_order_model.dart
+++ b/lib/features/producer_orders/data/models/producer_order_model.dart
@@ -5,6 +5,7 @@ import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_o
 class ProducerOrderModel extends ProducerOrder {
   const ProducerOrderModel({
     required super.id,
+    required super.orderNumber,
     required super.consumerName,
     required super.consumerAvatarUrl,
     required super.consumerSince,
@@ -34,6 +35,7 @@ class ProducerOrderModel extends ProducerOrder {
 
     return ProducerOrderModel(
       id: json['id'] as String? ?? '',
+      orderNumber: (json['orderNumber'] as num?)?.toInt() ?? 0,
       consumerName:
           json['consumerName'] as String? ??
           json['customerName'] as String? ??

--- a/lib/features/producer_orders/data/models/producer_order_model.dart
+++ b/lib/features/producer_orders/data/models/producer_order_model.dart
@@ -74,8 +74,14 @@ class ProducerOrderModel extends ProducerOrder {
           json['customerPhone'] as String? ??
           consumer?['phone'] as String? ??
           '',
-      cancellationReason: json['cancellationReason'] as String?,
-      cancellationDetails: json['cancellationDetails'] as String?,
+      cancellationReason:
+          json['cancellationReason'] as String? ??
+          json['cancelReason'] as String? ??
+          json['reason'] as String?,
+      cancellationDetails:
+          json['cancellationDetails'] as String? ??
+          json['cancelDetails'] as String? ??
+          json['details'] as String?,
     );
   }
 

--- a/lib/features/producer_orders/data/models/producer_order_model.dart
+++ b/lib/features/producer_orders/data/models/producer_order_model.dart
@@ -19,6 +19,8 @@ class ProducerOrderModel extends ProducerOrder {
     required super.createdAt,
     required super.isNew,
     required super.consumerPhone,
+    super.cancellationReason,
+    super.cancellationDetails,
   });
 
   factory ProducerOrderModel.fromJson(Map<String, dynamic> json) {
@@ -72,6 +74,8 @@ class ProducerOrderModel extends ProducerOrder {
           json['customerPhone'] as String? ??
           consumer?['phone'] as String? ??
           '',
+      cancellationReason: json['cancellationReason'] as String?,
+      cancellationDetails: json['cancellationDetails'] as String?,
     );
   }
 

--- a/lib/features/producer_orders/data/repositories/producer_orders_repository_impl.dart
+++ b/lib/features/producer_orders/data/repositories/producer_orders_repository_impl.dart
@@ -21,8 +21,11 @@ class ProducerOrdersRepositoryImpl implements ProducerOrdersRepository {
   Future<void> confirmOrder(String id) => _dataSource.confirmOrder(id);
 
   @override
-  Future<void> refuseOrder(String id, {required String reason, String? details}) =>
-      _dataSource.refuseOrder(id, reason: reason, details: details);
+  Future<void> refuseOrder(
+    String id, {
+    required String reason,
+    String? details,
+  }) => _dataSource.refuseOrder(id, reason: reason, details: details);
 
   @override
   Future<void> updateStatus(String id, ProducerOrderStatus status) =>

--- a/lib/features/producer_orders/domain/entities/producer_order.dart
+++ b/lib/features/producer_orders/domain/entities/producer_order.dart
@@ -5,6 +5,7 @@ import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_o
 class ProducerOrder extends Equatable {
   const ProducerOrder({
     required this.id,
+    required this.orderNumber,
     required this.consumerName,
     required this.consumerAvatarUrl,
     required this.consumerSince,
@@ -21,6 +22,7 @@ class ProducerOrder extends Equatable {
   });
 
   final String id;
+  final int orderNumber;
   final String consumerName;
   final String consumerAvatarUrl;
   final String consumerSince;
@@ -38,6 +40,7 @@ class ProducerOrder extends Equatable {
   ProducerOrder copyWith({ProducerOrderStatus? status, bool? isNew}) {
     return ProducerOrder(
       id: id,
+      orderNumber: orderNumber,
       consumerName: consumerName,
       consumerAvatarUrl: consumerAvatarUrl,
       consumerSince: consumerSince,
@@ -57,6 +60,7 @@ class ProducerOrder extends Equatable {
   @override
   List<Object?> get props => [
     id,
+    orderNumber,
     consumerName,
     consumerAvatarUrl,
     consumerSince,

--- a/lib/features/producer_orders/domain/entities/producer_order.dart
+++ b/lib/features/producer_orders/domain/entities/producer_order.dart
@@ -41,7 +41,12 @@ class ProducerOrder extends Equatable {
   final String? cancellationReason;
   final String? cancellationDetails;
 
-  ProducerOrder copyWith({ProducerOrderStatus? status, bool? isNew}) {
+  ProducerOrder copyWith({
+    ProducerOrderStatus? status,
+    bool? isNew,
+    String? cancellationReason,
+    String? cancellationDetails,
+  }) {
     return ProducerOrder(
       id: id,
       orderNumber: orderNumber,
@@ -58,8 +63,8 @@ class ProducerOrder extends Equatable {
       createdAt: createdAt,
       isNew: isNew ?? this.isNew,
       consumerPhone: consumerPhone,
-      cancellationReason: cancellationReason,
-      cancellationDetails: cancellationDetails,
+      cancellationReason: cancellationReason ?? this.cancellationReason,
+      cancellationDetails: cancellationDetails ?? this.cancellationDetails,
     );
   }
 

--- a/lib/features/producer_orders/domain/entities/producer_order.dart
+++ b/lib/features/producer_orders/domain/entities/producer_order.dart
@@ -19,6 +19,8 @@ class ProducerOrder extends Equatable {
     required this.createdAt,
     required this.isNew,
     required this.consumerPhone,
+    this.cancellationReason,
+    this.cancellationDetails,
   });
 
   final String id;
@@ -36,6 +38,8 @@ class ProducerOrder extends Equatable {
   final DateTime createdAt;
   final bool isNew;
   final String consumerPhone;
+  final String? cancellationReason;
+  final String? cancellationDetails;
 
   ProducerOrder copyWith({ProducerOrderStatus? status, bool? isNew}) {
     return ProducerOrder(
@@ -54,6 +58,8 @@ class ProducerOrder extends Equatable {
       createdAt: createdAt,
       isNew: isNew ?? this.isNew,
       consumerPhone: consumerPhone,
+      cancellationReason: cancellationReason,
+      cancellationDetails: cancellationDetails,
     );
   }
 
@@ -74,5 +80,7 @@ class ProducerOrder extends Equatable {
     createdAt,
     isNew,
     consumerPhone,
+    cancellationReason,
+    cancellationDetails,
   ];
 }

--- a/lib/features/producer_orders/domain/repositories/producer_orders_repository.dart
+++ b/lib/features/producer_orders/domain/repositories/producer_orders_repository.dart
@@ -5,6 +5,10 @@ abstract class ProducerOrdersRepository {
   Future<List<ProducerOrder>> getOrders({ProducerOrderStatus? status});
   Future<ProducerOrder> getOrderById(String id);
   Future<void> confirmOrder(String id);
-  Future<void> refuseOrder(String id, {required String reason, String? details});
+  Future<void> refuseOrder(
+    String id, {
+    required String reason,
+    String? details,
+  });
   Future<void> updateStatus(String id, ProducerOrderStatus status);
 }

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
@@ -32,15 +32,19 @@ class ProducerOrderDetailBloc
     ProducerOrderDetailStarted event,
     Emitter<ProducerOrderDetailState> emit,
   ) async {
-    if (event.initialOrder != null) {
-      emit(ProducerOrderDetailLoaded(event.initialOrder!));
-      return;
+    final initial = event.initialOrder;
+    if (initial != null) {
+      emit(ProducerOrderDetailLoaded(initial));
+      // Cancelled orders need a full fetch to load cancellationReason from API.
+      if (initial.status != ProducerOrderStatus.cancelled) return;
+    } else {
+      emit(const ProducerOrderDetailLoading());
     }
-    emit(const ProducerOrderDetailLoading());
     try {
       final order = await _getDetail(event.orderId);
       emit(ProducerOrderDetailLoaded(order));
     } on Exception catch (e) {
+      if (initial != null) return; // keep showing initial order on refresh failure
       emit(ProducerOrderDetailFailure(e.toString()));
     }
   }
@@ -80,6 +84,8 @@ class ProducerOrderDetailBloc
       );
       final updated = current.order.copyWith(
         status: ProducerOrderStatus.cancelled,
+        cancellationReason: event.reason,
+        cancellationDetails: event.details,
       );
       emit(ProducerOrderDetailSuccess(order: updated, action: 'refused'));
       emit(ProducerOrderDetailLoaded(updated));

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_bloc.dart
@@ -60,7 +60,8 @@ class ProducerOrderDetailBloc
       emit(ProducerOrderDetailSuccess(order: updated, action: 'confirmed'));
       emit(ProducerOrderDetailLoaded(updated));
     } on Exception catch (e) {
-      emit(ProducerOrderDetailFailure(e.toString()));
+      emit(ProducerOrderDetailActionError(current.order, e.toString()));
+      emit(ProducerOrderDetailLoaded(current.order));
     }
   }
 
@@ -72,14 +73,19 @@ class ProducerOrderDetailBloc
     if (current is! ProducerOrderDetailLoaded) return;
     emit(ProducerOrderDetailRefusing(current.order));
     try {
-      await _refuseOrder(event.orderId, reason: event.reason, details: event.details);
+      await _refuseOrder(
+        event.orderId,
+        reason: event.reason,
+        details: event.details,
+      );
       final updated = current.order.copyWith(
         status: ProducerOrderStatus.cancelled,
       );
       emit(ProducerOrderDetailSuccess(order: updated, action: 'refused'));
       emit(ProducerOrderDetailLoaded(updated));
     } on Exception catch (e) {
-      emit(ProducerOrderDetailFailure(e.toString()));
+      emit(ProducerOrderDetailActionError(current.order, e.toString()));
+      emit(ProducerOrderDetailLoaded(current.order));
     }
   }
 
@@ -98,7 +104,8 @@ class ProducerOrderDetailBloc
       );
       emit(ProducerOrderDetailLoaded(updated));
     } on Exception catch (e) {
-      emit(ProducerOrderDetailFailure(e.toString()));
+      emit(ProducerOrderDetailActionError(current.order, e.toString()));
+      emit(ProducerOrderDetailLoaded(current.order));
     }
   }
 }

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_event.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_event.dart
@@ -24,7 +24,11 @@ class ProducerOrderDetailConfirmed extends ProducerOrderDetailEvent {
 }
 
 class ProducerOrderDetailRefused extends ProducerOrderDetailEvent {
-  const ProducerOrderDetailRefused(this.orderId, {required this.reason, this.details});
+  const ProducerOrderDetailRefused(
+    this.orderId, {
+    required this.reason,
+    this.details,
+  });
   final String orderId;
   final String reason;
   final String? details;

--- a/lib/features/producer_orders/presentation/bloc/producer_order_detail_state.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_order_detail_state.dart
@@ -57,3 +57,11 @@ class ProducerOrderDetailFailure extends ProducerOrderDetailState {
   @override
   List<Object?> get props => [message];
 }
+
+class ProducerOrderDetailActionError extends ProducerOrderDetailState {
+  const ProducerOrderDetailActionError(this.order, this.message);
+  final ProducerOrder order;
+  final String message;
+  @override
+  List<Object?> get props => [order, message];
+}

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_bloc.dart
@@ -70,11 +70,13 @@ class ProducerOrdersBloc
     try {
       await _confirmProducerOrder(event.orderId);
       final orders = await _getProducerOrders();
-      emit(ProducerOrdersActionSuccess(
-        message: 'Pedido aceito com sucesso.',
-        orders: orders,
-        activeTab: _activeTab,
-      ));
+      emit(
+        ProducerOrdersActionSuccess(
+          message: 'Pedido aceito com sucesso.',
+          orders: orders,
+          activeTab: _activeTab,
+        ),
+      );
       emit(ProducerOrdersLoaded(orders: orders, activeTab: _activeTab));
     } on Exception catch (e) {
       emit(ProducerOrdersFailure(e.toString()));
@@ -94,7 +96,11 @@ class ProducerOrdersBloc
 
     emit(ProducerOrdersLoading(_activeTab));
     try {
-      await _refuseProducerOrder(event.orderId, reason: event.reason, details: event.details);
+      await _refuseProducerOrder(
+        event.orderId,
+        reason: event.reason,
+        details: event.details,
+      );
       final updated = currentOrders
           .map(
             (o) => o.id == event.orderId
@@ -102,11 +108,13 @@ class ProducerOrdersBloc
                 : o,
           )
           .toList();
-      emit(ProducerOrdersActionSuccess(
-        message: 'Pedido recusado com sucesso.',
-        orders: updated,
-        activeTab: _activeTab,
-      ));
+      emit(
+        ProducerOrdersActionSuccess(
+          message: 'Pedido recusado com sucesso.',
+          orders: updated,
+          activeTab: _activeTab,
+        ),
+      );
       emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));
     } on Exception catch (e) {
       emit(ProducerOrdersLoaded(orders: currentOrders, activeTab: _activeTab));
@@ -146,11 +154,13 @@ class ProducerOrdersBloc
         ProducerOrderStatus.inDelivery,
       );
       final orders = await _getProducerOrders();
-      emit(ProducerOrdersActionSuccess(
-        message: 'Entrega iniciada com sucesso.',
-        orders: orders,
-        activeTab: _activeTab,
-      ));
+      emit(
+        ProducerOrdersActionSuccess(
+          message: 'Entrega iniciada com sucesso.',
+          orders: orders,
+          activeTab: _activeTab,
+        ),
+      );
       emit(ProducerOrdersLoaded(orders: orders, activeTab: _activeTab));
     } on Exception catch (e) {
       emit(ProducerOrdersFailure(e.toString()));
@@ -181,11 +191,13 @@ class ProducerOrdersBloc
                 : o,
           )
           .toList();
-      emit(ProducerOrdersActionSuccess(
-        message: 'Entrega confirmada com sucesso.',
-        orders: updated,
-        activeTab: _activeTab,
-      ));
+      emit(
+        ProducerOrdersActionSuccess(
+          message: 'Entrega confirmada com sucesso.',
+          orders: updated,
+          activeTab: _activeTab,
+        ),
+      );
       emit(ProducerOrdersLoaded(orders: updated, activeTab: _activeTab));
     } on Exception catch (e) {
       emit(ProducerOrdersLoaded(orders: currentOrders, activeTab: _activeTab));

--- a/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
+++ b/lib/features/producer_orders/presentation/bloc/producer_orders_event.dart
@@ -35,7 +35,11 @@ class ProducerOrderAccepted extends ProducerOrdersEvent {
 }
 
 class ProducerOrderCancelled extends ProducerOrdersEvent {
-  const ProducerOrderCancelled(this.orderId, {required this.reason, this.details});
+  const ProducerOrderCancelled(
+    this.orderId, {
+    required this.reason,
+    this.details,
+  });
 
   final String orderId;
   final String reason;

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -208,6 +208,9 @@ class _ProducerOrderDetailView extends StatelessWidget {
                 children: [
                   _Header(order: order),
                   _CustomerHeader(order: order),
+                  if (order.status == ProducerOrderStatus.cancelled &&
+                      order.cancellationReason != null)
+                    _CancellationCard(order: order),
                   const _SectionTitle('ITENS DO PEDIDO'),
                   _ItemsCard(order: order),
                   const SizedBox(height: 18),
@@ -566,6 +569,69 @@ class _ProducerOrderItemRow extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _CancellationCard extends StatelessWidget {
+  const _CancellationCard({required this.order});
+
+  final ProducerOrder order;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: AppColors.red.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: AppColors.red.withValues(alpha: 0.25)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Row(
+              children: [
+                Icon(Icons.cancel_outlined, size: 16, color: AppColors.red),
+                SizedBox(width: 6),
+                Text(
+                  'Motivo do cancelamento',
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 13,
+                    color: AppColors.red,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              order.cancellationReason!,
+              style: const TextStyle(
+                fontFamily: 'Manrope',
+                fontSize: 14,
+                color: AppColors.black,
+              ),
+            ),
+            if (order.cancellationDetails != null &&
+                order.cancellationDetails!.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                order.cancellationDetails!,
+                style: const TextStyle(
+                  fontFamily: 'Manrope',
+                  fontSize: 13,
+                  color: AppColors.placeholder,
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -253,7 +253,9 @@ class _Header extends StatelessWidget {
         children: [
           GestureDetector(
             onTap: () => context.pop(
-              order.status == ProducerOrderStatus.cancelled ? 'cancelled' : null,
+              order.status == ProducerOrderStatus.cancelled
+                  ? 'cancelled'
+                  : null,
             ),
             child: const Padding(
               padding: EdgeInsets.all(8),
@@ -737,25 +739,11 @@ class _ActionFooter extends StatelessWidget {
           label: 'Recusar Pedido',
           icon: Icons.cancel_outlined,
           color: AppColors.red,
-          onTap: isProcessing
-              ? null
-              : () => _confirmRefuse(context, 'recusar'),
+          onTap: isProcessing ? null : () => _confirmRefuse(context),
         ),
       ],
-      if (order.status == ProducerOrderStatus.accepted) ...[
-        _ActionButton(
-          label: 'Iniciar Entrega',
-          icon: Icons.local_shipping_outlined,
-          color: const Color(0xFFF97316),
-          onTap: isProcessing
-              ? null
-              : () => bloc.add(
-                  ProducerOrderDetailStatusUpdated(
-                    order.id,
-                    ProducerOrderStatus.inDelivery,
-                  ),
-                ),
-        ),
+      if (order.status == ProducerOrderStatus.accepted ||
+          order.status == ProducerOrderStatus.inDelivery) ...[
         _ActionButton(
           label: 'Cancelar Pedido',
           icon: Icons.cancel_outlined,
@@ -763,24 +751,7 @@ class _ActionFooter extends StatelessWidget {
           outlined: true,
           onTap: isProcessing
               ? null
-              : () => _confirmRefuse(context, 'cancelar'),
-        ),
-      ],
-      if (order.status == ProducerOrderStatus.inDelivery) ...[
-        _ActionButton(
-          label: 'Confirmar Pedido',
-          icon: Icons.check_circle_outline,
-          color: const Color(0xFF3B82F6),
-          onTap: isProcessing ? null : () => _confirmDelivery(context),
-        ),
-        _ActionButton(
-          label: 'Cancelar Pedido',
-          icon: Icons.cancel_outlined,
-          color: AppColors.red,
-          outlined: true,
-          onTap: isProcessing
-              ? null
-              : () => _confirmRefuse(context, 'cancelar'),
+              : () => _confirmRefuse(context),
         ),
       ],
       if (order.consumerPhone.isNotEmpty &&
@@ -827,49 +798,16 @@ class _ActionFooter extends StatelessWidget {
     );
   }
 
-  Future<void> _confirmRefuse(BuildContext context, String verb) async {
-    if (verb == 'recusar') {
-      final confirmed = await showDialog<bool>(
-        context: context,
-        barrierColor: Colors.black.withValues(alpha: 0.4),
-        builder: (_) => const _ProducerConfirmDialog(
-          icon: Icons.shopping_cart_outlined,
-          title: 'Recusar pedido',
-          description: 'Tem certeza que deseja recusar o pedido?',
-        ),
-      );
-      if (!(confirmed ?? false)) return;
-      bloc.add(
-        ProducerOrderDetailRefused(order.id, reason: 'Recusado pelo produtor'),
-      );
-    } else {
-      final cancelResult = await CancelOrderDialog.showForProducer(context);
-      if (cancelResult == null) return;
-      bloc.add(
-        ProducerOrderDetailRefused(
-          order.id,
-          reason: cancelResult.reason,
-          details: cancelResult.details,
-        ),
-      );
-    }
-  }
-
-  Future<void> _confirmDelivery(BuildContext context) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      barrierColor: Colors.black.withValues(alpha: 0.4),
-      builder: (_) => const _ProducerConfirmDialog(
-        icon: Icons.local_shipping_outlined,
-        title: 'Confirmar entrega',
-        description: 'Tem certeza que deseja confirmar a entrega deste pedido?',
+  Future<void> _confirmRefuse(BuildContext context) async {
+    final cancelResult = await CancelOrderDialog.showForProducer(context);
+    if (cancelResult == null) return;
+    bloc.add(
+      ProducerOrderDetailRefused(
+        order.id,
+        reason: cancelResult.reason,
+        details: cancelResult.details,
       ),
     );
-    if (confirmed ?? false) {
-      bloc.add(
-        ProducerOrderDetailStatusUpdated(order.id, ProducerOrderStatus.delivered),
-      );
-    }
   }
 
   Future<void> _contactCustomer(BuildContext context) async {
@@ -906,8 +844,7 @@ class _ActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final effectiveColor =
-        onTap == null ? color.withValues(alpha: 0.5) : color;
+    final effectiveColor = onTap == null ? color.withValues(alpha: 0.5) : color;
     final iconColor = outlined ? effectiveColor : AppColors.white;
     final textColor = outlined ? effectiveColor : AppColors.white;
 
@@ -1010,95 +947,21 @@ class _ProducerSuccessDialog extends StatelessWidget {
   }
 }
 
-class _ProducerConfirmDialog extends StatelessWidget {
-  const _ProducerConfirmDialog({
-    required this.icon,
-    required this.title,
-    required this.description,
-  });
-
-  final IconData icon;
-  final String title;
-  final String description;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      backgroundColor: AppColors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-      insetPadding: const EdgeInsets.symmetric(horizontal: 40),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 56,
-              height: 56,
-              decoration: BoxDecoration(
-                color: AppColors.lightGreen.withValues(alpha: 0.15),
-                shape: BoxShape.circle,
-              ),
-              child: Icon(icon, color: AppColors.lightGreen, size: 28),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              title,
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                fontFamily: 'Figtree',
-                fontWeight: FontWeight.w700,
-                fontSize: 20,
-                color: AppColors.black,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              description,
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                fontFamily: 'Manrope',
-                fontSize: 14,
-                color: AppColors.placeholder,
-              ),
-            ),
-            const SizedBox(height: 24),
-            _ProducerDialogButton(
-              label: 'Voltar',
-              outlined: true,
-              color: AppColors.darkGreen,
-              onTap: () => Navigator.of(context).pop(false),
-            ),
-            const SizedBox(height: 10),
-            _ProducerDialogButton(
-              label: 'Confirmar',
-              color: AppColors.darkGreen,
-              onTap: () => Navigator.of(context).pop(true),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 class _ProducerDialogButton extends StatelessWidget {
   const _ProducerDialogButton({
     required this.label,
     required this.color,
     required this.onTap,
-    this.outlined = false,
   });
 
   final String label;
   final Color color;
   final VoidCallback? onTap;
-  final bool outlined;
 
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: outlined ? Colors.transparent : color,
+      color: color,
       borderRadius: BorderRadius.circular(12),
       child: InkWell(
         onTap: onTap,
@@ -1106,20 +969,14 @@ class _ProducerDialogButton extends StatelessWidget {
         child: Container(
           width: double.infinity,
           padding: const EdgeInsets.symmetric(vertical: 13),
-          decoration: outlined
-              ? BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: color),
-                )
-              : null,
           alignment: Alignment.center,
           child: Text(
             label,
-            style: TextStyle(
+            style: const TextStyle(
               fontFamily: 'Manrope',
               fontWeight: FontWeight.w700,
               fontSize: 15,
-              color: outlined ? color : AppColors.white,
+              color: AppColors.white,
             ),
           ),
         ),

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -51,6 +51,7 @@ class ProducerOrderDetailPage extends StatelessWidget {
                   backgroundColor: Colors.black87,
                 ),
               );
+              if (context.mounted) context.pop('cancelled');
             } else if (state.action == 'confirmed') {
               await showDialog<void>(
                 context: context,

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -32,36 +32,62 @@ class ProducerOrderDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) =>
-          getIt<ProducerOrderDetailBloc>()
-            ..add(
-              ProducerOrderDetailStarted(orderId, initialOrder: initialOrder),
-            ),
+      create: (_) => getIt<ProducerOrderDetailBloc>()
+        ..add(ProducerOrderDetailStarted(orderId, initialOrder: initialOrder)),
       child: BlocConsumer<ProducerOrderDetailBloc, ProducerOrderDetailState>(
-        listener: (context, state) {
-          if (state is ProducerOrderDetailSuccess) {
-            if (state.action == 'status_updated') {
-              if (state.order.status == ProducerOrderStatus.delivered) {
-                context.pop('delivered');
-              } else {
-                context.pop('in_delivery');
-              }
-              return;
-            }
-            if (state.action == 'refused') {
-              context.pop('cancelled');
-              return;
-            }
-            final message = switch (state.action) {
-              'confirmed' => 'Pedido aceito com sucesso.',
-              _ => 'Ação concluída.',
-            };
+        listener: (context, state) async {
+          if (state is ProducerOrderDetailActionError) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text(message),
-                backgroundColor: AppColors.darkGreen,
+                content: Text(state.message),
+                backgroundColor: Colors.red.shade700,
               ),
             );
+          } else if (state is ProducerOrderDetailSuccess) {
+            if (state.action == 'refused') {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Pedido cancelado com sucesso.'),
+                  backgroundColor: Colors.black87,
+                ),
+              );
+            } else if (state.action == 'confirmed') {
+              await showDialog<void>(
+                context: context,
+                barrierColor: Colors.black.withValues(alpha: 0.55),
+                builder: (_) => const _ProducerSuccessDialog(
+                  icon: Icons.check_circle_outline,
+                  title: 'Pedido confirmado\ncom sucesso!',
+                  description: 'O pedido foi aceito e está em andamento.',
+                ),
+              );
+            } else if (state.action == 'status_updated') {
+              if (state.order.status == ProducerOrderStatus.inDelivery) {
+                await showDialog<void>(
+                  context: context,
+                  barrierColor: Colors.black.withValues(alpha: 0.55),
+                  builder: (_) => const _ProducerSuccessDialog(
+                    icon: Icons.local_shipping_outlined,
+                    title: 'Entrega iniciada\ncom sucesso!',
+                    description:
+                        'Você iniciou a entrega do pedido. Boa entrega!',
+                  ),
+                );
+                if (context.mounted) context.pop('in_delivery');
+              } else if (state.order.status == ProducerOrderStatus.delivered) {
+                await showDialog<void>(
+                  context: context,
+                  barrierColor: Colors.black.withValues(alpha: 0.55),
+                  builder: (_) => const _ProducerSuccessDialog(
+                    icon: Icons.check_circle_outline,
+                    title: 'Entrega confirmada\ncom sucesso!',
+                    description:
+                        'O pedido foi entregue ao cliente e está concluído.',
+                  ),
+                );
+                if (context.mounted) context.pop('delivered');
+              }
+            }
           }
         },
         builder: (context, state) {
@@ -84,6 +110,7 @@ class ProducerOrderDetailPage extends StatelessWidget {
             ProducerOrderDetailRefusing(:final order) => order,
             ProducerOrderDetailUpdatingStatus(:final order) => order,
             ProducerOrderDetailSuccess(:final order) => order,
+            ProducerOrderDetailActionError(:final order) => order,
             _ => null,
           };
           if (order == null) return const Scaffold();
@@ -168,6 +195,7 @@ class _ProducerOrderDetailView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bloc = context.read<ProducerOrderDetailBloc>();
     return Scaffold(
       backgroundColor: AppColors.white,
       body: SafeArea(
@@ -192,7 +220,11 @@ class _ProducerOrderDetailView extends StatelessWidget {
               left: 16,
               right: 16,
               bottom: 16,
-              child: _ActionFooter(order: order, isProcessing: isProcessing),
+              child: _ActionFooter(
+                order: order,
+                isProcessing: isProcessing,
+                bloc: bloc,
+              ),
             ),
           ],
         ),
@@ -208,14 +240,18 @@ class _Header extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final shortId = order.id.length > 4 ? order.id.substring(0, 4) : order.id;
+    final displayId = order.orderNumber > 0
+        ? '#${order.orderNumber}'
+        : '#${order.id.length > 4 ? order.id.substring(0, 4) : order.id}';
 
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Row(
         children: [
           GestureDetector(
-            onTap: () => context.pop(),
+            onTap: () => context.pop(
+              order.status == ProducerOrderStatus.cancelled ? 'cancelled' : null,
+            ),
             child: const Padding(
               padding: EdgeInsets.all(8),
               child: Icon(Icons.arrow_back, size: 18),
@@ -236,7 +272,7 @@ class _Header extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  '#$shortId',
+                  displayId,
                   style: const TextStyle(
                     fontFamily: 'Manrope',
                     fontWeight: FontWeight.w600,
@@ -466,7 +502,8 @@ class _ProducerOrderItemRow extends StatelessWidget {
     symbol: r'R$',
   );
 
-  String get _quantity => 'Qtd: ${item.quantity} ${localizeUnityType(item.unityType)}';
+  String get _quantity =>
+      'Qtd: ${item.quantity} ${localizeUnityType(item.unityType)}';
 
   @override
   Widget build(BuildContext context) {
@@ -608,48 +645,45 @@ class _DeliveryCard extends StatelessWidget {
 }
 
 class _ActionFooter extends StatelessWidget {
-  const _ActionFooter({required this.order, required this.isProcessing});
+  const _ActionFooter({
+    required this.order,
+    required this.isProcessing,
+    required this.bloc,
+  });
 
   final ProducerOrder order;
   final bool isProcessing;
+  final ProducerOrderDetailBloc bloc;
 
   @override
   Widget build(BuildContext context) {
     final buttons = <Widget>[
-      if (order.status == ProducerOrderStatus.pending)
-        Row(
-          children: [
-            Expanded(
-              child: _ActionButton(
-                label: 'Recusar Pedido',
-                icon: Icons.cancel_outlined,
-                color: AppColors.red,
-                onTap: isProcessing ? null : () => _confirmCancel(context),
-              ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: _ActionButton(
-                label: 'Confirmar Pedido',
-                icon: Icons.check_circle_outline,
-                color: AppColors.darkGreen,
-                onTap: isProcessing
-                    ? null
-                    : () => context.read<ProducerOrderDetailBloc>().add(
-                        ProducerOrderDetailConfirmed(order.id),
-                      ),
-              ),
-            ),
-          ],
+      if (order.status == ProducerOrderStatus.pending) ...[
+        _ActionButton(
+          label: 'Confirmar Pedido',
+          icon: Icons.check_circle_outline,
+          color: AppColors.darkGreen,
+          onTap: isProcessing
+              ? null
+              : () => bloc.add(ProducerOrderDetailConfirmed(order.id)),
         ),
+        _ActionButton(
+          label: 'Recusar Pedido',
+          icon: Icons.cancel_outlined,
+          color: AppColors.red,
+          onTap: isProcessing
+              ? null
+              : () => _confirmRefuse(context, 'recusar'),
+        ),
+      ],
       if (order.status == ProducerOrderStatus.accepted) ...[
         _ActionButton(
           label: 'Iniciar Entrega',
           icon: Icons.local_shipping_outlined,
-          color: AppColors.darkGreen,
+          color: const Color(0xFFF97316),
           onTap: isProcessing
               ? null
-              : () => context.read<ProducerOrderDetailBloc>().add(
+              : () => bloc.add(
                   ProducerOrderDetailStatusUpdated(
                     order.id,
                     ProducerOrderStatus.inDelivery,
@@ -660,24 +694,36 @@ class _ActionFooter extends StatelessWidget {
           label: 'Cancelar Pedido',
           icon: Icons.cancel_outlined,
           color: AppColors.red,
-          onTap: isProcessing ? null : () => _confirmCancel(context),
-        ),
-      ],
-      if (order.status == ProducerOrderStatus.inDelivery)
-        _ActionButton(
-          label: 'Confirmar Entrega',
-          icon: Icons.check_circle_outline,
-          color: AppColors.darkGreen,
+          outlined: true,
           onTap: isProcessing
               ? null
-              : () => _confirmDelivery(context),
+              : () => _confirmRefuse(context, 'cancelar'),
         ),
+      ],
+      if (order.status == ProducerOrderStatus.inDelivery) ...[
+        _ActionButton(
+          label: 'Confirmar Pedido',
+          icon: Icons.check_circle_outline,
+          color: const Color(0xFF3B82F6),
+          onTap: isProcessing ? null : () => _confirmDelivery(context),
+        ),
+        _ActionButton(
+          label: 'Cancelar Pedido',
+          icon: Icons.cancel_outlined,
+          color: AppColors.red,
+          outlined: true,
+          onTap: isProcessing
+              ? null
+              : () => _confirmRefuse(context, 'cancelar'),
+        ),
+      ],
       if (order.consumerPhone.isNotEmpty &&
           order.status != ProducerOrderStatus.cancelled)
         _ActionButton(
           label: 'Contatar Cliente',
           icon: Icons.chat,
           color: const Color(0xFF25D366),
+          outlined: true,
           onTap: isProcessing ? null : () => _contactCustomer(context),
         ),
     ];
@@ -715,11 +761,30 @@ class _ActionFooter extends StatelessWidget {
     );
   }
 
-  Future<void> _confirmCancel(BuildContext context) async {
-    final result = await CancelOrderDialog.showForProducer(context);
-    if (result != null && context.mounted) {
-      context.read<ProducerOrderDetailBloc>().add(
-        ProducerOrderDetailRefused(order.id, reason: result.reason, details: result.details),
+  Future<void> _confirmRefuse(BuildContext context, String verb) async {
+    if (verb == 'recusar') {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        barrierColor: Colors.black.withValues(alpha: 0.4),
+        builder: (_) => const _ProducerConfirmDialog(
+          icon: Icons.shopping_cart_outlined,
+          title: 'Recusar pedido',
+          description: 'Tem certeza que deseja recusar o pedido?',
+        ),
+      );
+      if (!(confirmed ?? false)) return;
+      bloc.add(
+        ProducerOrderDetailRefused(order.id, reason: 'Recusado pelo produtor'),
+      );
+    } else {
+      final cancelResult = await CancelOrderDialog.showForProducer(context);
+      if (cancelResult == null) return;
+      bloc.add(
+        ProducerOrderDetailRefused(
+          order.id,
+          reason: cancelResult.reason,
+          details: cancelResult.details,
+        ),
       );
     }
   }
@@ -727,30 +792,16 @@ class _ActionFooter extends StatelessWidget {
   Future<void> _confirmDelivery(BuildContext context) async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Confirmar entrega'),
-        content: const Text(
-          'Tem certeza que deseja confirmar a entrega deste pedido?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('Voltar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('Confirmar entrega'),
-          ),
-        ],
+      barrierColor: Colors.black.withValues(alpha: 0.4),
+      builder: (_) => const _ProducerConfirmDialog(
+        icon: Icons.local_shipping_outlined,
+        title: 'Confirmar entrega',
+        description: 'Tem certeza que deseja confirmar a entrega deste pedido?',
       ),
     );
-
-    if ((confirmed ?? false) && context.mounted) {
-      context.read<ProducerOrderDetailBloc>().add(
-        ProducerOrderDetailStatusUpdated(
-          order.id,
-          ProducerOrderStatus.delivered,
-        ),
+    if (confirmed ?? false) {
+      bloc.add(
+        ProducerOrderDetailStatusUpdated(order.id, ProducerOrderStatus.delivered),
       );
     }
   }
@@ -778,41 +829,233 @@ class _ActionButton extends StatelessWidget {
     required this.icon,
     required this.color,
     required this.onTap,
+    this.outlined = false,
   });
 
   final String label;
   final IconData icon;
   final Color color;
   final VoidCallback? onTap;
+  final bool outlined;
 
   @override
   Widget build(BuildContext context) {
+    final effectiveColor =
+        onTap == null ? color.withValues(alpha: 0.5) : color;
+    final iconColor = outlined ? effectiveColor : AppColors.white;
+    final textColor = outlined ? effectiveColor : AppColors.white;
+
     return GestureDetector(
       onTap: onTap,
       child: Container(
         height: 52,
         decoration: BoxDecoration(
-          color: onTap == null ? color.withValues(alpha: 0.6) : color,
+          color: outlined ? Colors.transparent : effectiveColor,
           borderRadius: BorderRadius.circular(24),
+          border: outlined ? Border.all(color: effectiveColor) : null,
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(icon, color: AppColors.white, size: 20),
+            Icon(icon, color: iconColor, size: 20),
             const SizedBox(width: 8),
             Flexible(
               child: Text(
                 label,
                 overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
+                style: TextStyle(
                   fontFamily: 'Manrope',
                   fontWeight: FontWeight.w700,
                   fontSize: 15,
-                  color: AppColors.white,
+                  color: textColor,
                 ),
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProducerSuccessDialog extends StatelessWidget {
+  const _ProducerSuccessDialog({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 40),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: AppColors.lightGreen.withValues(alpha: 0.15),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(icon, color: AppColors.lightGreen, size: 28),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontFamily: 'Figtree',
+                fontWeight: FontWeight.w700,
+                fontSize: 20,
+                color: AppColors.black,
+                height: 1.3,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              description,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontFamily: 'Manrope',
+                fontSize: 14,
+                color: AppColors.placeholder,
+              ),
+            ),
+            const SizedBox(height: 24),
+            _ProducerDialogButton(
+              label: 'Fechar',
+              color: AppColors.darkGreen,
+              onTap: () => Navigator.of(context).pop(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProducerConfirmDialog extends StatelessWidget {
+  const _ProducerConfirmDialog({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 40),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: AppColors.lightGreen.withValues(alpha: 0.15),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(icon, color: AppColors.lightGreen, size: 28),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontFamily: 'Figtree',
+                fontWeight: FontWeight.w700,
+                fontSize: 20,
+                color: AppColors.black,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              description,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontFamily: 'Manrope',
+                fontSize: 14,
+                color: AppColors.placeholder,
+              ),
+            ),
+            const SizedBox(height: 24),
+            _ProducerDialogButton(
+              label: 'Voltar',
+              outlined: true,
+              color: AppColors.darkGreen,
+              onTap: () => Navigator.of(context).pop(false),
+            ),
+            const SizedBox(height: 10),
+            _ProducerDialogButton(
+              label: 'Confirmar',
+              color: AppColors.darkGreen,
+              onTap: () => Navigator.of(context).pop(true),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProducerDialogButton extends StatelessWidget {
+  const _ProducerDialogButton({
+    required this.label,
+    required this.color,
+    required this.onTap,
+    this.outlined = false,
+  });
+
+  final String label;
+  final Color color;
+  final VoidCallback? onTap;
+  final bool outlined;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: outlined ? Colors.transparent : color,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 13),
+          decoration: outlined
+              ? BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: color),
+                )
+              : null,
+          alignment: Alignment.center,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontFamily: 'Manrope',
+              fontWeight: FontWeight.w700,
+              fontSize: 15,
+              color: outlined ? color : AppColors.white,
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -217,14 +217,17 @@ class _ProducerOrderDetailView extends StatelessWidget {
                 children: [
                   _Header(order: order),
                   _CustomerHeader(order: order),
-                  if (order.status == ProducerOrderStatus.cancelled &&
-                      order.cancellationReason != null)
-                    _CancellationCard(order: order),
                   const _SectionTitle('ITENS DO PEDIDO'),
                   _ItemsCard(order: order),
                   const SizedBox(height: 18),
                   const _SectionTitle('ENTREGA'),
                   _DeliveryCard(order: order),
+                  if (order.status == ProducerOrderStatus.cancelled &&
+                      order.cancellationReason != null) ...[
+                    const SizedBox(height: 18),
+                    const _SectionTitle('CANCELAMENTO'),
+                    _CancellationCard(order: order),
+                  ],
                 ],
               ),
             ),
@@ -589,69 +592,6 @@ class _ProducerOrderItemRow extends StatelessWidget {
   }
 }
 
-class _CancellationCard extends StatelessWidget {
-  const _CancellationCard({required this.order});
-
-  final ProducerOrder order;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
-      child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: AppColors.red.withValues(alpha: 0.06),
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: AppColors.red.withValues(alpha: 0.25)),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Row(
-              children: [
-                Icon(Icons.cancel_outlined, size: 16, color: AppColors.red),
-                SizedBox(width: 6),
-                Text(
-                  'Motivo do cancelamento',
-                  style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 13,
-                    color: AppColors.red,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              order.cancellationReason!,
-              style: const TextStyle(
-                fontFamily: 'Manrope',
-                fontSize: 14,
-                color: AppColors.black,
-              ),
-            ),
-            if (order.cancellationDetails != null &&
-                order.cancellationDetails!.isNotEmpty) ...[
-              const SizedBox(height: 4),
-              Text(
-                order.cancellationDetails!,
-                style: const TextStyle(
-                  fontFamily: 'Manrope',
-                  fontSize: 13,
-                  color: AppColors.placeholder,
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 class _DeliveryCard extends StatelessWidget {
   const _DeliveryCard({required this.order});
 
@@ -716,6 +656,82 @@ class _DeliveryCard extends StatelessWidget {
                     ),
                   ),
                 ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CancellationCard extends StatelessWidget {
+  const _CancellationCard({required this.order});
+
+  final ProducerOrder order;
+
+  static const _reasonLabels = <String, String>{
+    'OUT_OF_STOCK': 'Produto indisponível',
+    'PRICE_CHANGE': 'Alteração de preço',
+    'DELIVERY_ISSUE': 'Problema na entrega',
+    'OTHER': 'Outro motivo',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final reason = _reasonLabels[order.cancellationReason] ??
+        order.cancellationReason ??
+        '';
+    final details = order.cancellationDetails;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(17),
+      decoration: BoxDecoration(
+        color: AppColors.red.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.red.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.cancel_outlined, size: 20, color: AppColors.red),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Motivo do cancelamento',
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                if (reason.isNotEmpty)
+                  Text(
+                    reason,
+                    style: const TextStyle(
+                      fontFamily: 'Manrope',
+                      fontSize: 14,
+                      color: AppColors.red,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                if (details != null && details.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    details,
+                    style: const TextStyle(
+                      fontFamily: 'Manrope',
+                      fontSize: 13,
+                      color: AppColors.black,
+                    ),
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -30,8 +30,43 @@ class ProducerOrdersPage extends StatelessWidget {
   }
 }
 
-class _ProducerOrdersView extends StatelessWidget {
+class _ProducerOrdersView extends StatefulWidget {
   const _ProducerOrdersView();
+
+  @override
+  State<_ProducerOrdersView> createState() => _ProducerOrdersViewState();
+}
+
+class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
+  bool _selectionMode = false;
+  final Set<String> _selectedIds = {};
+
+  void _enterSelectionMode() => setState(() {
+        _selectionMode = true;
+        _selectedIds.clear();
+      });
+
+  void _exitSelectionMode() => setState(() {
+        _selectionMode = false;
+        _selectedIds.clear();
+      });
+
+  void _toggleSelection(String id) => setState(() {
+        if (_selectedIds.contains(id)) {
+          _selectedIds.remove(id);
+        } else {
+          _selectedIds.add(id);
+        }
+      });
+
+  void _saveSelection(BuildContext context) {
+    final bloc = context.read<ProducerOrdersBloc>();
+    for (final id in _selectedIds) {
+      bloc.add(ProducerOrderMarkedInDelivery(id));
+    }
+    _exitSelectionMode();
+    bloc.add(const ProducerOrdersStarted(ProducerOrderStatus.inDelivery));
+  }
 
   static const _tabs = [
     (ProducerOrderStatus.pending, 'Pendentes'),
@@ -125,9 +160,12 @@ class _ProducerOrdersView extends StatelessWidget {
                       children: _tabs.map((tab) {
                         final isActive = activeTab == tab.$1;
                         return GestureDetector(
-                          onTap: () => context.read<ProducerOrdersBloc>().add(
-                            ProducerOrdersTabChanged(tab.$1),
-                          ),
+                          onTap: () {
+                            _exitSelectionMode();
+                            context.read<ProducerOrdersBloc>().add(
+                              ProducerOrdersTabChanged(tab.$1),
+                            );
+                          },
                           child: Container(
                             padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
                             decoration: BoxDecoration(
@@ -268,15 +306,26 @@ class _ProducerOrdersView extends StatelessWidget {
                           ),
                         Expanded(
                           child: ListView.separated(
-                            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                            padding: EdgeInsets.fromLTRB(
+                              16,
+                              12,
+                              16,
+                              activeTab == ProducerOrderStatus.accepted
+                                  ? 80
+                                  : 16,
+                            ),
                             itemCount: orders.length,
                             separatorBuilder: (_, __) =>
                                 const SizedBox(height: 12),
                             itemBuilder: (context, index) {
                               final order = orders[index];
+                              final inAcceptedSelection =
+                                  activeTab == ProducerOrderStatus.accepted &&
+                                  _selectionMode;
                               return ProducerOrderCard(
                                 order: order,
                                 onDetailTap: () async {
+                                  if (inAcceptedSelection) return;
                                   final result = await context.push<String?>(
                                     '/producer/home/orders/${order.id}',
                                     extra: order,
@@ -315,10 +364,109 @@ class _ProducerOrdersView extends StatelessWidget {
                                         ProducerOrderStatus.inDelivery
                                     ? () => _confirmDelivery(context, order.id)
                                     : null,
+                                isSelected: inAcceptedSelection
+                                    ? _selectedIds.contains(order.id)
+                                    : null,
+                                onSelect: inAcceptedSelection
+                                    ? () => _toggleSelection(order.id)
+                                    : null,
                               );
                             },
                           ),
                         ),
+                        if (activeTab == ProducerOrderStatus.accepted)
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                            child: _selectionMode
+                                ? Row(
+                                    children: [
+                                      Expanded(
+                                        child: OutlinedButton(
+                                          onPressed: _exitSelectionMode,
+                                          style: OutlinedButton.styleFrom(
+                                            foregroundColor:
+                                                AppColors.placeholder,
+                                            side: const BorderSide(
+                                              color: AppColors.placeholder,
+                                            ),
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(24),
+                                            ),
+                                            padding: const EdgeInsets.symmetric(
+                                              vertical: 12,
+                                            ),
+                                          ),
+                                          child: const Text(
+                                            'Cancelar',
+                                            style: TextStyle(
+                                              fontFamily: 'Manrope',
+                                              fontWeight: FontWeight.w600,
+                                              fontSize: 14,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                      const SizedBox(width: 10),
+                                      Expanded(
+                                        child: ElevatedButton(
+                                          onPressed: _selectedIds.isEmpty
+                                              ? null
+                                              : () =>
+                                                    _saveSelection(context),
+                                          style: ElevatedButton.styleFrom(
+                                            backgroundColor: AppColors.darkGreen,
+                                            disabledBackgroundColor:
+                                                AppColors.darkGreen
+                                                    .withValues(alpha: 0.4),
+                                            foregroundColor: AppColors.white,
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(24),
+                                            ),
+                                            padding: const EdgeInsets.symmetric(
+                                              vertical: 12,
+                                            ),
+                                          ),
+                                          child: Text(
+                                            _selectedIds.isEmpty
+                                                ? 'Salvar'
+                                                : 'Salvar (${_selectedIds.length})',
+                                            style: const TextStyle(
+                                              fontFamily: 'Manrope',
+                                              fontWeight: FontWeight.w600,
+                                              fontSize: 14,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  )
+                                : OutlinedButton(
+                                    onPressed: _enterSelectionMode,
+                                    style: OutlinedButton.styleFrom(
+                                      foregroundColor: AppColors.darkGreen,
+                                      side: const BorderSide(
+                                        color: AppColors.darkGreen,
+                                      ),
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(24),
+                                      ),
+                                      minimumSize: const Size(
+                                        double.infinity,
+                                        48,
+                                      ),
+                                    ),
+                                    child: const Text(
+                                      'Selecionar entregas de hoje',
+                                      style: TextStyle(
+                                        fontFamily: 'Figtree',
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 14,
+                                      ),
+                                    ),
+                                  ),
+                          ),
                       ],
                     );
                   },

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -14,7 +14,7 @@ import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_event.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_state.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/widgets/producer_order_card.dart';
-import 'package:ragro_mobile/shared/widgets/cancel_order_dialog.dart';
+import 'package:ragro_mobile/shared/widgets/confirm_dialog.dart';
 
 class ProducerOrdersPage extends StatelessWidget {
   const ProducerOrdersPage({super.key});
@@ -125,10 +125,9 @@ class _ProducerOrdersView extends StatelessWidget {
                       children: _tabs.map((tab) {
                         final isActive = activeTab == tab.$1;
                         return GestureDetector(
-                          onTap: () =>
-                              context.read<ProducerOrdersBloc>().add(
-                                ProducerOrdersTabChanged(tab.$1),
-                              ),
+                          onTap: () => context.read<ProducerOrdersBloc>().add(
+                            ProducerOrdersTabChanged(tab.$1),
+                          ),
                           child: Container(
                             padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
                             decoration: BoxDecoration(
@@ -224,8 +223,7 @@ class _ProducerOrdersView extends StatelessWidget {
                           Padding(
                             padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
                             child: GestureDetector(
-                              onTap: () =>
-                                  context.push('/producer/home/route'),
+                              onTap: () => context.push('/producer/home/route'),
                               child: Container(
                                 height: 44,
                                 decoration: BoxDecoration(
@@ -279,71 +277,43 @@ class _ProducerOrdersView extends StatelessWidget {
                               return ProducerOrderCard(
                                 order: order,
                                 onDetailTap: () async {
-                                  final result =
-                                      await context.push<String?>(
-                                        '/producer/home/orders/${order.id}',
-                                        extra: order,
-                                      );
+                                  final result = await context.push<String?>(
+                                    '/producer/home/orders/${order.id}',
+                                    extra: order,
+                                  );
                                   if (!context.mounted) return;
-                                  if (result == 'in_delivery') {
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      const SnackBar(
-                                        content: Text(
-                                          'Entrega iniciada com sucesso.',
-                                        ),
-                                        backgroundColor: AppColors.darkGreen,
-                                      ),
-                                    );
-                                    context.read<ProducerOrdersBloc>().add(
-                                      const ProducerOrdersStarted(
-                                        ProducerOrderStatus.inDelivery,
-                                      ),
-                                    );
-                                  } else if (result == 'cancelled') {
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      const SnackBar(
-                                        content: Text(
-                                          'Pedido recusado com sucesso.',
-                                        ),
-                                        backgroundColor: AppColors.darkGreen,
-                                      ),
-                                    );
+                                  if (result == 'cancelled') {
                                     context.read<ProducerOrdersBloc>().add(
                                       ProducerOrderLocallyRefused(order.id),
                                     );
-                                  } else if (result == 'delivered') {
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      const SnackBar(
-                                        content: Text(
-                                          'Entrega confirmada com sucesso.',
-                                        ),
-                                        backgroundColor: AppColors.darkGreen,
+                                    context.read<ProducerOrdersBloc>().add(
+                                      const ProducerOrdersTabChanged(
+                                        ProducerOrderStatus.cancelled,
                                       ),
                                     );
+                                  } else {
+                                    final targetTab = switch (result) {
+                                      'in_delivery' =>
+                                        ProducerOrderStatus.inDelivery,
+                                      'delivered' =>
+                                        ProducerOrderStatus.delivered,
+                                      _ => activeTab,
+                                    };
                                     context.read<ProducerOrdersBloc>().add(
-                                      ProducerOrderLocallyDelivered(order.id),
+                                      ProducerOrdersStarted(targetTab),
                                     );
                                   }
                                 },
-                                onCancelTap:
-                                    order.status == ProducerOrderStatus.pending
-                                    ? () => _confirmCancel(context, order.id)
-                                    : null,
                                 onActionTap:
                                     order.status == ProducerOrderStatus.pending
-                                    ? () =>
-                                          context
-                                              .read<ProducerOrdersBloc>()
-                                              .add(
-                                                ProducerOrderAccepted(order.id),
-                                              )
+                                    ? () => context
+                                          .read<ProducerOrdersBloc>()
+                                          .add(ProducerOrderAccepted(order.id))
                                     : null,
-                                onDeliveryConfirmTap: order.status ==
+                                onDeliveryConfirmTap:
+                                    order.status ==
                                         ProducerOrderStatus.inDelivery
-                                    ? () => _confirmDelivery(
-                                        context,
-                                        order.id,
-                                      )
+                                    ? () => _confirmDelivery(context, order.id)
                                     : null,
                               );
                             },
@@ -361,40 +331,18 @@ class _ProducerOrdersView extends StatelessWidget {
     );
   }
 
-  Future<void> _confirmCancel(BuildContext context, String orderId) async {
-    final result = await CancelOrderDialog.showForProducer(context);
-    if (result != null && context.mounted) {
-      context.read<ProducerOrdersBloc>().add(
-        ProducerOrderCancelled(orderId, reason: result.reason, details: result.details),
-      );
-    }
-  }
-
   Future<void> _confirmDelivery(BuildContext context, String orderId) async {
-    final confirmed = await showDialog<bool>(
+    final confirmed = await ConfirmDialog.show(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Confirmar entrega'),
-        content: const Text(
-          'Tem certeza que deseja confirmar a entrega deste pedido?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('Voltar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('Confirmar entrega'),
-          ),
-        ],
-      ),
+      title: 'Confirmar a entrega deste pedido?',
+      confirmLabel: 'Sim',
+      confirmColor: const Color(0xFF3B82F6),
+      cancelLabel: 'Não',
     );
-
     if ((confirmed ?? false) && context.mounted) {
-      context
-          .read<ProducerOrdersBloc>()
-          .add(ProducerOrderDeliveryConfirmed(orderId));
+      context.read<ProducerOrdersBloc>().add(
+        ProducerOrderDeliveryConfirmed(orderId),
+      );
     }
   }
 }

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -340,6 +340,10 @@ class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
                                         ProducerOrderStatus.cancelled,
                                       ),
                                     );
+                                  } else if (result == 'seen') {
+                                    context.read<ProducerOrdersBloc>().add(
+                                      ProducerOrderLocallySeen(order.id),
+                                    );
                                   } else {
                                     final targetTab = switch (result) {
                                       'in_delivery' =>
@@ -350,10 +354,6 @@ class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
                                     };
                                     context.read<ProducerOrdersBloc>().add(
                                       ProducerOrdersStarted(targetTab),
-                                    );
-                                  } else if (result == 'seen') {
-                                    context.read<ProducerOrdersBloc>().add(
-                                      ProducerOrderLocallySeen(order.id),
                                     );
                                   }
                                 },

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -42,22 +42,22 @@ class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
   final Set<String> _selectedIds = {};
 
   void _enterSelectionMode() => setState(() {
-        _selectionMode = true;
-        _selectedIds.clear();
-      });
+    _selectionMode = true;
+    _selectedIds.clear();
+  });
 
   void _exitSelectionMode() => setState(() {
-        _selectionMode = false;
-        _selectedIds.clear();
-      });
+    _selectionMode = false;
+    _selectedIds.clear();
+  });
 
   void _toggleSelection(String id) => setState(() {
-        if (_selectedIds.contains(id)) {
-          _selectedIds.remove(id);
-        } else {
-          _selectedIds.add(id);
-        }
-      });
+    if (_selectedIds.contains(id)) {
+      _selectedIds.remove(id);
+    } else {
+      _selectedIds.add(id);
+    }
+  });
 
   void _saveSelection(BuildContext context) {
     final bloc = context.read<ProducerOrdersBloc>();
@@ -412,13 +412,13 @@ class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
                                         child: ElevatedButton(
                                           onPressed: _selectedIds.isEmpty
                                               ? null
-                                              : () =>
-                                                    _saveSelection(context),
+                                              : () => _saveSelection(context),
                                           style: ElevatedButton.styleFrom(
-                                            backgroundColor: AppColors.darkGreen,
-                                            disabledBackgroundColor:
-                                                AppColors.darkGreen
-                                                    .withValues(alpha: 0.4),
+                                            backgroundColor:
+                                                AppColors.darkGreen,
+                                            disabledBackgroundColor: AppColors
+                                                .darkGreen
+                                                .withValues(alpha: 0.4),
                                             foregroundColor: AppColors.white,
                                             shape: RoundedRectangleBorder(
                                               borderRadius:

--- a/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
+++ b/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
@@ -220,31 +220,6 @@ class ProducerOrderCard extends StatelessWidget {
                   ),
                 ),
               ),
-              if (order.status == ProducerOrderStatus.pending &&
-                  onCancelTap != null) ...[
-                const SizedBox(width: 8),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: onCancelTap,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.red,
-                      foregroundColor: AppColors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(24),
-                      ),
-                      padding: const EdgeInsets.symmetric(vertical: 10),
-                    ),
-                    child: const Text(
-                      'Recusar',
-                      style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w600,
-                        fontSize: 14,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
               if (onActionTap != null) ...[
                 const SizedBox(width: 8),
                 Expanded(

--- a/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
+++ b/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
@@ -21,6 +21,7 @@ class ProducerOrderCard extends StatelessWidget {
   final VoidCallback? onActionTap;
   final VoidCallback? onCancelTap;
   final VoidCallback? onDeliveryConfirmTap;
+
   /// When non-null the card is in selection mode; tapping selects/deselects.
   final bool? isSelected;
   final VoidCallback? onSelect;

--- a/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
+++ b/lib/features/producer_orders/presentation/widgets/producer_order_card.dart
@@ -11,6 +11,8 @@ class ProducerOrderCard extends StatelessWidget {
     this.onActionTap,
     this.onCancelTap,
     this.onDeliveryConfirmTap,
+    this.isSelected,
+    this.onSelect,
     super.key,
   });
 
@@ -19,6 +21,9 @@ class ProducerOrderCard extends StatelessWidget {
   final VoidCallback? onActionTap;
   final VoidCallback? onCancelTap;
   final VoidCallback? onDeliveryConfirmTap;
+  /// When non-null the card is in selection mode; tapping selects/deselects.
+  final bool? isSelected;
+  final VoidCallback? onSelect;
 
   static final _dateFormat = DateFormat('dd/MM/yyyy, HH:mm', 'pt_BR');
 
@@ -30,25 +35,25 @@ class ProducerOrderCard extends StatelessWidget {
     ProducerOrderStatus.cancelled => 'Pedido cancelado',
   };
 
-  Color get _statusColor => switch (order.status) {
-    ProducerOrderStatus.pending => AppColors.yellow,
-    ProducerOrderStatus.accepted => AppColors.darkGreen,
-    ProducerOrderStatus.inDelivery => AppColors.lightGreen,
-    ProducerOrderStatus.delivered => AppColors.darkGreen,
-    ProducerOrderStatus.cancelled => AppColors.red,
-  };
-
   String _formatPrice(double price) =>
       r'R$ ' + price.toStringAsFixed(2).replaceAll('.', ',');
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final inSelectionMode = isSelected != null;
+    final selected = isSelected ?? false;
+
+    final card = Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: AppColors.white,
+        color: selected
+            ? AppColors.darkGreen.withValues(alpha: 0.06)
+            : AppColors.white,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFE2E8F0)),
+        border: Border.all(
+          color: selected ? AppColors.darkGreen : const Color(0xFFE2E8F0),
+          width: selected ? 1.5 : 1,
+        ),
         boxShadow: const [
           BoxShadow(
             color: Color(0x08000000),
@@ -102,45 +107,44 @@ class ProducerOrderCard extends StatelessWidget {
                   ],
                 ),
               ),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: _statusColor.withValues(alpha: 0.12),
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: Text(
-                  order.status.label.toUpperCase(),
-                  style: TextStyle(
-                    fontFamily: 'Manrope',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 11,
-                    color: _statusColor,
-                    letterSpacing: 0.5,
+              if (inSelectionMode)
+                Checkbox(
+                  value: selected,
+                  onChanged: (_) => onSelect?.call(),
+                  activeColor: AppColors.darkGreen,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4),
                   ),
-                ),
-              ),
-              const SizedBox(width: 6),
-              if (order.isNew)
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    color: AppColors.darkGreen.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                  child: const Text(
-                    'NOVO',
-                    style: TextStyle(
-                      fontFamily: 'Manrope',
-                      fontWeight: FontWeight.w700,
-                      fontSize: 11,
-                      color: AppColors.darkGreen,
-                      letterSpacing: 0.5,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: VisualDensity.compact,
+                )
+              else ...[
+                _StatusBadge(status: order.status),
+                if (order.isNew &&
+                    order.status != ProducerOrderStatus.accepted) ...[
+                  const SizedBox(width: 6),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColors.darkGreen.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: const Text(
+                      'NOVO',
+                      style: TextStyle(
+                        fontFamily: 'Manrope',
+                        fontWeight: FontWeight.w700,
+                        fontSize: 11,
+                        color: AppColors.darkGreen,
+                        letterSpacing: 0.5,
+                      ),
                     ),
                   ),
-                ),
+                ],
+              ],
             ],
           ),
 
@@ -194,47 +198,25 @@ class ProducerOrderCard extends StatelessWidget {
             ],
           ),
 
-          const SizedBox(height: 12),
+          if (!inSelectionMode) ...[
+            const SizedBox(height: 12),
 
-          // Actions
-          Row(
-            children: [
-              Expanded(
-                child: OutlinedButton(
-                  onPressed: onDetailTap,
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: AppColors.darkGreen,
-                    side: const BorderSide(color: AppColors.darkGreen),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(24),
-                    ),
-                    padding: const EdgeInsets.symmetric(vertical: 10),
-                  ),
-                  child: const Text(
-                    'Detalhes',
-                    style: TextStyle(
-                      fontFamily: 'Manrope',
-                      fontWeight: FontWeight.w600,
-                      fontSize: 14,
-                    ),
-                  ),
-                ),
-              ),
-              if (onActionTap != null) ...[
-                const SizedBox(width: 8),
+            // Actions
+            Row(
+              children: [
                 Expanded(
-                  child: ElevatedButton(
-                    onPressed: onActionTap,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.darkGreen,
-                      foregroundColor: AppColors.white,
+                  child: OutlinedButton(
+                    onPressed: onDetailTap,
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: AppColors.darkGreen,
+                      side: const BorderSide(color: AppColors.darkGreen),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(24),
                       ),
                       padding: const EdgeInsets.symmetric(vertical: 10),
                     ),
                     child: const Text(
-                      'Aceitar',
+                      'Detalhes',
                       style: TextStyle(
                         fontFamily: 'Manrope',
                         fontWeight: FontWeight.w600,
@@ -243,35 +225,128 @@ class ProducerOrderCard extends StatelessWidget {
                     ),
                   ),
                 ),
-              ],
-              if (order.status == ProducerOrderStatus.inDelivery &&
-                  onDeliveryConfirmTap != null) ...[
-                const SizedBox(width: 8),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: onDeliveryConfirmTap,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.darkGreen,
-                      foregroundColor: AppColors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(24),
+                if (onActionTap != null) ...[
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: onActionTap,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.darkGreen,
+                        foregroundColor: AppColors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                        padding: const EdgeInsets.symmetric(vertical: 10),
                       ),
-                      padding: const EdgeInsets.symmetric(vertical: 10),
-                    ),
-                    child: const Text(
-                      'Entregue',
-                      style: TextStyle(
-                        fontFamily: 'Manrope',
-                        fontWeight: FontWeight.w600,
-                        fontSize: 14,
+                      child: const Text(
+                        'Aceitar',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14,
+                        ),
                       ),
                     ),
                   ),
-                ),
+                ],
+                if (order.status == ProducerOrderStatus.inDelivery &&
+                    onDeliveryConfirmTap != null) ...[
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: onDeliveryConfirmTap,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.darkGreen,
+                        foregroundColor: AppColors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                        padding: const EdgeInsets.symmetric(vertical: 10),
+                      ),
+                      child: const Text(
+                        'Entregue',
+                        style: TextStyle(
+                          fontFamily: 'Manrope',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
               ],
-            ],
-          ),
+            ),
+          ],
         ],
+      ),
+    );
+
+    if (inSelectionMode) {
+      return GestureDetector(onTap: onSelect, child: card);
+    }
+    return card;
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+
+  final ProducerOrderStatus status;
+
+  static Color _colorFor(ProducerOrderStatus s) => switch (s) {
+    ProducerOrderStatus.pending => const Color(0xFFB45309),
+    ProducerOrderStatus.accepted => AppColors.darkGreen,
+    ProducerOrderStatus.inDelivery => const Color(0xFFEA580C),
+    ProducerOrderStatus.delivered => AppColors.darkGreen,
+    ProducerOrderStatus.cancelled => AppColors.red,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _colorFor(status);
+
+    if (status == ProducerOrderStatus.accepted) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: AppColors.darkGreen,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.check_circle_outline, color: AppColors.white, size: 12),
+            SizedBox(width: 4),
+            Text(
+              'ACEITO',
+              style: TextStyle(
+                fontFamily: 'Manrope',
+                fontWeight: FontWeight.w700,
+                fontSize: 11,
+                color: AppColors.white,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        status.label.toUpperCase(),
+        style: TextStyle(
+          fontFamily: 'Manrope',
+          fontWeight: FontWeight.w700,
+          fontSize: 11,
+          color: color,
+          letterSpacing: 0.5,
+        ),
       ),
     );
   }

--- a/lib/features/producer_profile/data/models/public_producer_model.dart
+++ b/lib/features/producer_profile/data/models/public_producer_model.dart
@@ -51,8 +51,12 @@ class PublicProducerModel extends PublicProducer {
       location: location,
       description: json['description'] as String? ?? '',
       story: json['story'] as String? ?? '',
-      avatarUrl: ApiEndpoints.resolveMediaUrl(json['avatarS3'] as String? ?? ''),
-      coverUrl: ApiEndpoints.resolveMediaUrl(json['displayPhotoS3'] as String? ?? ''),
+      avatarUrl: ApiEndpoints.resolveMediaUrl(
+        json['avatarS3'] as String? ?? '',
+      ),
+      coverUrl: ApiEndpoints.resolveMediaUrl(
+        json['displayPhotoS3'] as String? ?? '',
+      ),
       averageRating: (json['averageRating'] as num?)?.toDouble() ?? 0.0,
       totalReviews: json['totalReviews'] as int? ?? 0,
       phone: json['phone'] as String? ?? '',

--- a/lib/features/producer_profile/data/models/review_model.dart
+++ b/lib/features/producer_profile/data/models/review_model.dart
@@ -27,7 +27,9 @@ class ReviewModel extends Review {
           ? DateTime.parse(createdAtRaw)
           : DateTime.now(),
       authorAvatarUrl: () {
-        final raw = json['authorAvatarUrl'] as String? ?? json['author_avatar_url'] as String?;
+        final raw =
+            json['authorAvatarUrl'] as String? ??
+            json['author_avatar_url'] as String?;
         if (raw == null || raw.isEmpty) return null;
         return ApiEndpoints.resolveMediaUrl(raw);
       }(),

--- a/lib/features/producer_profile/domain/usecases/get_producer_profile.dart
+++ b/lib/features/producer_profile/domain/usecases/get_producer_profile.dart
@@ -10,6 +10,6 @@ class GetProducerProfile {
 
   Future<PublicProducer> call(String producerId, {bool isOwner = false}) =>
       isOwner
-          ? _repository.getOwnProfile(producerId)
-          : _repository.getProducer(producerId);
+      ? _repository.getOwnProfile(producerId)
+      : _repository.getProducer(producerId);
 }

--- a/lib/features/producer_profile/presentation/pages/reviews_page.dart
+++ b/lib/features/producer_profile/presentation/pages/reviews_page.dart
@@ -58,7 +58,7 @@ class _ReviewsPageState extends State<ReviewsPage> {
       setState(() {
         _error =
             (e.error as ApiException?)?.message ??
-                'Erro ao carregar avaliações';
+            'Erro ao carregar avaliações';
         _loading = false;
       });
     } on Object catch (_) {
@@ -99,144 +99,146 @@ class _ReviewsPageState extends State<ReviewsPage> {
       ),
       body: _loading
           ? const Center(
-        child: CircularProgressIndicator(color: AppColors.darkGreen),
-      )
+              child: CircularProgressIndicator(color: AppColors.darkGreen),
+            )
           : _error != null
           ? Center(child: Text(_error!))
           : SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              widget.producerName,
-              style: const TextStyle(
-                fontFamily: 'Figtree',
-                fontWeight: FontWeight.w700,
-                fontSize: 26,
-                color: AppColors.darkGreen,
-              ),
-            ),
-            if (widget.producerLocation.isNotEmpty) ...[
-              const SizedBox(height: 6),
-              Row(
-                children: [
-                  const Icon(
-                    Icons.location_on_outlined,
-                    size: 14,
-                    color: Color(0xFF64748B),
-                  ),
-                  const SizedBox(width: 4),
-                  Text(
-                    widget.producerLocation,
-                    style: const TextStyle(
-                      fontFamily: 'Figtree',
-                      fontWeight: FontWeight.w500,
-                      fontSize: 13,
-                      color: Color(0xFF64748B),
-                    ),
-                  ),
-                ],
-              ),
-            ],
-
-            const SizedBox(height: 24),
-            Container(
-              padding: const EdgeInsets.all(20),
-              decoration: BoxDecoration(
-                color: const Color(0x1A64748B), // #64748B1A do Figma
-                borderRadius: BorderRadius.circular(16),
-              ),
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text(
-                    'Resumo das Avaliações',
-                    style: TextStyle(
+                  Text(
+                    widget.producerName,
+                    style: const TextStyle(
                       fontFamily: 'Figtree',
                       fontWeight: FontWeight.w700,
-                      fontSize: 15,
-                      color: AppColors.black,
+                      fontSize: 26,
+                      color: AppColors.darkGreen,
                     ),
                   ),
-                  const SizedBox(height: 16),
-                  IntrinsicHeight(
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
+                  if (widget.producerLocation.isNotEmpty) ...[
+                    const SizedBox(height: 6),
+                    Row(
                       children: [
-                        Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              widget.averageRating.toStringAsFixed(1),
-                              style: const TextStyle(
-                                fontFamily: 'Figtree',
-                                fontWeight: FontWeight.w700,
-                                fontSize: 52,
-                                color: AppColors.black,
-                              ),
-                            ),
-                            _SummaryStarRow(rating: widget.averageRating),
-                            const SizedBox(height: 6),
-                            Text(
-                              '${widget.totalReviews} Avaliações',
-                              style: const TextStyle(
-                                fontFamily: 'Figtree',
-                                fontSize: 12,
-                                color: Color(0xFF94A3B8),
-                              ),
-                            ),
-                          ],
+                        const Icon(
+                          Icons.location_on_outlined,
+                          size: 14,
+                          color: Color(0xFF64748B),
                         ),
-                        const SizedBox(width: 20),
-                        Expanded(
-                          child: _RatingDistribution(
-                            distribution: _buildDistribution(),
-                            total: _reviews.length,
+                        const SizedBox(width: 4),
+                        Text(
+                          widget.producerLocation,
+                          style: const TextStyle(
+                            fontFamily: 'Figtree',
+                            fontWeight: FontWeight.w500,
+                            fontSize: 13,
+                            color: Color(0xFF64748B),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+
+                  const SizedBox(height: 24),
+                  Container(
+                    padding: const EdgeInsets.all(20),
+                    decoration: BoxDecoration(
+                      color: const Color(0x1A64748B), // #64748B1A do Figma
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'Resumo das Avaliações',
+                          style: TextStyle(
+                            fontFamily: 'Figtree',
+                            fontWeight: FontWeight.w700,
+                            fontSize: 15,
+                            color: AppColors.black,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        IntrinsicHeight(
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    widget.averageRating.toStringAsFixed(1),
+                                    style: const TextStyle(
+                                      fontFamily: 'Figtree',
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 52,
+                                      color: AppColors.black,
+                                    ),
+                                  ),
+                                  _SummaryStarRow(rating: widget.averageRating),
+                                  const SizedBox(height: 6),
+                                  Text(
+                                    '${widget.totalReviews} Avaliações',
+                                    style: const TextStyle(
+                                      fontFamily: 'Figtree',
+                                      fontSize: 12,
+                                      color: Color(0xFF94A3B8),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(width: 20),
+                              Expanded(
+                                child: _RatingDistribution(
+                                  distribution: _buildDistribution(),
+                                  total: _reviews.length,
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],
                     ),
                   ),
+
+                  const SizedBox(height: 24),
+                  if (_reviews.isEmpty)
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 32),
+                        child: Column(
+                          children: [
+                            Icon(
+                              Icons.rate_review_outlined,
+                              size: 48,
+                              color: AppColors.darkGreen.withValues(alpha: 0.3),
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              'Nenhuma avaliação ainda',
+                              style: TextStyle(
+                                fontFamily: 'Figtree',
+                                fontSize: 16,
+                                color: AppColors.darkGreen.withValues(
+                                  alpha: 0.6,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    )
+                  else
+                    ListView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: _reviews.length,
+                      itemBuilder: (_, i) => ReviewCard(review: _reviews[i]),
+                    ),
                 ],
               ),
             ),
-
-            const SizedBox(height: 24),
-            if (_reviews.isEmpty)
-              Center(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 32),
-                  child: Column(
-                    children: [
-                      Icon(
-                        Icons.rate_review_outlined,
-                        size: 48,
-                        color: AppColors.darkGreen.withValues(alpha: 0.3),
-                      ),
-                      const SizedBox(height: 12),
-                      Text(
-                        'Nenhuma avaliação ainda',
-                        style: TextStyle(
-                          fontFamily: 'Figtree',
-                          fontSize: 16,
-                          color: AppColors.darkGreen.withValues(alpha: 0.6),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              )
-            else
-              ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: _reviews.length,
-                itemBuilder: (_, i) => ReviewCard(review: _reviews[i]),
-              ),
-          ],
-        ),
-      ),
     );
   }
 }
@@ -251,11 +253,19 @@ class _SummaryStarRow extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: List.generate(5, (i) {
         if (i < rating.floor()) {
-          return const Icon(Icons.star,      size: 18, color: AppColors.darkGreen);
+          return const Icon(Icons.star, size: 18, color: AppColors.darkGreen);
         } else if (i < rating) {
-          return const Icon(Icons.star_half, size: 18, color: AppColors.darkGreen);
+          return const Icon(
+            Icons.star_half,
+            size: 18,
+            color: AppColors.darkGreen,
+          );
         }
-        return const Icon(Icons.star_border, size: 18, color: AppColors.darkGreen);
+        return const Icon(
+          Icons.star_border,
+          size: 18,
+          color: AppColors.darkGreen,
+        );
       }),
     );
   }

--- a/lib/features/producer_profile/presentation/widgets/review_card.dart
+++ b/lib/features/producer_profile/presentation/widgets/review_card.dart
@@ -48,11 +48,9 @@ class ReviewCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-
               CircleAvatar(
                 radius: 18,
 
@@ -65,14 +63,14 @@ class ReviewCard extends StatelessWidget {
                     : null,
                 child: review.authorAvatarUrl == null
                     ? Text(
-                  _authorInitial,
-                  style: const TextStyle(
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 14,
-                    color: AppColors.darkGreen,
-                  ),
-                )
+                        _authorInitial,
+                        style: const TextStyle(
+                          fontFamily: 'Figtree',
+                          fontWeight: FontWeight.w700,
+                          fontSize: 14,
+                          color: AppColors.darkGreen,
+                        ),
+                      )
                     : null,
               ),
               const SizedBox(width: 12),

--- a/lib/features/product_detail/data/models/product_detail_model.dart
+++ b/lib/features/product_detail/data/models/product_detail_model.dart
@@ -29,9 +29,11 @@ class ProductDetailModel extends ProductDetail {
     final firstPhotoUrl = photos != null && photos.isNotEmpty
         ? (photos.first as Map<String, dynamic>)['url'] as String? ?? ''
         : '';
-    final imageUrl = ApiEndpoints.resolveMediaUrl(firstPhotoUrl.isNotEmpty
-        ? firstPhotoUrl
-        : (json['imageS3'] as String? ?? ''));
+    final imageUrl = ApiEndpoints.resolveMediaUrl(
+      firstPhotoUrl.isNotEmpty
+          ? firstPhotoUrl
+          : (json['imageS3'] as String? ?? ''),
+    );
     return ProductDetailModel(
       id: (json['id'] as Object).toString(),
       name: json['name'] as String,

--- a/lib/features/search/data/models/search_result_model.dart
+++ b/lib/features/search/data/models/search_result_model.dart
@@ -37,7 +37,9 @@ class SearchResultModel extends SearchResult {
       type: type,
       name: json['name'] as String? ?? '',
       subtitle: json['subtitle'] as String? ?? '',
-      imageUrl: ApiEndpoints.resolveMediaUrl(json['image_url'] as String? ?? ''),
+      imageUrl: ApiEndpoints.resolveMediaUrl(
+        json['image_url'] as String? ?? '',
+      ),
       producerId:
           json['producerId'] as String? ??
           json['farmerId'] as String? ??

--- a/lib/features/search/presentation/pages/search_result_page.dart
+++ b/lib/features/search/presentation/pages/search_result_page.dart
@@ -342,10 +342,7 @@ class _SearchResultsViewState extends State<_SearchResultsView> {
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(
-        SnackBar(
-          content: Text(message),
-          backgroundColor: AppColors.darkGreen,
-        ),
+        SnackBar(content: Text(message), backgroundColor: AppColors.darkGreen),
       );
   }
 

--- a/lib/shared/widgets/cancel_order_dialog.dart
+++ b/lib/shared/widgets/cancel_order_dialog.dart
@@ -66,9 +66,9 @@ class _CancelOrderDialogState extends State<CancelOrderDialog> {
     final details = _isOther && _detailsController.text.trim().isNotEmpty
         ? _detailsController.text.trim()
         : null;
-    Navigator.of(context).pop<CancelResult>(
-      (reason: _selectedReason!, details: details),
-    );
+    Navigator.of(
+      context,
+    ).pop<CancelResult>((reason: _selectedReason!, details: details));
   }
 
   @override

--- a/test/features/cart/presentation/bloc/cart_bloc_test.dart
+++ b/test/features/cart/presentation/bloc/cart_bloc_test.dart
@@ -31,13 +31,8 @@ void main() {
   late _MockRemoveFromCart removeFromCart;
   late _MockClearCart clearCart;
 
-  CartBloc buildBloc() => CartBloc(
-    getCart,
-    addToCart,
-    updateQuantity,
-    removeFromCart,
-    clearCart,
-  );
+  CartBloc buildBloc() =>
+      CartBloc(getCart, addToCart, updateQuantity, removeFromCart, clearCart);
 
   const tItem = CartItem(
     id: 'item-1',
@@ -117,9 +112,8 @@ void main() {
         ).thenAnswer((_) async => tCart);
         return buildBloc();
       },
-      act: (bloc) => bloc.add(
-        const CartItemAdded(productId: 'p-1', quantity: 2),
-      ),
+      act: (bloc) =>
+          bloc.add(const CartItemAdded(productId: 'p-1', quantity: 2)),
       expect: () => [const CartLoaded(tCart)],
       verify: (_) {
         verify(() => addToCart(productId: 'p-1', quantity: 2)).called(1);
@@ -138,13 +132,9 @@ void main() {
         return buildBloc();
       },
       seed: () => const CartLoaded(tEmptyCart),
-      act: (bloc) => bloc.add(
-        const CartItemAdded(productId: 'p-1', quantity: 2),
-      ),
-      expect: () => [
-        const CartUpdating(tEmptyCart),
-        const CartLoaded(tCart),
-      ],
+      act: (bloc) =>
+          bloc.add(const CartItemAdded(productId: 'p-1', quantity: 2)),
+      expect: () => [const CartUpdating(tEmptyCart), const CartLoaded(tCart)],
     );
 
     blocTest<CartBloc, CartState>(
@@ -164,9 +154,8 @@ void main() {
         return buildBloc();
       },
       seed: () => const CartLoaded(tCart),
-      act: (bloc) => bloc.add(
-        const CartItemAdded(productId: 'p-2', quantity: 1),
-      ),
+      act: (bloc) =>
+          bloc.add(const CartItemAdded(productId: 'p-2', quantity: 1)),
       expect: () => [
         const CartUpdating(tCart),
         const CartUpdateFailure(
@@ -187,9 +176,8 @@ void main() {
         ).thenThrow(const NetworkException());
         return buildBloc();
       },
-      act: (bloc) => bloc.add(
-        const CartItemAdded(productId: 'p-1', quantity: 1),
-      ),
+      act: (bloc) =>
+          bloc.add(const CartItemAdded(productId: 'p-1', quantity: 1)),
       expect: () => [const CartFailure('Sem conexão com a internet')],
     );
   });
@@ -217,7 +205,10 @@ void main() {
           () => updateQuantity(cartItemId: 'item-1', quantity: 3),
         ).called(1);
         verifyNever(
-          () => updateQuantity(cartItemId: 'p-1', quantity: any(named: 'quantity')),
+          () => updateQuantity(
+            cartItemId: 'p-1',
+            quantity: any(named: 'quantity'),
+          ),
         );
       },
     );
@@ -232,10 +223,7 @@ void main() {
       },
       seed: () => const CartLoaded(tCart),
       act: (bloc) => bloc.add(const CartItemRemoved('item-1')),
-      expect: () => [
-        const CartUpdating(tCart),
-        const CartLoaded(tEmptyCart),
-      ],
+      expect: () => [const CartUpdating(tCart), const CartLoaded(tEmptyCart)],
       verify: (_) {
         verify(() => removeFromCart('item-1')).called(1);
       },
@@ -251,10 +239,7 @@ void main() {
       },
       seed: () => const CartLoaded(tCart),
       act: (bloc) => bloc.add(const CartCleared()),
-      expect: () => [
-        const CartUpdating(tCart),
-        const CartLoaded(tEmptyCart),
-      ],
+      expect: () => [const CartUpdating(tCart), const CartLoaded(tEmptyCart)],
     );
   });
 }

--- a/test/features/orders/data/models/order_detail_model_test.dart
+++ b/test/features/orders/data/models/order_detail_model_test.dart
@@ -75,10 +75,7 @@ void main() {
     });
 
     test('returns safe defaults when fields are missing or null', () {
-      final json = <String, dynamic>{
-        'id': 'order-3',
-        'status': 'PENDING',
-      };
+      final json = <String, dynamic>{'id': 'order-3', 'status': 'PENDING'};
 
       final model = OrderDetailModel.fromJson(json);
 

--- a/test/features/orders/domain/usecases/cancel_customer_order_test.dart
+++ b/test/features/orders/domain/usecases/cancel_customer_order_test.dart
@@ -51,28 +51,28 @@ void main() {
       await useCase('order-2', reason: 'Outro');
 
       verify(
-        () => repo.cancelCustomerOrder(
-          'order-2',
-          reason: 'Outro',
-          details: null,
-        ),
+        () =>
+            repo.cancelCustomerOrder('order-2', reason: 'Outro', details: null),
       ).called(1);
     });
 
-    test('propaga NotFoundException do repository (bug C1: endpoint pode não existir)', () async {
-      when(
-        () => repo.cancelCustomerOrder(
-          any(),
-          reason: any(named: 'reason'),
-          details: any(named: 'details'),
-        ),
-      ).thenThrow(const NotFoundException());
+    test(
+      'propaga NotFoundException do repository (bug C1: endpoint pode não existir)',
+      () async {
+        when(
+          () => repo.cancelCustomerOrder(
+            any(),
+            reason: any(named: 'reason'),
+            details: any(named: 'details'),
+          ),
+        ).thenThrow(const NotFoundException());
 
-      expect(
-        () => useCase('order-3', reason: 'Mudei de ideia'),
-        throwsA(isA<NotFoundException>()),
-      );
-    });
+        expect(
+          () => useCase('order-3', reason: 'Mudei de ideia'),
+          throwsA(isA<NotFoundException>()),
+        );
+      },
+    );
   });
 
   // Sanity-check para evitar warning de import não usado quando entidades

--- a/test/features/orders/domain/usecases/confirm_customer_delivery_test.dart
+++ b/test/features/orders/domain/usecases/confirm_customer_delivery_test.dart
@@ -58,15 +58,15 @@ void main() {
       verify(() => repo.confirmCustomerDelivery('order-1')).called(1);
     });
 
-    test('propaga NotFoundException quando endpoint backend ainda não existe (bug C2)', () async {
-      when(
-        () => repo.confirmCustomerDelivery(any()),
-      ).thenThrow(const NotFoundException());
+    test(
+      'propaga NotFoundException quando endpoint backend ainda não existe (bug C2)',
+      () async {
+        when(
+          () => repo.confirmCustomerDelivery(any()),
+        ).thenThrow(const NotFoundException());
 
-      expect(
-        () => useCase('order-x'),
-        throwsA(isA<NotFoundException>()),
-      );
-    });
+        expect(() => useCase('order-x'), throwsA(isA<NotFoundException>()));
+      },
+    );
   });
 }

--- a/test/features/orders/domain/usecases/confirm_order_test.dart
+++ b/test/features/orders/domain/usecases/confirm_order_test.dart
@@ -46,9 +46,7 @@ void main() {
 
   group('ConfirmOrder', () {
     test('chama createOrderFromCart e retorna nova Order', () async {
-      when(
-        () => repo.createOrderFromCart(),
-      ).thenAnswer((_) async => tOrder);
+      when(() => repo.createOrderFromCart()).thenAnswer((_) async => tOrder);
 
       final result = await useCase();
 
@@ -58,48 +56,44 @@ void main() {
       verify(() => repo.createOrderFromCart()).called(1);
     });
 
-    test('ignora cartId quando fornecido (parâmetro opcional não usado)', () async {
-      when(
-        () => repo.createOrderFromCart(),
-      ).thenAnswer((_) async => tOrder);
+    test(
+      'ignora cartId quando fornecido (parâmetro opcional não usado)',
+      () async {
+        when(() => repo.createOrderFromCart()).thenAnswer((_) async => tOrder);
 
-      final result = await useCase('cart-123');
+        final result = await useCase('cart-123');
 
-      expect(result.id, 'order-new-1');
-      verify(() => repo.createOrderFromCart()).called(1);
-    });
+        expect(result.id, 'order-new-1');
+        verify(() => repo.createOrderFromCart()).called(1);
+      },
+    );
 
-    test('propaga ConflictException quando carrinho vazio ou inválido', () async {
-      when(
-        () => repo.createOrderFromCart(),
-      ).thenThrow(const ConflictException());
+    test(
+      'propaga ConflictException quando carrinho vazio ou inválido',
+      () async {
+        when(
+          () => repo.createOrderFromCart(),
+        ).thenThrow(const ConflictException());
 
-      expect(
-        () => useCase(),
-        throwsA(isA<ConflictException>()),
-      );
-    });
+        expect(() => useCase(), throwsA(isA<ConflictException>()));
+      },
+    );
 
-    test('propaga UnauthorizedException quando usuário não autenticado', () async {
-      when(
-        () => repo.createOrderFromCart(),
-      ).thenThrow(const UnauthorizedException());
+    test(
+      'propaga UnauthorizedException quando usuário não autenticado',
+      () async {
+        when(
+          () => repo.createOrderFromCart(),
+        ).thenThrow(const UnauthorizedException());
 
-      expect(
-        () => useCase(),
-        throwsA(isA<UnauthorizedException>()),
-      );
-    });
+        expect(() => useCase(), throwsA(isA<UnauthorizedException>()));
+      },
+    );
 
     test('propaga ServerException em erro do servidor', () async {
-      when(
-        () => repo.createOrderFromCart(),
-      ).thenThrow(const ServerException());
+      when(() => repo.createOrderFromCart()).thenThrow(const ServerException());
 
-      expect(
-        () => useCase(),
-        throwsA(isA<ServerException>()),
-      );
+      expect(() => useCase(), throwsA(isA<ServerException>()));
     });
   });
 }

--- a/test/features/orders/domain/usecases/get_customer_order_by_id_test.dart
+++ b/test/features/orders/domain/usecases/get_customer_order_by_id_test.dart
@@ -45,72 +45,78 @@ void main() {
   });
 
   group('GetCustomerOrderById', () {
-    test('repassa orderId para o repository e retorna OrderDetail completo', () async {
-      when(
-        () => repo.getCustomerOrderById(any()),
-      ).thenAnswer((_) async => tOrderDetail);
+    test(
+      'repassa orderId para o repository e retorna OrderDetail completo',
+      () async {
+        when(
+          () => repo.getCustomerOrderById(any()),
+        ).thenAnswer((_) async => tOrderDetail);
 
-      final result = await useCase('order-detail-1');
+        final result = await useCase('order-detail-1');
 
-      expect(result.id, 'order-detail-1');
-      expect(result.orderNumber, '#0001');
-      expect(result.status, 'PENDING');
-      expect(result.producerName, 'Fazenda Teste');
-      expect(result.deliveryAddress.city, 'Porto Alegre');
-      expect(result.actions?.canCancel, isTrue);
-      verify(() => repo.getCustomerOrderById('order-detail-1')).called(1);
-    });
+        expect(result.id, 'order-detail-1');
+        expect(result.orderNumber, '#0001');
+        expect(result.status, 'PENDING');
+        expect(result.producerName, 'Fazenda Teste');
+        expect(result.deliveryAddress.city, 'Porto Alegre');
+        expect(result.actions?.canCancel, isTrue);
+        verify(() => repo.getCustomerOrderById('order-detail-1')).called(1);
+      },
+    );
 
-    test('retorna OrderDetail com items quando houver itens no pedido', () async {
-      final orderWithItems = OrderDetail(
-        id: 'order-detail-2',
-        orderNumber: '#0002',
-        status: 'PENDING',
-        statusLabel: 'Pendente',
-        createdAt: DateTime(2026, 5, 5),
-        producerId: 'p1',
-        producerName: 'Fazenda Teste',
-        producerPhone: '5199999999',
-        producerPicture: null,
-        items: const [
-          OrderDetailItem(
-            id: 'item-1',
-            productId: 'prod-1',
-            productName: 'Tomate',
-            productPhoto: 'http://example.com/tomate.jpg',
-            quantity: 2.5,
-            unityType: 'kg',
-            unitPrice: 5.0,
-            subtotal: 12.5,
+    test(
+      'retorna OrderDetail com items quando houver itens no pedido',
+      () async {
+        final orderWithItems = OrderDetail(
+          id: 'order-detail-2',
+          orderNumber: '#0002',
+          status: 'PENDING',
+          statusLabel: 'Pendente',
+          createdAt: DateTime(2026, 5, 5),
+          producerId: 'p1',
+          producerName: 'Fazenda Teste',
+          producerPhone: '5199999999',
+          producerPicture: null,
+          items: const [
+            OrderDetailItem(
+              id: 'item-1',
+              productId: 'prod-1',
+              productName: 'Tomate',
+              productPhoto: 'http://example.com/tomate.jpg',
+              quantity: 2.5,
+              unityType: 'kg',
+              unitPrice: 5.0,
+              subtotal: 12.5,
+            ),
+          ],
+          totalAmount: 12.5,
+          deliveryAddress: const OrderDetailAddress(
+            street: 'Rua A',
+            number: '123',
+            complement: 'Apt 101',
+            neighborhood: 'Centro',
+            city: 'Porto Alegre',
+            state: 'RS',
+            reference: 'Próximo ao banco',
           ),
-        ],
-        totalAmount: 12.5,
-        deliveryAddress: const OrderDetailAddress(
-          street: 'Rua A',
-          number: '123',
-          complement: 'Apt 101',
-          neighborhood: 'Centro',
-          city: 'Porto Alegre',
-          state: 'RS',
-          reference: 'Próximo ao banco',
-        ),
-        actions: const OrderDetailActions(
-          canConfirmDelivery: false,
-          canCancel: true,
-          canContactProducer: true,
-        ),
-      );
+          actions: const OrderDetailActions(
+            canConfirmDelivery: false,
+            canCancel: true,
+            canContactProducer: true,
+          ),
+        );
 
-      when(
-        () => repo.getCustomerOrderById(any()),
-      ).thenAnswer((_) async => orderWithItems);
+        when(
+          () => repo.getCustomerOrderById(any()),
+        ).thenAnswer((_) async => orderWithItems);
 
-      final result = await useCase('order-detail-2');
+        final result = await useCase('order-detail-2');
 
-      expect(result.items, isNotEmpty);
-      expect(result.items.first.productName, 'Tomate');
-      expect(result.items.first.quantity, 2.5);
-    });
+        expect(result.items, isNotEmpty);
+        expect(result.items.first.productName, 'Tomate');
+        expect(result.items.first.quantity, 2.5);
+      },
+    );
 
     test('propaga NotFoundException quando order não existe', () async {
       when(
@@ -123,26 +129,26 @@ void main() {
       );
     });
 
-    test('propaga UnauthorizedException quando ordem pertence a outro cliente', () async {
-      when(
-        () => repo.getCustomerOrderById(any()),
-      ).thenThrow(const UnauthorizedException());
+    test(
+      'propaga UnauthorizedException quando ordem pertence a outro cliente',
+      () async {
+        when(
+          () => repo.getCustomerOrderById(any()),
+        ).thenThrow(const UnauthorizedException());
 
-      expect(
-        () => useCase('order-other-user'),
-        throwsA(isA<UnauthorizedException>()),
-      );
-    });
+        expect(
+          () => useCase('order-other-user'),
+          throwsA(isA<UnauthorizedException>()),
+        );
+      },
+    );
 
     test('propaga NetworkException em caso de erro de conectividade', () async {
       when(
         () => repo.getCustomerOrderById(any()),
       ).thenThrow(const NetworkException());
 
-      expect(
-        () => useCase('order-detail-1'),
-        throwsA(isA<NetworkException>()),
-      );
+      expect(() => useCase('order-detail-1'), throwsA(isA<NetworkException>()));
     });
   });
 }

--- a/test/features/orders/domain/usecases/repeat_order_test.dart
+++ b/test/features/orders/domain/usecases/repeat_order_test.dart
@@ -46,9 +46,7 @@ void main() {
 
   group('RepeatOrder', () {
     test('repassa orderId para o repository e retorna nova Order', () async {
-      when(
-        () => repo.repeatOrder(any()),
-      ).thenAnswer((_) async => tOrder);
+      when(() => repo.repeatOrder(any())).thenAnswer((_) async => tOrder);
 
       final result = await useCase('order-1');
 
@@ -60,9 +58,7 @@ void main() {
     });
 
     test('propaga NotFoundException quando order não existe', () async {
-      when(
-        () => repo.repeatOrder(any()),
-      ).thenThrow(const NotFoundException());
+      when(() => repo.repeatOrder(any())).thenThrow(const NotFoundException());
 
       expect(
         () => useCase('order-nonexistent'),
@@ -70,26 +66,24 @@ void main() {
       );
     });
 
-    test('propaga UnauthorizedException quando usuário não tem permissão', () async {
-      when(
-        () => repo.repeatOrder(any()),
-      ).thenThrow(const UnauthorizedException());
+    test(
+      'propaga UnauthorizedException quando usuário não tem permissão',
+      () async {
+        when(
+          () => repo.repeatOrder(any()),
+        ).thenThrow(const UnauthorizedException());
 
-      expect(
-        () => useCase('order-forbidden'),
-        throwsA(isA<UnauthorizedException>()),
-      );
-    });
+        expect(
+          () => useCase('order-forbidden'),
+          throwsA(isA<UnauthorizedException>()),
+        );
+      },
+    );
 
     test('propaga NetworkException quando há erro de rede', () async {
-      when(
-        () => repo.repeatOrder(any()),
-      ).thenThrow(const NetworkException());
+      when(() => repo.repeatOrder(any())).thenThrow(const NetworkException());
 
-      expect(
-        () => useCase('order-1'),
-        throwsA(isA<NetworkException>()),
-      );
+      expect(() => useCase('order-1'), throwsA(isA<NetworkException>()));
     });
   });
 }

--- a/test/features/producer_orders/domain/usecases/update_producer_order_status_test.dart
+++ b/test/features/producer_orders/domain/usecases/update_producer_order_status_test.dart
@@ -23,9 +23,7 @@ void main() {
 
   group('UpdateProducerOrderStatus', () {
     test('repassa orderId e status (in_delivery) para o repository', () async {
-      when(
-        () => repo.updateStatus(any(), any()),
-      ).thenAnswer((_) async {});
+      when(() => repo.updateStatus(any(), any())).thenAnswer((_) async {});
 
       await useCase('order-1', ProducerOrderStatus.inDelivery);
 
@@ -35,9 +33,7 @@ void main() {
     });
 
     test('repassa status (delivered) corretamente', () async {
-      when(
-        () => repo.updateStatus(any(), any()),
-      ).thenAnswer((_) async {});
+      when(() => repo.updateStatus(any(), any())).thenAnswer((_) async {});
 
       await useCase('order-2', ProducerOrderStatus.delivered);
 
@@ -46,15 +42,18 @@ void main() {
       ).called(1);
     });
 
-    test('propaga ForbiddenException do repository (producer sem permissão)', () async {
-      when(
-        () => repo.updateStatus(any(), any()),
-      ).thenThrow(const ForbiddenException());
+    test(
+      'propaga ForbiddenException do repository (producer sem permissão)',
+      () async {
+        when(
+          () => repo.updateStatus(any(), any()),
+        ).thenThrow(const ForbiddenException());
 
-      expect(
-        () => useCase('order-3', ProducerOrderStatus.delivered),
-        throwsA(isA<ForbiddenException>()),
-      );
-    });
+        expect(
+          () => useCase('order-3', ProducerOrderStatus.delivered),
+          throwsA(isA<ForbiddenException>()),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## O que mudou?

Cancelamento de pedidos: fluxo corrigido — ao confirmar o motivo no modal CancelOrderDialog, o cancelamento é executado com sucesso. Removido o segundo modal de confirmação.
Salvar motivo de cancelamento: integrado ao endpoint PATCH /orders/{id}/cancel, que persiste cancellationReason e cancellationDetails no banco. O motivo é exibido num card vermelho na tela de detalhes do pedido cancelado.
Cancelamento em "A caminho": produtores agora podem cancelar pedidos com status IN_DELIVERY (validação do backend alterada de allowlist para blocklist — apenas DELIVERED e CANCELLED bloqueados).
Erros de ação silenciosos corrigidos: novo estado ProducerOrderDetailActionError mantém a página visível ao falhar uma ação e exibe snackbar de erro.
Seleção múltipla na aba Aceitos: botão "Selecionar entregas de hoje" ativa modo de seleção com checkboxes por card; "Salvar (N)" despacha ProducerOrderMarkedInDelivery para cada pedido selecionado e navega para aba "A caminho".
Ajustes visuais (Figma): badge "NOVO" removido de pedidos aceitos; badge "ACEITO" agora é uma pílula sólida verde com ícone de check; botão "Selecionar entregas de hoje" em estilo outlined.
Tipo de mudança


## Tipo de mudança

- [X] Nova feature
- [X] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?
Cancelamento:

Como produtor, abra um pedido com status Pendente, Aceito ou A caminho
Toque em "Cancelar Pedido" → selecione um motivo → toque "Confirmar cancelamento"
Verifique que o pedido some da aba atual e aparece em Cancelados
Abra o detalhe do pedido cancelado → confirme que o card vermelho com o motivo está visível
Seleção múltipla:

Como produtor, acesse a aba Aceitos
Toque em "Selecionar entregas de hoje" → checkboxes aparecem nos cards
Selecione um ou mais pedidos → o botão "Salvar (N)" fica ativo
Toque "Salvar" → pedidos selecionados movem para aba A caminho
Regressão:

Aceitar pedido pendente (botão "Aceitar" no card) continua funcionando
Confirmar entrega em "A caminho" continua funcionando
Navegar para detalhes do pedido sem entrar em modo de seleção continua funcionando


## Screenshots / Gravações

<img width="512" height="706" alt="image" src="https://github.com/user-attachments/assets/8afb4d32-b6b7-4f24-9947-c80a636550f6" />

<img width="545" height="43" alt="image" src="https://github.com/user-attachments/assets/762fab6e-2fc3-43fa-9955-2aa0c4c68723" />

<img width="542" height="812" alt="image" src="https://github.com/user-attachments/assets/6488fbd4-ce43-493f-9fcc-f504e16b045d" />

<img width="545" height="842" alt="image" src="https://github.com/user-attachments/assets/7ad2aae1-c054-4967-a261-189d0448e377" />

<img width="529" height="601" alt="image" src="https://github.com/user-attachments/assets/f8ad8f48-17b2-44db-9d70-a7d6eda672fe" />

<img width="543" height="844" alt="image" src="https://github.com/user-attachments/assets/6313f6e4-7d97-4227-9027-28e84daf8959" />


<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist

- [x] Código formatado (`dart format .`) 317 arquivos, 0 alterados
- [x] Sem warnings no analyze (`dart analyze`) 0 erros (corrigido home_bloc.dart
- [x] Testes passando (`flutter test`)   141/141 testes passando
- [x] Segue o padrão de arquitetura do projeto 
