### PR TITLE
Implementação da conecção com a AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ flutter run -d chrome
 
 ### Testing with the backend (real login)
 
-The app authenticates via Keycloak. You need the backend running locally.
+The app authenticates via Keycloak. You can run the backend locally or point the app at AWS through `API_BASE_URL`.
 
 **1. Start the backend** (from `ragro-backend/`):
 
@@ -84,7 +84,7 @@ This starts PostgreSQL, Keycloak, and the Spring Boot API. Three test users are 
 flutter run -d chrome
 ```
 
-The app defaults to `http://localhost:8080` as the API base URL.
+The app defaults to `https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com` as the API base URL. To use the local backend, set `API_BASE_URL=http://localhost:8080`.
 
 **3. Log in with one of the test users:**
 
@@ -94,7 +94,7 @@ The app defaults to `http://localhost:8080` as the API base URL.
 | Farmer | `farmer@ragro.com.br` | `Test@123` |
 | Admin | `admin@ragro.com.br` | `Admin@123` |
 
-The login flow calls `GET /auth/config` to discover the Keycloak token URL, authenticates directly with Keycloak, then calls `GET /auth/session` to get the user's profile. The app routes to the correct home screen based on the user type.
+The login flow calls `GET /auth/config` to discover the Keycloak token URL, authenticates directly with Keycloak, then calls `GET /auth/session` to get the user's profile. The backend can return a local Keycloak URL (`http://localhost:8180`) or the AWS equivalent (`https://kwn6g5amn5.execute-api.us-east-2.amazonaws.com`) depending on the environment. The app routes to the correct home screen based on the user type.
 
 ### Demo mode (skip login, no backend needed)
 
@@ -109,10 +109,16 @@ flutter run -d chrome --dart-define=DEMO_MODE=true --dart-define=DEMO_ROLE=produ
 flutter run -d chrome --dart-define=DEMO_MODE=true --dart-define=DEMO_ROLE=admin
 ```
 
-### Production base URL
+### Switching between local and AWS
 
 ```bash
-flutter run --dart-define=API_BASE_URL=https://api.ragro.com.br
+flutter run --dart-define=API_BASE_URL=https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com
+
+# Local backend on desktop
+flutter run --dart-define=API_BASE_URL=http://localhost:8080
+
+# Local backend on Android emulator
+flutter run --dart-define=API_BASE_URL=http://10.0.2.2:8080
 ```
 
 ### Run on Android
@@ -137,7 +143,7 @@ flutter test
 
 ### Visual regression tests (Playwright)
 
-Requires the Flutter app running on `http://localhost:8080`.
+Requires the Flutter app running locally in Chrome. The API can point to local backend or AWS via `API_BASE_URL`.
 
 ```bash
 # 1. Start the app

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,6 +1,8 @@
 # RAGRO API — Endpoint Reference
 
-Base URL: `https://api.ragro.com.br`
+Base URL: `https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com`
+
+Set `API_BASE_URL` in the Flutter app to switch to a local backend such as `http://localhost:8080` or `http://10.0.2.2:8080` on the Android emulator.
 
 All authenticated endpoints require the header: `Authorization: Bearer <token>`
 
@@ -15,7 +17,7 @@ Returns the Keycloak authentication configuration. No authentication required.
 **Response (200 OK):**
 ```json
 {
-  "tokenUrl": "https://keycloak.ragro.com.br/realms/ragro/protocol/openid-connect/token",
+  "tokenUrl": "https://kwn6g5amn5.execute-api.us-east-2.amazonaws.com/realms/ragro/protocol/openid-connect/token",
   "clientId": "ragro-app",
   "realm": "ragro"
 }

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -3,10 +3,12 @@
 ## Base URL
 
 ```
-https://api.ragro.com.br
+https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com
 ```
 
 All requests are made over HTTPS. There is no API version in the URL — versioning is managed via headers when necessary.
+
+Use `API_BASE_URL` in the Flutter app to switch between this AWS environment and a local backend such as `http://localhost:8080`.
 
 ---
 
@@ -87,7 +89,7 @@ Three users are pre-configured in both Keycloak and the database when the backen
 | Farmer | `farmer@ragro.com.br` | `Test@123` |
 | Admin | `admin@ragro.com.br` | `Admin@123` |
 
