### PR TITLE
Alterando front para mostrar produtos na tela de pesquisa

### DIFF
--- a/lib/features/admin/presentation/pages/admin_create_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_create_producer_page.dart
@@ -1,4 +1,5 @@
 // Admin create-producer screen (US-31). Backed by POST /admin/producers.
+// ignore_for_file: unused_element, unused_element_parameter
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -1107,13 +1108,12 @@ class _TextField extends StatelessWidget {
 }
 
 // Mantido intencionalmente: widget privado usado condicionalmente em formulários.
-// ignore: unused_element
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
-    super.key,
     required this.initialValue,
     required this.onSelected,
     this.enabled = true,
+    super.key,
   });
 
   final String? initialValue;

--- a/lib/features/admin/presentation/pages/admin_create_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_create_producer_page.dart
@@ -1106,6 +1106,8 @@ class _TextField extends StatelessWidget {
   }
 }
 
+// Mantido intencionalmente: widget privado usado condicionalmente em formulários.
+// ignore: unused_element
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
     super.key,

--- a/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
@@ -1,4 +1,5 @@
 // Admin edit-producer screen (US-30). Backed by PUT /admin/producers/{id}.
+// ignore_for_file: unused_element, unused_element_parameter
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -1189,13 +1190,12 @@ class _TextField extends StatelessWidget {
 }
 
 // Mantido intencionalmente: widget privado usado condicionalmente em formulários.
-// ignore: unused_element
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
-    super.key,
     required this.initialValue,
     required this.onSelected,
     this.enabled = true,
+    super.key,
   });
 
   final String? initialValue;

--- a/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
+++ b/lib/features/admin/presentation/pages/admin_edit_producer_page.dart
@@ -1188,6 +1188,8 @@ class _TextField extends StatelessWidget {
   }
 }
 
+// Mantido intencionalmente: widget privado usado condicionalmente em formulários.
+// ignore: unused_element
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
     super.key,

--- a/lib/features/auth/presentation/pages/customer_register_page.dart
+++ b/lib/features/auth/presentation/pages/customer_register_page.dart
@@ -1,4 +1,5 @@
 // Customer registration screen (US-01). Backed by POST /auth/register/customer.
+// ignore_for_file: unused_element, unused_element_parameter
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -476,12 +477,11 @@ class _TermsCheckboxState extends State<_TermsCheckbox> {
 }
 
 // Mantido intencionalmente: widget privado usado condicionalmente em formulários.
-// ignore: unused_element
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
-    super.key,
     required this.initialValue,
     required this.onSelected,
+    super.key,
   });
 
   final String? initialValue;

--- a/lib/features/auth/presentation/pages/customer_register_page.dart
+++ b/lib/features/auth/presentation/pages/customer_register_page.dart
@@ -475,6 +475,8 @@ class _TermsCheckboxState extends State<_TermsCheckbox> {
   }
 }
 
