### PR TITLE
Feature/338 recommendations home

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -255,6 +255,16 @@ import 'package:ragro_mobile/features/product_detail/domain/usecases/get_product
     as _i680;
 import 'package:ragro_mobile/features/product_detail/presentation/bloc/product_detail_bloc.dart'
     as _i740;
+import 'package:ragro_mobile/features/recommendations/data/datasources/recommendation_remote_datasource.dart'
+    as _i1008;
+import 'package:ragro_mobile/features/recommendations/data/repositories/recommentations_repository_impl.dart'
+    as _i941;
+import 'package:ragro_mobile/features/recommendations/domain/repositories/recommendations_repository.dart'
+    as _i485;
+import 'package:ragro_mobile/features/recommendations/domain/usecases/get_recommendations_usecase.dart'
+    as _i3;
+import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_bloc.dart'
+    as _i721;
 import 'package:ragro_mobile/features/search/data/datasources/search_local_datasource.dart'
     as _i52;
 import 'package:ragro_mobile/features/search/data/datasources/search_remote_datasource.dart'
@@ -371,6 +381,9 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i127.ProductDetailRemoteDataSource>(
       () => _i127.ProductDetailRemoteDataSource(gh<_i873.ApiClient>()),
+    );
+    gh.lazySingleton<_i1008.RecommendationsRemoteDatasource>(
+      () => _i1008.RecommendationsRemoteDatasource(gh<_i873.ApiClient>()),
     );
     gh.lazySingleton<_i987.SearchRemoteDataSource>(
       () => _i987.SearchRemoteDataSource(gh<_i873.ApiClient>()),
@@ -509,6 +522,11 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i567.StockExitBloc>(
       () => _i567.StockExitBloc(gh<_i736.RegisterStockExit>()),
     );
+    gh.lazySingleton<_i485.RecommendationsRepository>(
+      () => _i941.RecommendationsRepositoryImpl(
+        gh<_i1008.RecommendationsRemoteDatasource>(),
+      ),
+    );
     gh.lazySingleton<_i285.HomeRepository>(
       () => _i1055.HomeRepositoryImpl(gh<_i904.HomeRemoteDataSource>()),
     );
@@ -642,6 +660,10 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i419.AppRouter>(
       () => _i419.AppRouter(gh<_i475.AuthBloc>()),
     );
+    gh.lazySingleton<_i3.GetRecommendationsUsecase>(
+      () =>
+          _i3.GetRecommendationsUsecase(gh<_i485.RecommendationsRepository>()),
+    );
     gh.factory<_i846.AdminProducerFormBloc>(
       () => _i846.AdminProducerFormBloc(gh<_i321.CreateAdminProducer>()),
     );
@@ -668,6 +690,9 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i626.GetCustomerProfile>(),
         gh<_i436.UpdateCustomerProfile>(),
       ),
