### PR TITLE
fix: corrige tela branca em avaliações, navegação home e atualização de pedidos

### DIFF
--- a/lib/core/navigation/orders_route_observer.dart
+++ b/lib/core/navigation/orders_route_observer.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+/// Shared RouteObserver registered on the orders shell-branch navigator.
+/// Allows widgets inside that branch to detect when a sub-route is popped
+/// (e.g. returning from OrderDetailPage to CustomerOrdersPage).
+final RouteObserver<ModalRoute<void>> ordersRouteObserver =
+    RouteObserver<ModalRoute<void>>();

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/core/navigation/orders_route_observer.dart';
 import 'package:ragro_mobile/features/admin/presentation/pages/admin_create_producer_page.dart';
 import 'package:ragro_mobile/features/admin/presentation/pages/admin_edit_producer_page.dart';
 import 'package:ragro_mobile/features/admin/presentation/pages/admin_producers_page.dart';
@@ -64,8 +65,7 @@ class AppRouter {
         }
         if (authState is AuthAuthenticated && isAuthRoute) {
           return switch (authState.user.type) {
-            UserType.customer =>
-              '/customer/impact',
+            UserType.customer => '/customer/impact',
             UserType.producer => '/producer/home',
             UserType.admin => '/admin/producers',
           };
@@ -139,6 +139,7 @@ class AppRouter {
               ],
             ),
             StatefulShellBranch(
+              observers: [ordersRouteObserver],
               routes: [
                 GoRoute(
                   path: '/customer/orders',
@@ -236,12 +237,30 @@ class AppRouter {
           builder: (_, __) => const CustomerEditAddressPage(),
         ),
 
-        // Top-level producer profile (fullscreen)
+        // Top-level producer profile (fullscreen) — used by map and other contexts
+        // outside the shell; reviews sub-route lives here so navigation from both
+        // the home branch and the map never crosses shell boundaries.
         GoRoute(
           path: '/customer/producer/:producerId',
           builder: (context, state) => ProducerPublicProfilePage(
             producerId: state.pathParameters['producerId']!,
           ),
+          routes: [
+            GoRoute(
+              path: 'reviews',
+              builder: (context, state) {
+                final extra = state.extra as Map<String, dynamic>? ?? {};
+                return ReviewsPage(
+                  producerId: state.pathParameters['producerId']!,
+                  producerName: extra['producerName'] as String? ?? '',
+                  producerLocation: extra['producerLocation'] as String? ?? '',
+                  averageRating:
+                      (extra['averageRating'] as num?)?.toDouble() ?? 0.0,
+                  totalReviews: extra['totalReviews'] as int? ?? 0,
+                );
+              },
+            ),
+          ],
         ),
 
         // Producer shell with 3 tabs

--- a/lib/features/orders/presentation/pages/customer_orders_page.dart
+++ b/lib/features/orders/presentation/pages/customer_orders_page.dart
@@ -6,6 +6,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/core/navigation/orders_route_observer.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
 import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
@@ -35,7 +36,8 @@ class _OrdersView extends StatefulWidget {
 }
 
 class _OrdersViewState extends State<_OrdersView>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin
+    implements RouteAware {
   static const _tabs = [
     (OrderStatus.pending, 'Pendentes'),
     (OrderStatus.accepted, 'Aceitos'),
@@ -55,12 +57,38 @@ class _OrdersViewState extends State<_OrdersView>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      ordersRouteObserver.subscribe(this, route);
+    }
+  }
+
+  @override
   void dispose() {
+    ordersRouteObserver.unsubscribe(this);
     _tabController
       ..removeListener(_onTabChanged)
       ..dispose();
     super.dispose();
   }
+
+  // Called when a sub-route (e.g. OrderDetailPage) is popped and this page
+  // becomes visible again — refresh to show any newly created orders.
+  @override
+  void didPopNext() {
+    context.read<OrdersBloc>().add(const OrdersRefreshed());
+  }
+
+  @override
+  void didPush() {}
+
+  @override
+  void didPop() {}
+
+  @override
+  void didPushNext() {}
 
   void _onTabChanged() {
     if (_tabController.indexIsChanging ||

--- a/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
+++ b/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
@@ -231,7 +231,7 @@ class _ProducerPublicProfileViewState
                                       const SizedBox(height: 8),
                                       GestureDetector(
                                         onTap: () => context.push(
-                                          '/customer/home/producer/${producer.id}/reviews',
+                                          '/customer/producer/${producer.id}/reviews',
                                           extra: {
                                             'producerName': producer.name,
                                             'producerLocation':


### PR DESCRIPTION
## Resumo

- **Bug 1:** Tela de avaliações de produtor com zero avaliações causava tela branca. Corrigido adicionando rota top-level `/customer/producer/:id/reviews` fora do `StatefulShellRoute`, eliminando conflito de contexto de navegação.
- **Bug 2:** Após visitar a tela de avaliações via contexto do mapa (rota fora do shell), o tab "Início" redirecionava incorretamente para o Mapa. Corrigido: `ProducerPublicProfilePage` agora sempre navega para a rota top-level `/customer/producer/:id/reviews`, independente do contexto de entrada.
- **Bug 3:** Ao voltar da tela de detalhe do pedido, a lista de pedidos pendentes não atualizava. Corrigido via `RouteObserver` global registrado na branch de pedidos do `StatefulShellRoute`; `CustomerOrdersPage` assina como `RouteAware` e dispara `OrdersRefreshed` no `didPopNext`.

## Arquivos alterados

- `lib/core/navigation/orders_route_observer.dart` — novo singleton `RouteObserver`
- `lib/core/router/app_router.dart` — rota top-level de avaliações + observer na branch de pedidos
- `lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart` — navega para rota top-level
- `lib/features/orders/presentation/pages/customer_orders_page.dart` — implementa `RouteAware` para refresh automático

## Plano de teste

- [x] Abrir perfil de produtor com 0 avaliações → tela de Avaliações exibe "Nenhuma avaliação ainda" (sem tela branca)
- [x] Após visitar Avaliações, tocar tab Início → permanece em Início (não redireciona para Mapa)
- [x] Fazer pedido → ir para Detalhes do Pedido → voltar → lista de Pedidos Pendentes atualiza automaticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed orders list to automatically refresh when returning from an order detail page.
  * Corrected navigation route for viewing producer reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->