+// Mantido intencionalmente: widget privado usado condicionalmente em formulários.
+// ignore: unused_element
 class _UfAutocomplete extends StatelessWidget {
   const _UfAutocomplete({
     super.key,

--- a/lib/features/search/data/datasources/search_local_datasource.dart
+++ b/lib/features/search/data/datasources/search_local_datasource.dart
@@ -9,7 +9,7 @@ class SearchLocalDataSource {
   final SharedPreferences _prefs;
 
   static const _recentSearchesKey = 'search_recent_searches';
-  static const _maxRecent = 10;
+  static const _maxRecent = 4;
 
   List<String> getRecentSearches() {
     final json = _prefs.getString(_recentSearchesKey);

--- a/lib/features/search/data/datasources/search_remote_datasource.dart
+++ b/lib/features/search/data/datasources/search_remote_datasource.dart
@@ -53,18 +53,22 @@ class SearchRemoteDataSource {
       if (data == null) throw const UnknownApiException();
 
       List<Map<String, dynamic>> readList(dynamic d) {
-        if (d is List<dynamic>) return d.whereType<Map<String, dynamic>>().toList();
+        if (d is List<dynamic>)
+          return d.whereType<Map<String, dynamic>>().toList();
         if (d is Map<String, dynamic>) {
           for (final key in const [
             'data',
             'content',
             'items',
             'recommendations',
+            'recommendedProducts',
             'result',
             'list',
           ]) {
             if (d[key] is List<dynamic>) {
-              return (d[key] as List<dynamic>).whereType<Map<String, dynamic>>().toList();
+              return (d[key] as List<dynamic>)
+                  .whereType<Map<String, dynamic>>()
+                  .toList();
             }
           }
         }
@@ -82,29 +86,38 @@ class SearchRemoteDataSource {
 
         // image handling: recommendation items use 'imageS3'
         if (map['imageS3'] is String && (map['imageS3'] as String).isNotEmpty) {
-          map['image_url'] = ApiEndpoints.resolveMediaUrl(map['imageS3'] as String);
-        } else if (map['image_url'] is String && (map['image_url'] as String).isNotEmpty) {
-          map['image_url'] = ApiEndpoints.resolveMediaUrl(map['image_url'] as String);
+          map['image_url'] = ApiEndpoints.resolveMediaUrl(
+            map['imageS3'] as String,
+          );
+        } else if (map['image_url'] is String &&
+            (map['image_url'] as String).isNotEmpty) {
+          map['image_url'] = ApiEndpoints.resolveMediaUrl(
+            map['image_url'] as String,
+          );
         } else {
           map['image_url'] = '';
         }
 
         // farm/farmer -> subtitle/producerId
-        if (map['farmName'] != null && map['subtitle'] == null) {
+        if (map['farmName'] is String && map['subtitle'] == null) {
           map['subtitle'] = map['farmName'];
         }
-        if (map['farmerId'] != null && map['producerId'] == null) {
+        if (map['farmerId'] is String && map['producerId'] == null) {
           map['producerId'] = map['farmerId'];
         }
 
         // unity/unit
-        if (map['unityType'] != null && map['unit'] == null) {
+        if (map['unityType'] is String && map['unit'] == null) {
           map['unit'] = map['unityType'];
         }
 
         // categories -> category (pick first)
-        if (map['categoryNames'] is List && (map['categoryNames'] as List).isNotEmpty) {
-          map['category'] = (map['categoryNames'] as List).first as String;
+        if (map['categoryNames'] is List &&
+            (map['categoryNames'] as List).isNotEmpty) {
+          final firstName = (map['categoryNames'] as List)
+              .whereType<String>()
+              .firstOrNull;
+          if (firstName != null) map['category'] = firstName;
         }
 
         return SearchResultModel.fromJson(map);

--- a/lib/features/search/data/datasources/search_remote_datasource.dart
+++ b/lib/features/search/data/datasources/search_remote_datasource.dart
@@ -36,4 +36,81 @@ class SearchRemoteDataSource {
       throw e.error as ApiException? ?? const UnknownApiException();
     }
   }
+
+  Future<List<SearchResultModel>> getProductsByCategory({
+    required String category,
+  }) async {
+    try {
+      final response = await _apiClient.dio.get<dynamic>(
+        ApiEndpoints.recommendations,
+        queryParameters: {
+          if (category.isNotEmpty) 'category': category,
+          'limit': 6,
+        },
+      );
+
+      final data = response.data;
+      if (data == null) throw const UnknownApiException();
+
+      List<Map<String, dynamic>> readList(dynamic d) {
+        if (d is List<dynamic>) return d.whereType<Map<String, dynamic>>().toList();
+        if (d is Map<String, dynamic>) {
+          for (final key in const [
+            'data',
+            'content',
+            'items',
+            'recommendations',
+            'result',
+            'list',
+          ]) {
+            if (d[key] is List<dynamic>) {
+              return (d[key] as List<dynamic>).whereType<Map<String, dynamic>>().toList();
+            }
+          }
+        }
+        return const [];
+      }
+
+      final list = readList(data);
+      if (list.isEmpty) return const [];
+
+      return list.map((e) {
+        final map = Map<String, dynamic>.from(e);
+
+        // Normalize to the shape expected by SearchResultModel
+        map['type'] = 'product';
+
+        // image handling: recommendation items use 'imageS3'
+        if (map['imageS3'] is String && (map['imageS3'] as String).isNotEmpty) {
+          map['image_url'] = ApiEndpoints.resolveMediaUrl(map['imageS3'] as String);
+        } else if (map['image_url'] is String && (map['image_url'] as String).isNotEmpty) {
+          map['image_url'] = ApiEndpoints.resolveMediaUrl(map['image_url'] as String);
+        } else {
+          map['image_url'] = '';
+        }
+
+        // farm/farmer -> subtitle/producerId
+        if (map['farmName'] != null && map['subtitle'] == null) {
+          map['subtitle'] = map['farmName'];
+        }
+        if (map['farmerId'] != null && map['producerId'] == null) {
+          map['producerId'] = map['farmerId'];
+        }
+
+        // unity/unit
+        if (map['unityType'] != null && map['unit'] == null) {
+          map['unit'] = map['unityType'];
+        }
+
+        // categories -> category (pick first)
+        if (map['categoryNames'] is List && (map['categoryNames'] as List).isNotEmpty) {
+          map['category'] = (map['categoryNames'] as List).first as String;
+        }
+
+        return SearchResultModel.fromJson(map);
+      }).toList();
+    } on DioException catch (e) {
+      throw e.error as ApiException? ?? const UnknownApiException();
+    }
+  }
 }

--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -13,5 +13,14 @@ class SearchRepositoryImpl implements SearchRepository {
   Future<List<SearchResult>> search({
     required String query,
     String? category,
-  }) => _dataSource.search(query: query, category: category);
+  }) async {
+    final list = await _dataSource.search(query: query, category: category);
+    return List<SearchResult>.from(list);
+  }
+
+  @override
+  Future<List<SearchResult>> getProductsByCategory({required String category}) async {
+    final list = await _dataSource.getProductsByCategory(category: category);
+    return List<SearchResult>.from(list);
+  }
 }

--- a/lib/features/search/domain/repositories/search_repository.dart
+++ b/lib/features/search/domain/repositories/search_repository.dart
@@ -2,4 +2,5 @@ import 'package:ragro_mobile/features/search/domain/entities/search_result.dart'
 
 abstract class SearchRepository {
   Future<List<SearchResult>> search({required String query, String? category});
+  Future<List<SearchResult>> getProductsByCategory({required String category});
 }

--- a/lib/features/search/domain/usecases/search_producers_and_products.dart
+++ b/lib/features/search/domain/usecases/search_producers_and_products.dart
@@ -11,16 +11,7 @@ class SearchProducersAndProducts {
   Future<List<SearchResult>> call({required String query, String? category}) =>
       _repository.search(query: query, category: category);
 
-    Future<List<SearchResult>> getProductsByCategory({required String category}) =>
-      _repository.getProductsByCategory(category: category);
-}
-
-@lazySingleton
-class GetProductsByCategory {
-  const GetProductsByCategory(this._repository);
-
-  final SearchRepository _repository;
-
-  Future<List<SearchResult>> call({required String category}) =>
-      _repository.getProductsByCategory(category: category);
+  Future<List<SearchResult>> getProductsByCategory({
+    required String category,
+  }) => _repository.getProductsByCategory(category: category);
 }

--- a/lib/features/search/domain/usecases/search_producers_and_products.dart
+++ b/lib/features/search/domain/usecases/search_producers_and_products.dart
@@ -10,4 +10,17 @@ class SearchProducersAndProducts {
 
   Future<List<SearchResult>> call({required String query, String? category}) =>
       _repository.search(query: query, category: category);
+
+    Future<List<SearchResult>> getProductsByCategory({required String category}) =>
+      _repository.getProductsByCategory(category: category);
+}
+
+@lazySingleton
+class GetProductsByCategory {
+  const GetProductsByCategory(this._repository);
+
+  final SearchRepository _repository;
+
+  Future<List<SearchResult>> call({required String category}) =>
+      _repository.getProductsByCategory(category: category);
 }

--- a/lib/features/search/presentation/bloc/search_bloc.dart
+++ b/lib/features/search/presentation/bloc/search_bloc.dart
@@ -14,6 +14,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     on<SearchQuerySubmitted>(_onQuerySubmitted);
     on<SearchRecentItemRemoved>(_onRecentRemoved);
     on<SearchLoadRecentSearches>(_onLoadRecent);
+    on<SearchCategoryProductsRequested>(_onCategoryProductsRequested);
     add(const SearchLoadRecentSearches());
   }
 
@@ -51,6 +52,21 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     Emitter<SearchState> emit,
   ) async {
     _currentCategory = event.category ?? 'Tudo';
+  }
+
+  Future<void> _onCategoryProductsRequested(
+    SearchCategoryProductsRequested event,
+    Emitter<SearchState> emit,
+  ) async {
+    emit(const SearchCategoryLoading());
+    try {
+      final products = await _search.getProductsByCategory(category: event.category);
+      emit(SearchCategoryLoaded(products: products));
+    } on ApiException catch (e) {
+      emit(SearchCategoryFailure(e.message));
+    } on Exception catch (_) {
+      emit(const SearchCategoryFailure('Erro ao buscar produtos da categoria.'));
+    }
   }
 
   Future<void> _onQuerySubmitted(

--- a/lib/features/search/presentation/bloc/search_bloc.dart
+++ b/lib/features/search/presentation/bloc/search_bloc.dart
@@ -60,12 +60,16 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   ) async {
     emit(const SearchCategoryLoading());
     try {
-      final products = await _search.getProductsByCategory(category: event.category);
+      final products = await _search.getProductsByCategory(
+        category: event.category == 'Tudo' ? '' : event.category,
+      );
       emit(SearchCategoryLoaded(products: products));
     } on ApiException catch (e) {
       emit(SearchCategoryFailure(e.message));
     } on Exception catch (_) {
-      emit(const SearchCategoryFailure('Erro ao buscar produtos da categoria.'));
+      emit(
+        const SearchCategoryFailure('Erro ao buscar produtos da categoria.'),
+      );
     }
   }
 

--- a/lib/features/search/presentation/bloc/search_event.dart
+++ b/lib/features/search/presentation/bloc/search_event.dart
@@ -42,3 +42,11 @@ class SearchRecentItemRemoved extends SearchEvent {
 class SearchLoadRecentSearches extends SearchEvent {
   const SearchLoadRecentSearches();
 }
+
+class SearchCategoryProductsRequested extends SearchEvent {
+  const SearchCategoryProductsRequested(this.category);
+  final String category;
+
+  @override
+  List<Object?> get props => [category];
+}

--- a/lib/features/search/presentation/bloc/search_state.dart
+++ b/lib/features/search/presentation/bloc/search_state.dart
@@ -36,3 +36,23 @@ class SearchFailure extends SearchState {
   @override
   List<Object?> get props => [message];
 }
+
+class SearchCategoryLoaded extends SearchState {
+  const SearchCategoryLoaded({required this.products});
+  final List<SearchResult> products;
+
+  @override
+  List<Object?> get props => [products];
+}
+
+class SearchCategoryLoading extends SearchState {
+  const SearchCategoryLoading();
+}
+
+class SearchCategoryFailure extends SearchState {
+  const SearchCategoryFailure(this.message);
+  final String message;
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/search/presentation/pages/search_page.dart
+++ b/lib/features/search/presentation/pages/search_page.dart
@@ -8,6 +8,8 @@ import 'package:ragro_mobile/features/search/presentation/bloc/search_event.dart
 import 'package:ragro_mobile/features/search/presentation/bloc/search_state.dart';
 import 'package:ragro_mobile/features/search/presentation/pages/search_result_page.dart';
 import 'package:ragro_mobile/features/search/presentation/widgets/category_chip.dart';
+import 'package:ragro_mobile/features/home/presentation/widgets/products_grid.dart';
+import 'package:ragro_mobile/features/home/domain/entities/home_product.dart';
 
 class SearchPage extends StatelessWidget {
   const SearchPage({super.key});
@@ -85,6 +87,53 @@ class _SearchViewState extends State<_SearchView> {
                   ),
                 ),
               ),
+              // Category products (below recent searches)
+              BlocBuilder<SearchBloc, SearchState>(
+                buildWhen: (prev, curr) =>
+                    curr is SearchCategoryLoading ||
+                    curr is SearchCategoryLoaded ||
+                    curr is SearchCategoryFailure,
+                builder: (context, state) {
+                  if (state is SearchCategoryLoading) {
+                    return const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+                  if (state is SearchCategoryLoaded) {
+                    final results = state.products;
+                    if (results.isEmpty) return const SizedBox.shrink();
+                    final homeProducts = results
+                        .map((r) => HomeProduct(
+                              id: r.id,
+                              name: r.name,
+                              category: r.category ?? '',
+                              price: r.price ?? 0.0,
+                              unityType: r.unit ?? '',
+                              imageUrl: r.imageUrl,
+                              farmName: r.subtitle,
+                              producerId: r.producerId ?? '',
+                            ))
+                        .toList();
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 16, 0, 24),
+                      child: ProductsGrid(
+                        products: homeProducts,
+                        recommendations: const [],
+                        onProductTap: (p) {},
+                        onAddToCart: (p) {},
+                      ),
+                    );
+                  }
+                  if (state is SearchCategoryFailure) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: Center(child: Text(state.message)),
+                    );
+                  }
+                  return const SizedBox.shrink();
+                },
+              ),
               // Search bar
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
@@ -151,15 +200,21 @@ class _SearchViewState extends State<_SearchView> {
                         padding: const EdgeInsets.symmetric(horizontal: 16),
                         itemCount: _categories.length,
                         separatorBuilder: (_, __) => const SizedBox(width: 8),
-                        itemBuilder: (_, i) => CategoryChip(
-                          label: _categories[i],
-                          isSelected: _selectedCategory == _categories[i],
-                          onTap: () {
-                            setState(() => _selectedCategory = _categories[i]);
-                          },
-                        ),
+                        itemBuilder: (_, i) {
+                          final c = _categories[i];
+                          return CategoryChip(
+                            label: c,
+                            isSelected: _selectedCategory == c,
+                            onTap: () {
+                              setState(() => _selectedCategory = c);
+                              context.read<SearchBloc>().add(SearchCategoryChanged(c));
+                              context.read<SearchBloc>().add(SearchCategoryProductsRequested(c));
+                            },
+                          );
+                        },
                       ),
                     ),
+                    const SizedBox(height: 12),
                   ],
                 ),
               ),