+    );
+    gh.factory<_i721.RecommendationsBloc>(
+      () => _i721.RecommendationsBloc(gh<_i3.GetRecommendationsUsecase>()),
     );
     gh.factory<_i463.CheckoutBloc>(
       () => _i463.CheckoutBloc(gh<_i680.ConfirmOrder>(), gh<_i535.GetCart>()),

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -1,12 +1,12 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/home/domain/repositories/favorite_producer_repository.dart';
 import 'package:ragro_mobile/features/home/domain/usecases/get_home_data.dart';
 import 'package:ragro_mobile/features/home/domain/usecases/get_producers.dart';
 import 'package:ragro_mobile/features/home/domain/usecases/get_recommended_products.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_event.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_state.dart';
-import 'package:ragro_mobile/features/home/domain/repositories/favorite_producer_repository.dart';
 
 @lazySingleton
 class HomeBloc extends Bloc<HomeEvent, HomeState> {
@@ -31,23 +31,23 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   Future<void> _onStarted(HomeEvent event, Emitter<HomeState> emit) async {
     emit(const HomeLoading());
     try {
-      final results = await Future.wait([
-        _getHomeData(),
-        _favoriteRepository.getFavorites(),
-      ]);
+      final (
+        :producers,
+        :products,
+        :hasMoreProducts,
+      ) = await _getHomeData();
 
-      final data = results[0] as dynamic;
-      final favorites = results[1] as dynamic;
+      final favorites = await _favoriteRepository.getFavorites();
 
       emit(
         HomeLoaded(
-          producers: data.producers.content,
-          products: data.products,
+          producers: producers.content,
+          products: products,
           favorites: favorites,
           favoriteIds: {for (final f in favorites) f.producerId},
-          currentProducersPage: data.producers.page,
-          hasMoreProducers: data.producers.page < data.producers.totalPages - 1,
-          hasMoreProducts: data.hasMoreProducts,
+          currentProducersPage: producers.page,
+          hasMoreProducers: producers.page < producers.totalPages - 1,
+          hasMoreProducts: hasMoreProducts,
         ),
       );
     } on ApiException catch (e) {
@@ -58,9 +58,9 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   Future<void> _onFavoriteToggled(
-      HomeFavoriteToggled event,
-      Emitter<HomeState> emit,
-      ) async {
+    HomeFavoriteToggled event,
+    Emitter<HomeState> emit,
+  ) async {
     final current = state;
     if (current is! HomeLoaded) return;
 
@@ -69,8 +69,8 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     final newIds = Set<String>.from(current.favoriteIds);
     final newFavorites = isFav
         ? current.favorites
-              .where((f) => f.producerId != event.producerId)
-              .toList()
+            .where((f) => f.producerId != event.producerId)
+            .toList()
         : current.favorites;
 
     if (isFav) {

--- a/lib/features/home/presentation/pages/customer_home_page.dart
+++ b/lib/features/home/presentation/pages/customer_home_page.dart
@@ -1,8 +1,3 @@
-// Screen: Customer Home
-// User Story: US-12 — View Producer List, US-35 — Recommend Products
-// Epic: EPIC 2 — Marketplace, EPIC 10 — Recommendations
-// Routes: GET /producers, GET /recommendations
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -16,14 +11,24 @@ import 'package:ragro_mobile/features/home/presentation/bloc/home_event.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_state.dart';
 import 'package:ragro_mobile/features/home/presentation/widgets/producers_section.dart';
 import 'package:ragro_mobile/features/home/presentation/widgets/products_grid.dart';
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_bloc.dart';
+import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_event.dart';
+import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_state.dart';
 
 class CustomerHomePage extends StatelessWidget {
   const CustomerHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider.value(
-      value: getIt<HomeBloc>(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider.value(value: getIt<HomeBloc>()),
+        BlocProvider(
+          create: (_) => getIt<RecommendationsBloc>()
+            ..add(const RecommendationsStarted()),
+        ),
+      ],
       child: const _CustomerHomeView(),
     );
   }
@@ -73,58 +78,77 @@ class _CustomerHomeViewState extends State<_CustomerHomeView> {
           builder: (context, state) {
             return switch (state) {
               HomeLoading() || HomeInitial() => const _HomeLoadingView(),
-              HomeLoaded(:final producers, :final products) => RefreshIndicator(
-                onRefresh: () async {
-                  context.read<HomeBloc>().add(const HomeRefreshed());
-                },
-                child: CustomScrollView(
-                  controller: _scrollController,
-                  slivers: [
-                    const SliverToBoxAdapter(
-                      child: Padding(
-                        padding: EdgeInsets.fromLTRB(16, 16, 16, 0),
-                        child: Text(
-                          'Início',
-                          style: TextStyle(
-                            fontFamily: 'Figtree',
-                            fontWeight: FontWeight.w700,
-                            fontSize: 34,
-                            color: AppColors.darkGreen,
+              HomeLoaded(:final producers, :final products) =>
+                BlocBuilder<RecommendationsBloc, RecommendationsState>(
+                  builder: (context, recommendationsState) {
+                    final recommendations = switch (recommendationsState) {
+                      RecommendationsLoaded(:final recommendations) =>
+                        recommendations,
+                      _ => <Recommendation>[],
+                    };
+
+                    return RefreshIndicator(
+                      onRefresh: () async {
+                        context.read<HomeBloc>().add(const HomeRefreshed());
+                        context.read<RecommendationsBloc>().add(
+                          const RecommendationsRefreshRequested(),
+                        );
+                      },
+                      child: CustomScrollView(
+                        controller: _scrollController,
+                        slivers: [
+                          const SliverToBoxAdapter(
+                            child: Padding(
+                              padding: EdgeInsets.fromLTRB(16, 16, 16, 0),
+                              child: Text(
+                                'Início',
+                                style: TextStyle(
+                                  fontFamily: 'Figtree',
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 34,
+                                  color: AppColors.darkGreen,
+                                ),
+                              ),
+                            ),
                           ),
-                        ),
+                          const SliverToBoxAdapter(child: SizedBox(height: 24)),
+                          SliverToBoxAdapter(
+                            child: ProducersSection(
+                              producers: producers,
+                              favorites: state.favorites,
+                              favoriteIds: state.favoriteIds,
+                              onProducerTap: (p) =>
+                                  _onProducerTap(context, p),
+                              isLoadingMore: state.isFetchingMoreProducers,
+                            ),
+                          ),
+                          const SliverToBoxAdapter(child: SizedBox(height: 32)),
+                          SliverToBoxAdapter(
+                            child: ProductsGrid(
+                              products: products,
+                              recommendations: recommendations,
+                              isLoadingMore: state.isFetchingMoreProducts,
+                              onProductTap: (p) => context.push(
+                                '/customer/home/product/${p.id}',
+                                extra: p.producerId,
+                              ),
+                              onAddToCart: (product) {
+                                getIt<CartBloc>().add(
+                                  CartItemAdded(
+                                    productId: product.id,
+                                    quantity: 1,
+                                  ),
+                                );
+                                context.push('/customer/cart');
+                              },
+                            ),
+                          ),
+                          const SliverToBoxAdapter(child: SizedBox(height: 32)),
+                        ],
                       ),
-                    ),
-                    const SliverToBoxAdapter(child: SizedBox(height: 24)),
-                    SliverToBoxAdapter(
-                      child: ProducersSection(
-                        producers: producers,
-                        favorites: state.favorites,
-                        favoriteIds: state.favoriteIds,
-                        onProducerTap: (p) => _onProducerTap(context, p),
-                        isLoadingMore: state.isFetchingMoreProducers,
-                      ),
-                    ),
-                    const SliverToBoxAdapter(child: SizedBox(height: 32)),
-                    SliverToBoxAdapter(
-                      child: ProductsGrid(
-                        products: products,
-                        isLoadingMore: state.isFetchingMoreProducts,
-                        onProductTap: (p) => context.push(
-                          '/customer/home/product/${p.id}',
-                          extra: p.producerId,
-                        ),
-                        onAddToCart: (product) {
-                          getIt<CartBloc>().add(
-                            CartItemAdded(productId: product.id, quantity: 1),
-                          );
-                          context.push('/customer/cart');
-                        },
-                      ),
-                    ),
-                    const SliverToBoxAdapter(child: SizedBox(height: 32)),
-                  ],
+                    );
+                  },
                 ),
-              ),
               HomeFailure(:final message) => Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/home/presentation/widgets/home_product_card.dart
+++ b/lib/features/home/presentation/widgets/home_product_card.dart
@@ -7,12 +7,14 @@ class HomeProductCard extends StatelessWidget {
     required this.product,
     required this.onTap,
     required this.onAddToCart,
+    this.isRecommended = false,
     super.key,
   });
 
   final HomeProduct product;
   final VoidCallback onTap;
   final VoidCallback onAddToCart;
+  final bool isRecommended;
 
   @override
   Widget build(BuildContext context) {
@@ -35,18 +37,56 @@ class HomeProductCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Product image
-            AspectRatio(
-              aspectRatio: 1,
-              child: product.imageUrl.isNotEmpty
-                  ? Image.network(
-                      product.imageUrl,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => const _ProductPlaceholder(),
-                    )
-                  : const _ProductPlaceholder(),
+            Stack(
+              children: [
+                AspectRatio(
+                  aspectRatio: 1,
+                  child: product.imageUrl.isNotEmpty
+                      ? Image.network(
+                          product.imageUrl,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) =>
+                              const _ProductPlaceholder(),
+                        )
+                      : const _ProductPlaceholder(),
+                ),
+                if (isRecommended)
+                  Positioned(
+                    top: 8,
+                    left: 8,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF98FFBD),
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.auto_awesome,
+                            color: AppColors.darkGreen,
+                            size: 11,
+                          ),
+                          SizedBox(width: 4),
+                          Text(
+                            'IA recomenda',
+                            style: TextStyle(
+                              fontFamily: 'Figtree',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 10,
+                              color: AppColors.darkGreen,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
             ),
-            // Product info
             Padding(
               padding: const EdgeInsets.fromLTRB(4, 4, 4, 0),
               child: Column(

--- a/lib/features/home/presentation/widgets/products_grid.dart
+++ b/lib/features/home/presentation/widgets/products_grid.dart
@@ -2,23 +2,54 @@ import 'package:flutter/material.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/home/domain/entities/home_product.dart';
 import 'package:ragro_mobile/features/home/presentation/widgets/home_product_card.dart';
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
 
 class ProductsGrid extends StatelessWidget {
   const ProductsGrid({
     required this.products,
     required this.onProductTap,
     required this.onAddToCart,
+    this.recommendations = const [],
     this.isLoadingMore = false,
     super.key,
   });
 
   final List<HomeProduct> products;
+  final List<Recommendation> recommendations;
   final void Function(HomeProduct) onProductTap;
   final void Function(HomeProduct) onAddToCart;
   final bool isLoadingMore;
 
+  List<({HomeProduct product, bool isRecommended})> _buildItems() {
+    final recommended = recommendations
+        .take(20)
+        .map((r) => (
+              product: HomeProduct(
+                id: r.id,
+                name: r.name,
+                price: r.price,
+                imageUrl: r.imageS3 ?? '',
+                farmName: r.farmName,
+                category: r.categoryNames.isNotEmpty
+                    ? r.categoryNames.first
+                    : '',
+                producerId: r.farmerId,
+              ),
+              isRecommended: true,
+            ))
+        .toList();
+
+    final regular = products
+        .map((p) => (product: p, isRecommended: false))
+        .toList();
+
+    return [...recommended, ...regular];
+  }
+
   @override
   Widget build(BuildContext context) {
+    final items = _buildItems();
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -45,12 +76,16 @@ class ProductsGrid extends StatelessWidget {
               mainAxisSpacing: 12,
               childAspectRatio: 0.55,
             ),
-            itemCount: products.length,
-            itemBuilder: (context, index) => HomeProductCard(
-              product: products[index],
-              onTap: () => onProductTap(products[index]),
-              onAddToCart: () => onAddToCart(products[index]),
-            ),
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return HomeProductCard(
+                product: item.product,
+                isRecommended: item.isRecommended,
+                onTap: () => onProductTap(item.product),
+                onAddToCart: () => onAddToCart(item.product),
+              );
+            },
           ),
         ),
         if (isLoadingMore)

--- a/lib/features/recommendations/data/datasources/recommendation_remote_datasource.dart
+++ b/lib/features/recommendations/data/datasources/recommendation_remote_datasource.dart
@@ -1,0 +1,49 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/network/api_client.dart';
+import 'package:ragro_mobile/core/network/api_endpoints.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/recommendations/data/models/recommendation_model.dart';
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+
+@lazySingleton
+class RecommendationsRemoteDatasource {
+  const RecommendationsRemoteDatasource(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  Future<List<Recommendation>> getRecommendations() async {
+    try {
+      final response = await _apiClient.dio.get<dynamic>(
+        ApiEndpoints.recommendations,
+      );
+
+      return _readList(response.data).map(RecommendationModel.fromJson).toList();
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
+  List<Map<String, dynamic>> _readList(dynamic data) {
+    if (data is List<dynamic>) {
+      return data.whereType<Map<String, dynamic>>().toList();
+    }
+    if (data is Map<String, dynamic>) {
+      for (final key in const [
+        'data',
+        'content',
+        'items',
+        'recommendations',
+        'result',
+        'list',
+      ]) {
+        if (data[key] is List<dynamic>) {
+          return (data[key] as List<dynamic>)
+              .whereType<Map<String, dynamic>>()
+              .toList();
+        }
+      }
+    }
+    return const [];
+  }
+}

--- a/lib/features/recommendations/data/models/recommendation_model.dart
+++ b/lib/features/recommendations/data/models/recommendation_model.dart
@@ -1,0 +1,33 @@
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+
+class RecommendationModel extends Recommendation {
+  const RecommendationModel({
+    required super.id,
+    required super.name,
+    required super.price,
+    required super.unityType,
+    required super.farmerId,
+    required super.farmName,
+    required super.categoryNames,
+    required super.score,
+    required super.reason,
+    super.imageS3,
+  });
+
+  factory RecommendationModel.fromJson(Map<String, dynamic> json) {
+    return RecommendationModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      price: (json['price'] as num).toDouble(),
+      unityType: json['unityType'] as String,
+      farmerId: json['farmerId'] as String,
+      farmName: json['farmName'] as String,
+      categoryNames: (json['categoryNames'] as List<dynamic>)
+          .whereType<String>()
+          .toList(),
+      score: json['score'] as int,
+      reason: json['reason'] as String,
+      imageS3: json['imageS3'] as String?,
+    );
+  }
+}

--- a/lib/features/recommendations/data/repositories/recommentations_repository_impl.dart
+++ b/lib/features/recommendations/data/repositories/recommentations_repository_impl.dart
@@ -1,0 +1,15 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/recommendations/data/datasources/recommendation_remote_datasource.dart';
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+import 'package:ragro_mobile/features/recommendations/domain/repositories/recommendations_repository.dart';
+
+@LazySingleton(as: RecommendationsRepository)
+class RecommendationsRepositoryImpl implements RecommendationsRepository {
+  const RecommendationsRepositoryImpl(this._datasource);
+
+  final RecommendationsRemoteDatasource _datasource;
+
+  @override
+  Future<List<Recommendation>> getRecommendations() =>
+      _datasource.getRecommendations();
+}

--- a/lib/features/recommendations/domain/entities/recommendation.dart
+++ b/lib/features/recommendations/domain/entities/recommendation.dart
@@ -1,0 +1,25 @@
+class Recommendation {
+  const Recommendation({
+    required this.id,
+    required this.name,
+    required this.price,
+    required this.unityType,
+    required this.imageS3,
+    required this.farmerId,
+    required this.farmName,
+    required this.categoryNames,
+    required this.score,
+    required this.reason,
+  });
+
+  final String id;
+  final String name;
+  final double price;
+  final String unityType;
+  final String? imageS3;
+  final String farmerId;
+  final String farmName;
+  final List<String> categoryNames;
+  final int score;
+  final String reason;
+}

--- a/lib/features/recommendations/domain/repositories/recommendations_repository.dart
+++ b/lib/features/recommendations/domain/repositories/recommendations_repository.dart
@@ -1,0 +1,5 @@
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+
+abstract class RecommendationsRepository {
+  Future<List<Recommendation>> getRecommendations();
+}

--- a/lib/features/recommendations/domain/usecases/get_recommendations_usecase.dart
+++ b/lib/features/recommendations/domain/usecases/get_recommendations_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+import 'package:ragro_mobile/features/recommendations/domain/repositories/recommendations_repository.dart';
+
+@lazySingleton
+class GetRecommendationsUsecase {
+  const GetRecommendationsUsecase(this._repository);
+
+  final RecommendationsRepository _repository;
+
+  Future<List<Recommendation>> call() => _repository.getRecommendations();
+}

--- a/lib/features/recommendations/presentation/bloc/recommendations_bloc.dart
+++ b/lib/features/recommendations/presentation/bloc/recommendations_bloc.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/recommendations/domain/usecases/get_recommendations_usecase.dart';
+import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_event.dart';
+import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_state.dart';
+
+@injectable
+class RecommendationsBloc
+    extends Bloc<RecommendationsEvent, RecommendationsState> {
+  RecommendationsBloc(this._getRecommendations)
+      : super(const RecommendationsInitial()) {
+    on<RecommendationsStarted>(_onStarted);
+    on<RecommendationsRefreshRequested>(_onRefreshRequested);
+  }
+
+  final GetRecommendationsUsecase _getRecommendations;
+
+  Future<void> _onStarted(
+    RecommendationsStarted event,
+    Emitter<RecommendationsState> emit,
+  ) async {
+    emit(const RecommendationsLoading());
+    await _fetchRecommendations(emit);
+  }
+
+  Future<void> _onRefreshRequested(
+    RecommendationsRefreshRequested event,
+    Emitter<RecommendationsState> emit,
+  ) async {
+    emit(const RecommendationsLoading());
+    await _fetchRecommendations(emit);
+  }
+
+  Future<void> _fetchRecommendations(
+    Emitter<RecommendationsState> emit,
+  ) async {
+    try {
+      final recommendations = await _getRecommendations();
+      if (recommendations.isEmpty) {
+        emit(const RecommendationsEmpty());
+      } else {
+        emit(RecommendationsLoaded(recommendations));
+      }
+    } on ApiException catch (e) {
+      emit(RecommendationsError(e.message));
+    } on Exception catch (_) {
+      emit(const RecommendationsError('Não foi possível carregar as recomendações.'));
+    }
+  }
+}

--- a/lib/features/recommendations/presentation/bloc/recommendations_event.dart
+++ b/lib/features/recommendations/presentation/bloc/recommendations_event.dart
@@ -1,0 +1,15 @@
+import 'package:equatable/equatable.dart';
+
+sealed class RecommendationsEvent extends Equatable {
+  const RecommendationsEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class RecommendationsStarted extends RecommendationsEvent {
+  const RecommendationsStarted();
+}
+
+class RecommendationsRefreshRequested extends RecommendationsEvent {
+  const RecommendationsRefreshRequested();
+}

--- a/lib/features/recommendations/presentation/bloc/recommendations_state.dart
+++ b/lib/features/recommendations/presentation/bloc/recommendations_state.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+
+sealed class RecommendationsState extends Equatable {
+  const RecommendationsState();
+  @override
+  List<Object?> get props => [];
+}
+
+class RecommendationsInitial extends RecommendationsState {
+  const RecommendationsInitial();
+}
+
+class RecommendationsLoading extends RecommendationsState {
+  const RecommendationsLoading();
+}
+
+class RecommendationsLoaded extends RecommendationsState {
+  const RecommendationsLoaded(this.recommendations);
+  final List<Recommendation> recommendations;
+  @override
+  List<Object?> get props => [recommendations];
+}
+
+class RecommendationsEmpty extends RecommendationsState {
+  const RecommendationsEmpty();
+}
+
+class RecommendationsError extends RecommendationsState {
+  const RecommendationsError(this.message);
+  final String message;
+  @override
+  List<Object?> get props => [message];
+}

--- a/test/features/recommendations/domain/usecases/get_recommendations_test.dart
+++ b/test/features/recommendations/domain/usecases/get_recommendations_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ragro_mobile/core/network/api_exception.dart';
+import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
+import 'package:ragro_mobile/features/recommendations/domain/repositories/recommendations_repository.dart';
+import 'package:ragro_mobile/features/recommendations/domain/usecases/get_recommendations_usecase.dart';
+
+class MockRecommendationsRepository extends Mock
+    implements RecommendationsRepository {}
+
+void main() {
+  late GetRecommendationsUsecase useCase;
+  late MockRecommendationsRepository repo;
+
+  final tRecommendations = [
+    const Recommendation(
+      id: 'b0000000-0000-0000-0000-000000000004',
+      name: 'Espinafre Orgânico',
+      price: 6,
+      unityType: 'bunch',
+      imageS3: null,
+      farmerId: 'a0000000-0000-0000-0000-000000000003',
+      farmName: 'Sítio Boa Vista',
+      categoryNames: ['Verduras'],
+      score: 85,
+      reason: 'PURCHASE_HISTORY',
+    ),
+    const Recommendation(
+      id: 'b0000000-0000-0000-0000-000000000005',
+      name: 'Cenoura Baby',
+      price: 7.5,
+      unityType: 'kg',
+      imageS3: null,
+      farmerId: 'a0000000-0000-0000-0000-000000000003',
+      farmName: 'Sítio Boa Vista',
+      categoryNames: ['Legumes'],
+      score: 70,
+      reason: 'CATEGORY_PREFERENCE',
+    ),
+  ];
+
+  setUp(() {
+    repo = MockRecommendationsRepository();
+    useCase = GetRecommendationsUsecase(repo);
+  });
+
+  group('GetRecommendationsUsecase', () {
+    test('chama o repository e retorna lista de recomendações', () async {
+      when(
+        () => repo.getRecommendations(),
+      ).thenAnswer((_) async => tRecommendations);
+
+      final result = await useCase();
+
+      expect(result, hasLength(2));
+      expect(result.first.id, 'b0000000-0000-0000-0000-000000000004');
+      expect(result.first.name, 'Espinafre Orgânico');
+      expect(result.first.score, 85);
+      expect(result.first.reason, 'PURCHASE_HISTORY');
+      verify(() => repo.getRecommendations()).called(1);
+    });
+
+    test('retorna lista vazia quando não há recomendações', () async {
+      when(
+        () => repo.getRecommendations(),
+      ).thenAnswer((_) async => []);
+
+      final result = await useCase();
+
+      expect(result, isEmpty);
+      verify(() => repo.getRecommendations()).called(1);
+    });
+
+    test('propaga NetworkException em caso de erro de conectividade', () async {
+      when(
+        () => repo.getRecommendations(),
+      ).thenThrow(const NetworkException());
+
+      expect(
+        () => useCase(),
+        throwsA(isA<NetworkException>()),
+      );
+    });
+
+    test('propaga UnauthorizedException quando usuário não autenticado', () async {
+      when(
+        () => repo.getRecommendations(),
+      ).thenThrow(const UnauthorizedException());
+
+      expect(
+        () => useCase(),
+        throwsA(isA<UnauthorizedException>()),
+      );
+    });
+
+    test('propaga ServerException em erro do servidor', () async {
+      when(
+        () => repo.getRecommendations(),
+      ).thenThrow(const ServerException());
+
+      expect(
+        () => useCase(),
+        throwsA(isA<ServerException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## O que mudou?
Adição da feature de recomendações personalizadas na home do consumidor. Produtos recomendados pelo backend aparecem no topo da seção "Produtos para você" com uma tag "IA recomenda", integrados ao grid existente.
Caso haja erro nas recomendações ou o usuário não tiver produtos recomendados ainda, os produtos com a tag simplesmente não aparecem. 

## Tipo de mudança

- [X] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [ ] Chore (dependências, configs, etc.)

## Como testar?
1) Faça login com customer@ragro.com.br / Test@123
2) Acesse a home do consumidor
3) Os produtos recomendados aparecem no topo da seção "Produtos para você" com a tag "IA recomenda"
4) Faça pull-to-refresh para atualizar as recomendações

## Screenshots / Gravações

Tela home:
<img width="365" height="801" alt="image" src="https://github.com/user-attachments/assets/7ac0615f-9047-4d68-b3f9-c36704ed1467" />

Testes: 
<img width="1751" height="354" alt="image" src="https://github.com/user-attachments/assets/d6c1c1a1-6ed8-491f-8345-aaa6749dc3ec" />

## Checklist

- [X] Código formatado (`dart format .`)
- [X] Sem warnings no analyze (`dart analyze`)
- [X] Testes passando (`flutter test`)
- [X] Segue o padrão de arquitetura do projeto
