### PR TITLE
resolvendo o bug para mostrar a unidade de medida dos produtos

### DIFF
--- a/lib/features/home/data/models/home_product_model.dart
+++ b/lib/features/home/data/models/home_product_model.dart
@@ -7,6 +7,7 @@ class HomeProductModel extends HomeProduct {
     required super.name,
     required super.category,
     required super.price,
+    required super.unityType,
     required super.imageUrl,
     required super.farmName,
     required super.producerId,
@@ -29,6 +30,11 @@ class HomeProductModel extends HomeProduct {
           primaryCategory?['name'] as String? ??
           '',
       price: (json['price'] as num?)?.toDouble() ?? 0,
+      unityType:
+          json['unityType'] as String? ??
+          json['unity_type'] as String? ??
+          json['unit'] as String? ??
+          '',
       imageUrl: ApiEndpoints.resolveMediaUrl(
         json['imageS3'] as String? ??
             json['image_s3'] as String? ??

--- a/lib/features/home/domain/entities/home_product.dart
+++ b/lib/features/home/domain/entities/home_product.dart
@@ -6,6 +6,7 @@ class HomeProduct extends Equatable {
     required this.name,
     required this.category,
     required this.price,
+    required this.unityType,
     required this.imageUrl,
     required this.farmName,
     required this.producerId,
@@ -15,6 +16,7 @@ class HomeProduct extends Equatable {
   final String name;
   final String category;
   final double price;
+  final String unityType;
   final String imageUrl;
   final String farmName;
   final String producerId;
@@ -25,6 +27,7 @@ class HomeProduct extends Equatable {
     name,
     category,
     price,
+    unityType,
     imageUrl,
     farmName,
     producerId,

--- a/lib/features/home/presentation/widgets/home_product_card.dart
+++ b/lib/features/home/presentation/widgets/home_product_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/home/domain/entities/home_product.dart';
+import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
 
 class HomeProductCard extends StatelessWidget {
   const HomeProductCard({
@@ -113,16 +114,31 @@ class HomeProductCard extends StatelessWidget {
                   Row(
                     children: [
                       Expanded(
-                        child: Text(
-                          'R\$ ${product.price.toStringAsFixed(2).replaceAll('.', ',')}',
-                          style: const TextStyle(
-                            fontFamily: 'Figtree',
-                            fontWeight: FontWeight.w700,
-                            fontSize: 16,
-                            color: AppColors.black,
-                          ),
+                        child: RichText(
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
+                          text: TextSpan(
+                            text:
+                                'R\$ ${product.price.toStringAsFixed(2).replaceAll('.', ',')}',
+                            style: const TextStyle(
+                              fontFamily: 'Figtree',
+                              fontWeight: FontWeight.w700,
+                              fontSize: 16,
+                              color: AppColors.black,
+                            ),
+                            children: [
+                              if (product.unityType.isNotEmpty)
+                                TextSpan(
+                                  text:
+                                      ' /${localizeUnityType(product.unityType)}',
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w400,
+                                    fontSize: 12,
+                                    color: AppColors.placeholder,
+                                  ),
+                                ),
+                            ],
+                          ),
                         ),
                       ),
                       GestureDetector(
@@ -165,7 +181,9 @@ class _RecommendationBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final label = aiRanked
-        ? (score != null && score! > 0 ? 'IA recomenda · $score%' : 'IA recomenda')
+        ? (score != null && score! > 0
+              ? 'IA recomenda · $score%'
+              : 'IA recomenda')
         : 'Para você';
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),

--- a/lib/features/home/presentation/widgets/products_grid.dart
+++ b/lib/features/home/presentation/widgets/products_grid.dart
@@ -30,6 +30,7 @@ class ProductsGrid extends StatelessWidget {
               id: r.id,
               name: r.name,
               price: r.price,
+              unityType: r.unityType,
               imageUrl: r.imageS3 ?? '',
               farmName: r.farmName,
               category: r.categoryNames.isNotEmpty ? r.categoryNames.first : '',

--- a/lib/features/product_detail/data/models/product_detail_model.dart
+++ b/lib/features/product_detail/data/models/product_detail_model.dart
@@ -39,7 +39,11 @@ class ProductDetailModel extends ProductDetail {
       name: json['name'] as String,
       description: json['description'] as String? ?? '',
       price: (json['price'] as num).toDouble(),
-      unityType: json['unityType'] as String? ?? 'kg',
+      unityType:
+          json['unityType'] as String? ??
+          json['unity_type'] as String? ??
+          json['unit'] as String? ??
+          'kg',
       category: firstCategory,
       imageUrl: imageUrl,
       farmName: farmName,

--- a/lib/features/product_detail/presentation/pages/product_detail_page.dart
+++ b/lib/features/product_detail/presentation/pages/product_detail_page.dart
@@ -11,6 +11,7 @@ import 'package:ragro_mobile/features/cart/presentation/bloc/cart_event.dart';
 import 'package:ragro_mobile/features/product_detail/presentation/bloc/product_detail_bloc.dart';
 import 'package:ragro_mobile/features/product_detail/presentation/bloc/product_detail_event.dart';
 import 'package:ragro_mobile/features/product_detail/presentation/bloc/product_detail_state.dart';
+import 'package:ragro_mobile/shared/utils/unity_type_label.dart';
 
 class ProductDetailPage extends StatelessWidget {
   const ProductDetailPage({
@@ -153,13 +154,31 @@ class _ProductDetailView extends StatelessWidget {
                                       ),
                                     ),
                                   ),
-                                  Text(
-                                    'R\$ ${product.price.toStringAsFixed(2).replaceAll('.', ',')}',
-                                    style: const TextStyle(
-                                      fontFamily: 'Figtree',
-                                      fontWeight: FontWeight.w600,
-                                      fontSize: 24,
-                                      color: AppColors.black,
+                                  RichText(
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    textAlign: TextAlign.end,
+                                    text: TextSpan(
+                                      text:
+                                          'R\$ ${product.price.toStringAsFixed(2).replaceAll('.', ',')}',
+                                      style: const TextStyle(
+                                        fontFamily: 'Figtree',
+                                        fontWeight: FontWeight.w600,
+                                        fontSize: 24,
+                                        color: AppColors.black,
+                                      ),
+                                      children: [
+                                        if (product.unityType.isNotEmpty)
+                                          TextSpan(
+                                            text:
+                                                ' /${localizeUnityType(product.unityType)}',
+                                            style: const TextStyle(
+                                              fontWeight: FontWeight.w400,
+                                              fontSize: 14,
+                                              color: AppColors.placeholder,
+                                            ),
+                                          ),
+                                      ],
                                     ),
                                   ),
                                 ],


### PR DESCRIPTION
## What changed?

Fixed product price displays in the consumer flow to include the product unit of measure.

Updated:
- Recommended products
- Product catalog on the producer public profile
- Product detail page

Implementation details:
- Added `unityType` to `HomeProduct`.
- Mapped unit fields in `HomeProductModel` from `unityType`, `unity_type`, or `unit`.
- Passed recommendation `unityType` into `HomeProduct`.
- Updated `HomeProductCard` to display prices as `R$ value /unit`.
- Updated `ProductDetailPage` to display the unit next to the price.
- Reused `localizeUnityType(...)`, matching the existing search result behavior.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (dependencies, configs, etc.)

## How to test?

1. Open the consumer home screen.
2. Check recommended products.
3. Confirm product prices show the unit, for example: `R$ 10,00 /kg`.
4. Open a producer public profile.
5. Check the product catalog and confirm prices include the unit.
6. Open a product detail page.
7. Confirm the product price includes the unit.
8. Compare with search results to verify consistent behavior.

Validated with:

- `flutter test`
- `dart analyze lib\features\home lib\features\producer_profile lib\features\product_detail`

Result:
- All tests passing.
- No errors found in the analyzed areas.
- Only pre-existing informational warnings outside the changed files.

## Screenshots / Recordings

<!-- If you changed something visual, paste screenshots or recordings here -->

## Checklist

- [x] Code formatted (`dart format .`)
- [ ] No analyze warnings (`dart analyze`)
- [x] Tests passing (`flutter test`)
- [x] Follows the project's architecture pattern