### PR TITLE
Fix/year producer profile

### DIFF
--- a/lib/features/producer_profile/data/models/public_producer_model.dart
+++ b/lib/features/producer_profile/data/models/public_producer_model.dart
@@ -42,7 +42,7 @@ class PublicProducerModel extends PublicProducer {
       );
     }
 
-    final memberSinceRaw = json['memberSince'] as String?;
+    final memberSinceRaw = json['memberSince']?.toString().trim();
 
     return PublicProducerModel(
       id: json['id'] as String? ?? '',
@@ -62,11 +62,7 @@ class PublicProducerModel extends PublicProducer {
       totalReviews: json['totalReviews'] as int? ?? 0,
       phone: json['phone'] as String? ?? '',
       availability: _parseAvailability(json['availability']),
-      memberSince: memberSinceRaw != null
-          ? DateTime.parse(memberSinceRaw)
-          : throw FormatException(
-              'memberSince is required in producer profile response for producer ${json['id']}',
-            ),
+      memberSince: _parseMemberSince(memberSinceRaw),
       photoUrl: () {
         final raw = json['photoUrl'] as String?;
         if (raw == null || raw.isEmpty) return null;
@@ -76,6 +72,14 @@ class PublicProducerModel extends PublicProducer {
       paymentMethods: _parsePaymentMethods(json['paymentMethods']),
       products: const [],
     );
+  }
+
+  static DateTime? _parseMemberSince(String? value) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+
+    return DateTime.tryParse(value);
   }
 
   static String _deriveLocation(

--- a/lib/features/producer_profile/data/models/public_producer_model.dart
+++ b/lib/features/producer_profile/data/models/public_producer_model.dart
@@ -64,7 +64,9 @@ class PublicProducerModel extends PublicProducer {
       availability: _parseAvailability(json['availability']),
       memberSince: memberSinceRaw != null
           ? DateTime.parse(memberSinceRaw)
-          : DateTime(2016),
+          : throw FormatException(
+              'memberSince is required in producer profile response for producer ${json['id']}',
+            ),
       photoUrl: () {
         final raw = json['photoUrl'] as String?;
         if (raw == null || raw.isEmpty) return null;

--- a/lib/features/producer_profile/domain/entities/public_producer.dart
+++ b/lib/features/producer_profile/domain/entities/public_producer.dart
@@ -137,7 +137,15 @@ class PublicProducer extends Equatable {
   final List<Review>? reviews;
 
   int get yearsOnPlatform {
-    return DateTime.now().difference(memberSince).inDays ~/ 365;
+    final now = DateTime.now();
+    var years = now.year - memberSince.year;
+    final anniversaryThisYear = DateTime(
+      now.year,
+      memberSince.month,
+      memberSince.day,
+    );
+    if (now.isBefore(anniversaryThisYear)) years--;
+    return years;
   }
 
   @override

--- a/lib/features/producer_profile/domain/entities/public_producer.dart
+++ b/lib/features/producer_profile/domain/entities/public_producer.dart
@@ -128,7 +128,7 @@ class PublicProducer extends Equatable {
   final int totalReviews;
   final String phone;
   final List<AvailabilitySlot> availability;
-  final DateTime memberSince;
+  final DateTime? memberSince;
 
   final String? photoUrl;
   final ProducerAddress? producerAddress;
@@ -136,7 +136,10 @@ class PublicProducer extends Equatable {
   final List<HomeProduct>? products;
   final List<Review>? reviews;
 
-  int get yearsOnPlatform {
+  int? get yearsOnPlatform {
+    final memberSince = this.memberSince;
+    if (memberSince == null) return null;
+
     final now = DateTime.now();
     var years = now.year - memberSince.year;
     final anniversaryThisYear = DateTime(

--- a/lib/features/producer_profile/presentation/widgets/producer_stats_row.dart
+++ b/lib/features/producer_profile/presentation/widgets/producer_stats_row.dart
@@ -11,7 +11,7 @@ class ProducerStatsRow extends StatelessWidget {
 
   final int productCount;
   final double rating;
-  final int yearsOnPlatform;
+  final int? yearsOnPlatform;
 
   @override
   Widget build(BuildContext context) {
@@ -22,7 +22,9 @@ class ProducerStatsRow extends StatelessWidget {
         _StatCard(value: rating.toStringAsFixed(1), label: 'AVALIAÇÃO'),
         const SizedBox(width: 16),
         _StatCard(
-          value: '${yearsOnPlatform > 0 ? yearsOnPlatform : 1} anos',
+          value: yearsOnPlatform == null
+              ? '--'
+              : '${yearsOnPlatform! > 0 ? yearsOnPlatform : 1} anos',
           label: 'DE RAGRO',
         ),
       ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -868,10 +868,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1257,26 +1257,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -358,14 +358,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.4"
-  flutter_markdown:
-    dependency: "direct main"
-    description:
-      name: flutter_markdown
-      sha256: "04c4722cc36ec5af38acc38ece70d22d3c2123c61305d555750a091517bbe504"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.23"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -856,14 +848,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  markdown:
-    dependency: transitive
-    description:
-      name: markdown
-      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.3.1"
   matcher:
     dependency: transitive
     description:
@@ -884,10 +868,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1273,26 +1257,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -358,6 +358,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.4"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "04c4722cc36ec5af38acc38ece70d22d3c2123c61305d555750a091517bbe504"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.23"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -848,6 +856,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:

--- a/test/features/producer_profile/data/models/public_producer_model_test.dart
+++ b/test/features/producer_profile/data/models/public_producer_model_test.dart
@@ -77,7 +77,7 @@ void main() {
       expect(model.location, '');
     });
 
-    test('falha quando memberSince esta ausente', () {
+    test('mantem memberSince nulo quando esta ausente', () {
       final json = {
         'id': 'abc-sem-data',
         'name': 'Sem data',
@@ -85,10 +85,10 @@ void main() {
         'farmName': 'Fazenda X',
       };
 
-      expect(
-        () => PublicProducerModel.fromJson(json),
-        throwsA(isA<FormatException>()),
-      );
+      final model = PublicProducerModel.fromJson(json);
+
+      expect(model.memberSince, isNull);
+      expect(model.yearsOnPlatform, isNull);
     });
 
     test('parseia resposta camelCase com photoUrl opcional', () {

--- a/test/features/producer_profile/data/models/public_producer_model_test.dart
+++ b/test/features/producer_profile/data/models/public_producer_model_test.dart
@@ -54,6 +54,7 @@ void main() {
         'name': 'Ana',
         'phone': '',
         'farmName': 'Sítio',
+        'memberSince': '2020-03-15',
         'address': {'city': 'Curitiba'},
       };
 
@@ -68,11 +69,26 @@ void main() {
         'name': 'Sem endereço',
         'phone': '',
         'farmName': 'Fazenda X',
+        'memberSince': '2020-03-15',
       };
 
       final model = PublicProducerModel.fromJson(json);
 
       expect(model.location, '');
+    });
+
+    test('falha quando memberSince esta ausente', () {
+      final json = {
+        'id': 'abc-sem-data',
+        'name': 'Sem data',
+        'phone': '',
+        'farmName': 'Fazenda X',
+      };
+
+      expect(
+        () => PublicProducerModel.fromJson(json),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     test('parseia resposta camelCase com photoUrl opcional', () {


### PR DESCRIPTION
## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (dependencies, configs, etc.)

OBS: tive que fazer ajustes tambem no backend

## How to test?

1. Acessar o fluxo do consumidor.
2. Abrir o perfil público de um produtor.
3. Validar que o campo "DE RAGRO" usa a data recebida em `memberSince` para calcular o tempo do produtor no app.
4. Validar que o perfil do produtor continua carregando mesmo quando `memberSince` não estiver disponível ou vier inválido.
5. Executar:

bash
dart analyze lib/features/producer_profile/data/models/public_producer_model.dart lib/features/producer_profile/domain/entities/public_producer.dart lib/features/producer_profile/presentation/widgets/producer_stats_row.dart test/features/producer_profile/data/models/public_producer_model_test.dart


## Screenshots / Recordings

<img width="748" height="282" alt="image" src="https://github.com/user-attachments/assets/678af463-0b66-40b8-9efb-bbed690bf0dc" />



## Checklist

- [ ] Code formatted (`dart format .`)
- [ ] No analyze warnings (`dart analyze`)
- [ ] Tests passing (`flutter test`)
- [x] Follows the project's architecture pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of missing member join dates in producer profiles—unavailable dates now display as '--' instead of defaulting to a placeholder value.
  * Updated years on platform calculation to be more accurate using anniversary-based logic.

* **Tests**
  * Added test coverage for missing member join date scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->