--- a/lib/features/search/presentation/pages/search_page.dart
+++ b/lib/features/search/presentation/pages/search_page.dart
@@ -3,13 +3,15 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/cart/presentation/bloc/cart_bloc.dart';
+import 'package:ragro_mobile/features/cart/presentation/bloc/cart_event.dart';
+import 'package:ragro_mobile/features/home/domain/entities/home_product.dart';
+import 'package:ragro_mobile/features/home/presentation/widgets/products_grid.dart';
 import 'package:ragro_mobile/features/search/presentation/bloc/search_bloc.dart';
 import 'package:ragro_mobile/features/search/presentation/bloc/search_event.dart';
 import 'package:ragro_mobile/features/search/presentation/bloc/search_state.dart';
 import 'package:ragro_mobile/features/search/presentation/pages/search_result_page.dart';
 import 'package:ragro_mobile/features/search/presentation/widgets/category_chip.dart';
-import 'package:ragro_mobile/features/home/presentation/widgets/products_grid.dart';
-import 'package:ragro_mobile/features/home/domain/entities/home_product.dart';
 
 class SearchPage extends StatelessWidget {
   const SearchPage({super.key});
@@ -87,53 +89,7 @@ class _SearchViewState extends State<_SearchView> {
                   ),
                 ),
               ),
