### PR TITLE
fix: ajuste no dashboard e no botao editar foto de perfil do produtor 

### DIFF
--- a/lib/features/producer_management/presentation/pages/producer_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_profile_page.dart
@@ -302,17 +302,17 @@ class _ProducerProfileView extends StatelessWidget {
                           ),
                         ),
                         Positioned(
-                          bottom: 4,
-                          right: 4,
+                          bottom: 0,
+                          right: 0,
                           child: Container(
-                            padding: const EdgeInsets.all(6),
+                            padding: const EdgeInsets.all(8),
                             decoration: const BoxDecoration(
                               color: AppColors.darkGreen,
                               shape: BoxShape.circle,
                             ),
                             child: const Icon(
                               Icons.camera_alt,
-                              size: 14,
+                              size: 18,
                               color: AppColors.white,
                             ),
                           ),
@@ -521,7 +521,6 @@ class _ProducerProfileView extends StatelessWidget {
           ),
 
           const SizedBox(height: 24),
-          const SizedBox(height: 20),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: _WeeklyChart(data: dashboard.weeklyChartData),
@@ -786,20 +785,20 @@ class _StatCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(
-            width: 24,
-            height: 24,
+            width: 40,
+            height: 40,
             decoration: BoxDecoration(
               color: iconColor.withValues(alpha: 0.1),
               shape: BoxShape.circle,
             ),
-            child: Icon(icon, size: 14, color: iconColor),
+            child: Icon(icon, size: 20, color: iconColor),
           ),
-          const SizedBox(height: 26),
+          const SizedBox(height: 16),
           Text(
             label,
             style: const TextStyle(
               fontFamily: 'Manrope',
-              fontSize: 11,
+              fontSize: 14,
               color: AppColors.placeholder,
             ),
           ),
@@ -809,7 +808,7 @@ class _StatCard extends StatelessWidget {
             style: const TextStyle(
               fontFamily: 'Figtree',
               fontWeight: FontWeight.w800,
-              fontSize: 22,
+              fontSize: 28,
               color: AppColors.black,
             ),
           ),
@@ -819,7 +818,7 @@ class _StatCard extends StatelessWidget {
             style: TextStyle(
               fontFamily: 'Manrope',
               fontWeight: FontWeight.w700,
-              fontSize: 10,
+              fontSize: 12,
               color: positive ? AppColors.lightGreen : AppColors.red,
             ),
           ),

--- a/lib/features/producer_management/presentation/pages/producer_profile_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_profile_page.dart
@@ -304,16 +304,19 @@ class _ProducerProfileView extends StatelessWidget {
                         Positioned(
                           bottom: 0,
                           right: 0,
-                          child: Container(
-                            padding: const EdgeInsets.all(8),
-                            decoration: const BoxDecoration(
-                              color: AppColors.darkGreen,
-                              shape: BoxShape.circle,
-                            ),
-                            child: const Icon(
-                              Icons.camera_alt,
-                              size: 18,
-                              color: AppColors.white,
+                          child: GestureDetector(
+                            onTap: () => _openEditProfile(context),
+                            child: Container(
+                              padding: const EdgeInsets.all(8),
+                              decoration: const BoxDecoration(
+                                color: AppColors.darkGreen,
+                                shape: BoxShape.circle,
+                              ),
+                              child: const Icon(
+                                Icons.camera_alt,
+                                size: 18,
+                                color: AppColors.white,
+                              ),
                             ),
                           ),
                         ),


### PR DESCRIPTION
O que mudou?
Aumento do tamanho do botão de editar foto de perfil (ícone de câmera) na capa do perfil do produtor.
Aumento geral no tamanho da fonte dos valores e dos ícones nos cards de "Pedidos" e "Estoque" no Dashboard do produtor para melhorar a legibilidade.
Redução do espaçamento em branco (SizedBox) excessivo que existia entre os cards de resumo e o gráfico da "Visão Semanal".

Tipo de mudança

( ) Nova feature
( ) Correção de bug
(x) Refatoração / Ajustes de UI
( ) Documentação
( ) Chore (dependências, configs, etc.)

Como testar?

Faça o login no app usando a conta de um produtor.
Acesse a aba Perfil no menu inferior.
Verifique na parte superior da tela se o ícone da câmera verde (usado para editar a foto de perfil) agora está com um tamanho maior.
Role a página para baixo até o Dashboard.
Verifique se os ícones (carrinho de Pedidos e caixa de Estoque) e as fontes numéricas principais dos cards estão maiores.
Confira se o distanciamento entre esses cards e a seção de "Visão Semanal" logo abaixo diminuiu e está mais harmonioso.
Screenshots / Gravações

Checklist

(x) Código formatado (dart format .)
(x) Sem warnings no analyze (dart analyze)
(x) Testes passando (flutter test)
(x) Segue o padrão de arquitetura do projeto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated producer profile avatar camera overlay styling with improved positioning, larger circular padding, and a larger camera icon.
  * Refreshed dashboard spacing by increasing the gap between the sales/stat cards area and the weekly chart.
  * Updated stat card visuals: larger icon badge sizing, tighter internal spacing, and revised typography scaling for label, value, and change text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->