-These credentials authenticate against the real Keycloak instance running at `http://localhost:8180`. The backend must be running (`docker compose up -d` from `ragro-backend/`).
+These credentials authenticate against the local Keycloak instance at `http://localhost:8180` or the AWS equivalent at `https://kwn6g5amn5.execute-api.us-east-2.amazonaws.com`, depending on the backend selected through `API_BASE_URL`.
 
 ---
 

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -1,5 +1,6 @@
 // lib/core/network/api_client.dart
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 
@@ -71,6 +72,7 @@ class _ErrorInterceptor extends Interceptor {
     } else if (err.type == DioExceptionType.connectionError) {
       exception = const NetworkException();
     } else {
+      debugPrint('[ApiClient] DioExceptionType: ${err.type} | message: ${err.message} | error: ${err.error}');
       exception = const UnknownApiException();
     }
     handler.reject(

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -2,24 +2,37 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 
 abstract final class ApiEndpoints {
-  static String get _defaultBase {
-    if (kIsWeb) return 'http://localhost:8080';
-    if (Platform.isAndroid) return 'http://10.0.2.2:8080';
-    return 'http://localhost:8080';
-  }
+    static const String _productionBase =
+            'https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com';
+
+    static String get _defaultBase => _productionBase;
 
   static final String _base = _resolveBaseUrl();
 
   static String _resolveBaseUrl() {
     const rawBase = String.fromEnvironment('API_BASE_URL');
 
-    if (rawBase.isNotEmpty) {
-      final normalized = rawBase.trim().replaceFirst(RegExp(r'\/+$'), '');
-      return normalized;
+        if (rawBase.trim().isNotEmpty) {
+            final normalized = rawBase.trim().replaceFirst(RegExp(r'\/+'), '');
+            return _normalizeForRuntime(normalized);
     }
 
     return _defaultBase;
   }
+
+    static String _normalizeForRuntime(String baseUrl) {
+        if (kIsWeb) return baseUrl;
+
+        final apiUri = Uri.tryParse(baseUrl);
+        if (apiUri == null) return baseUrl;
+
+        if (Platform.isAndroid &&
+                (apiUri.host == 'localhost' || apiUri.host == '127.0.0.1')) {
+            return apiUri.replace(host: '10.0.2.2').toString();
+        }
+
+        return baseUrl;
+    }
 
   // Auth
   static String get authConfig => '$_base/auth/config';
@@ -109,10 +122,9 @@ abstract final class ApiEndpoints {
   static String get adminProducers => '$_base/admin/producers';
   static String adminProducer(String id) => '$_base/admin/producers/$id';
 
-  /// Rewrites a media URL that came from the backend (e.g. MinIO public URL).
-  /// In dev, the backend stores `http://localhost:9000/...` but the device
-  /// cannot reach `localhost` on the host machine — it needs the same host
-  /// that the API uses (e.g. `10.0.2.2` for an Android emulator).
+    /// Rewrites a media URL that came from the backend (e.g. MinIO public URL).
+    /// This keeps local backend URLs reachable on emulators by matching the
+    /// host used by the configured API base URL.
   static String resolveMediaUrl(String url) {
     if (url.isEmpty) return url;
     final mediaUri = Uri.tryParse(url);

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -13,7 +13,7 @@ abstract final class ApiEndpoints {
     const rawBase = String.fromEnvironment('API_BASE_URL');
 
         if (rawBase.trim().isNotEmpty) {
-            final normalized = rawBase.trim().replaceFirst(RegExp(r'\/+'), '');
+            final normalized = rawBase.trim().replaceFirst(RegExp(r'\/+$'), '');
             return _normalizeForRuntime(normalized);
     }
 

--- a/scripts/run_emulator.sh
+++ b/scripts/run_emulator.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-API_BASE_URL="${API_BASE_URL:-http://10.0.2.2:8080}"
+API_BASE_URL="${API_BASE_URL:-https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com}"
 DEVICE="${DEVICE:-emulator-5554}"
 KEYCLOAK_PORT="${KEYCLOAK_PORT:-8180}"
 ADB="${ADB:-$HOME/Android/Sdk/platform-tools/adb}"


### PR DESCRIPTION
## O que mudou?

Atualização da URL base padrão no Flutter para apontar para a API hospedada na AWS (Amazon API Gateway + ECS), substituindo o endereço local. O app agora se conecta ao backend em produção por padrão.

- `api_endpoints.dart`: URL base alterada de `localhost:8080` para `https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com` (Spring Boot na AWS)
- O Keycloak (`https://kwn6g5amn5.execute-api.us-east-2.amazonaws.com`) não é referenciado diretamente no Flutter — sua URL é retornada dinamicamente pelo endpoint `/auth/config` do Spring Boot

## Tipo de mudança
- [ ] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação
- [x] Chore (dependências, configs, etc.)

## Como testar?
1. Rodar o app **sem** definir `API_BASE_URL` — deve conectar na AWS automaticamente
2. Tentar fazer login — o app deve chamar `https://7ruopxdlm7.execute-api.us-east-2.amazonaws.com/auth/config` e receber as configurações do Keycloak
3. O login deve completar com sucesso, obtendo token JWT via Keycloak na AWS
4. Para testar localmente, rodar com `--dart-define=API_BASE_URL=http://10.0.2.2:8080` (emulador Android) ou `http://localhost:8080` (web/iOS)

## Screenshots / Gravações
<!-- Se mudou algo visual, cole prints ou gravações aqui -->

## Checklist
- [ ] Código formatado (`dart format .`)
- [ ] Sem warnings no analyze (`dart analyze`)
- [ ] Testes passando (`flutter test`)
- [x] Segue o padrão de arquitetura do projeto