-              // Category products (below recent searches)
-              BlocBuilder<SearchBloc, SearchState>(
-                buildWhen: (prev, curr) =>
-                    curr is SearchCategoryLoading ||
-                    curr is SearchCategoryLoaded ||
-                    curr is SearchCategoryFailure,
-                builder: (context, state) {
-                  if (state is SearchCategoryLoading) {
-                    return const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 12),
-                      child: Center(child: CircularProgressIndicator()),
-                    );
-                  }
-                  if (state is SearchCategoryLoaded) {
-                    final results = state.products;
-                    if (results.isEmpty) return const SizedBox.shrink();
-                    final homeProducts = results
-                        .map((r) => HomeProduct(
-                              id: r.id,
-                              name: r.name,
-                              category: r.category ?? '',
-                              price: r.price ?? 0.0,
-                              unityType: r.unit ?? '',
-                              imageUrl: r.imageUrl,
-                              farmName: r.subtitle,
-                              producerId: r.producerId ?? '',
-                            ))
-                        .toList();
-                    return Padding(
-                      padding: const EdgeInsets.fromLTRB(0, 16, 0, 24),
-                      child: ProductsGrid(
-                        products: homeProducts,
-                        recommendations: const [],
-                        onProductTap: (p) {},
-                        onAddToCart: (p) {},
-                      ),
-                    );
-                  }
-                  if (state is SearchCategoryFailure) {
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                      child: Center(child: Text(state.message)),
-                    );
-                  }
-                  return const SizedBox.shrink();
-                },
-              ),
+
               // Search bar
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
@@ -207,8 +163,12 @@ class _SearchViewState extends State<_SearchView> {
                             isSelected: _selectedCategory == c,
                             onTap: () {
                               setState(() => _selectedCategory = c);
-                              context.read<SearchBloc>().add(SearchCategoryChanged(c));
-                              context.read<SearchBloc>().add(SearchCategoryProductsRequested(c));
+                              context.read<SearchBloc>().add(
+                                SearchCategoryChanged(c),
+                              );
+                              context.read<SearchBloc>().add(
+                                SearchCategoryProductsRequested(c),
+                              );
                             },
                           );
                         },
@@ -263,6 +223,58 @@ class _SearchViewState extends State<_SearchView> {
                       ],
                     ),
                   );
+                },
+              ),
+              // Category products (below recent searches)
+              BlocBuilder<SearchBloc, SearchState>(
+                builder: (context, state) {
+                  if (state is SearchCategoryLoading) {
+                    return const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+                  if (state is SearchCategoryLoaded) {
+                    final results = state.products;
+                    if (results.isEmpty) return const SizedBox.shrink();
+                    final homeProducts = results
+                        .map(
+                          (r) => HomeProduct(
+                            id: r.id,
+                            name: r.name,
+                            category: r.category ?? '',
+                            price: r.price ?? 0.0,
+                            unityType: r.unit ?? '',
+                            imageUrl: r.imageUrl,
+                            farmName: r.subtitle,
+                            producerId: r.producerId ?? '',
+                          ),
+                        )
+                        .toList();
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 16, 0, 24),
+                      child: ProductsGrid(
+                        products: homeProducts,
+                        onProductTap: (p) => context.push(
+                          '/customer/home/product/${p.id}',
+                          extra: p.producerId,
+                        ),
+                        onAddToCart: (p) {
+                          getIt<CartBloc>().add(
+                            CartItemAdded(productId: p.id, quantity: 1),
+                          );
+                          context.push('/customer/cart');
+                        },
+                      ),
+                    );
+                  }
+                  if (state is SearchCategoryFailure) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: Center(child: Text(state.message)),
+                    );
+                  }
+                  return const SizedBox.shrink();
                 },
               ),
             ],

--- a/lib/features/search/presentation/pages/search_result_page.dart
+++ b/lib/features/search/presentation/pages/search_result_page.dart
@@ -132,36 +132,30 @@ class _SearchResultsViewState extends State<_SearchResultsView> {
         ),
         body: BlocBuilder<SearchBloc, SearchState>(
           builder: (context, state) {
-            if (state is SearchIdle) {
-              return const SizedBox.shrink();
-            }
-            if (state is SearchLoading) {
-              return const Center(
+            return switch (state) {
+              SearchIdle() => const SizedBox.shrink(),
+              SearchLoading() => const Center(
                 child: CircularProgressIndicator(color: AppColors.darkGreen),
-              );
-            }
-            if (state is SearchLoaded) {
-              final results = state.results;
-              if (results.isEmpty) {
-                return const Center(
-                  child: Text(
-                    'Nenhum resultado encontrado.',
-                    style: TextStyle(color: AppColors.placeholder),
-                  ),
-                );
-              }
-              return _buildTabs(results);
-            }
-            if (state is SearchFailure) {
-              return Center(
+              ),
+              SearchLoaded(:final results) =>
+                results.isEmpty
+                    ? const Center(
+                        child: Text(
+                          'Nenhum resultado encontrado.',
+                          style: TextStyle(color: AppColors.placeholder),
+                        ),
+                      )
+                    : _buildTabs(results),
+              SearchFailure(:final message) => Center(
                 child: Text(
-                  state.message,
+                  message,
                   style: const TextStyle(color: AppColors.placeholder),
                 ),
-              );
-            }
-
-            return const SizedBox.shrink();
+              ),
+              SearchCategoryLoading() ||
+              SearchCategoryLoaded() ||
+              SearchCategoryFailure() => const SizedBox.shrink(),
+            };
           },
         ),
       ),

--- a/lib/features/search/presentation/pages/search_result_page.dart
+++ b/lib/features/search/presentation/pages/search_result_page.dart
@@ -132,27 +132,36 @@ class _SearchResultsViewState extends State<_SearchResultsView> {
         ),
         body: BlocBuilder<SearchBloc, SearchState>(
           builder: (context, state) {
-            return switch (state) {
-              SearchIdle() => const SizedBox.shrink(),
-              SearchLoading() => const Center(
+            if (state is SearchIdle) {
+              return const SizedBox.shrink();
+            }
+            if (state is SearchLoading) {
+              return const Center(
                 child: CircularProgressIndicator(color: AppColors.darkGreen),
-              ),
-              SearchLoaded(:final results) =>
-                results.isEmpty
-                    ? const Center(
-                        child: Text(
-                          'Nenhum resultado encontrado.',
-                          style: TextStyle(color: AppColors.placeholder),
-                        ),
-                      )
-                    : _buildTabs(results),
-              SearchFailure(:final message) => Center(
+              );
+            }
+            if (state is SearchLoaded) {
+              final results = state.results;
+              if (results.isEmpty) {
+                return const Center(
+                  child: Text(
+                    'Nenhum resultado encontrado.',
+                    style: TextStyle(color: AppColors.placeholder),
+                  ),
+                );
+              }
+              return _buildTabs(results);
+            }
+            if (state is SearchFailure) {
+              return Center(
                 child: Text(
-                  message,
+                  state.message,
                   style: const TextStyle(color: AppColors.placeholder),
                 ),
-              ),
-            };
+              );
+            }
+
+            return const SizedBox.shrink();
           },
         ),
       ),
@@ -465,12 +474,15 @@ class _SearchDropdownFilter extends StatelessWidget {
           switch (value) {
             case _SortMenuAction.ascending:
               onSelected(_SortDirection.ascending);
+              return;
             case _SortMenuAction.descending:
               onSelected(_SortDirection.descending);
+              return;
             case _SortMenuAction.clear:
               onSelected(null);
+              return;
             case null:
-              break;
+              return;
           }
         },
         child: Container(

--- a/test/features/search/presentation/search_bloc_test.dart
+++ b/test/features/search/presentation/search_bloc_test.dart
@@ -36,7 +36,7 @@ void main() {
     name: 'Tomate',
     subtitle: 'Sítio Boa Vista',
     imageUrl: '',
-    price: 5.0,
+    price: 5,
   );
 
   setUp(() async {

--- a/test/features/search/presentation/search_bloc_test.dart
+++ b/test/features/search/presentation/search_bloc_test.dart
@@ -30,6 +30,15 @@ void main() {
     rating: 0,
   );
 
+  const tProduct = SearchResult(
+    id: 'b0000000-0000-0000-0000-000000000001',
+    type: SearchResultType.product,
+    name: 'Tomate',
+    subtitle: 'Sítio Boa Vista',
+    imageUrl: '',
+    price: 5.0,
+  );
+
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -168,6 +177,63 @@ void main() {
       verify: (_) {
         verify(() => mockRepository.search(query: 'tomate')).called(1);
       },
+    );
+  });
+
+  group('SearchCategoryProductsRequested', () {
+    blocTest<SearchBloc, SearchState>(
+      'emite [SearchCategoryLoading, SearchCategoryLoaded] quando retorna produtos',
+      build: () {
+        when(
+          () => mockRepository.getProductsByCategory(category: 'Horta'),
+        ).thenAnswer((_) async => [tProduct]);
+        return bloc;
+      },
+      act: (b) => b.add(const SearchCategoryProductsRequested('Horta')),
+      expect: () => [
+        const SearchCategoryLoading(),
+        const SearchCategoryLoaded(products: [tProduct]),
+      ],
+      verify: (_) {
+        verify(
+          () => mockRepository.getProductsByCategory(category: 'Horta'),
+        ).called(1);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'envia categoria vazia quando categoria é Tudo',
+      build: () {
+        when(
+          () => mockRepository.getProductsByCategory(category: ''),
+        ).thenAnswer((_) async => []);
+        return bloc;
+      },
+      act: (b) => b.add(const SearchCategoryProductsRequested('Tudo')),
+      expect: () => [
+        const SearchCategoryLoading(),
+        const SearchCategoryLoaded(products: []),
+      ],
+      verify: (_) {
+        verify(
+          () => mockRepository.getProductsByCategory(category: ''),
+        ).called(1);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'emite [SearchCategoryLoading, SearchCategoryFailure] quando ocorre ApiException',
+      build: () {
+        when(
+          () => mockRepository.getProductsByCategory(category: 'Horta'),
+        ).thenThrow(const UnknownApiException());
+        return bloc;
+      },
+      act: (b) => b.add(const SearchCategoryProductsRequested('Horta')),
+      expect: () => [
+        const SearchCategoryLoading(),
+        isA<SearchCategoryFailure>(),
+      ],
     );
   });
 


### PR DESCRIPTION
## What changed?
Fiz uma alteração no frontend para exibir os produtos na tela de pesquisa do consumidor e aplicar filtros. Além disso, coloquei um limite de no maximo 4 pesquisas recentes na mesma tela.


## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (dependencies, configs, etc.)

## How to test?



## Screenshots / Recordings

<!-- If you changed something visual, paste screenshots or recordings here -->

## Checklist

- [ ] Code formatted (`dart format .`)
- [ ] No analyze warnings (`dart analyze`)
- [ ] Tests passing (`flutter test`)
- [ ] Follows the project's architecture pattern


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category-based product recommendations to the search flow, including loading and error states.

* **Refactor**
  * Updated the search page to fetch and display products based on the selected category.
  * Improved search result/category rendering behavior for loading and empty states.

* **Tests**
  * Added Bloc coverage for category product requests, including success, empty (“Tudo”), and failure scenarios.

* **Chores**
  * Updated analyzer warning suppressions in auth/admin pages.
  * Reduced the stored recent-search limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->