### PR TITLE
feat(impact): CO2 route history timeline

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -201,6 +201,8 @@ import 'package:ragro_mobile/features/producer_orders/data/repositories/route_re
     as _i609;
 import 'package:ragro_mobile/features/producer_orders/domain/repositories/producer_orders_repository.dart'
     as _i649;
+import 'package:ragro_mobile/features/producer_orders/domain/usecases/confirm_producer_delivery_with_code.dart'
+    as _i474;
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/confirm_producer_order.dart'
     as _i141;
 import 'package:ragro_mobile/features/producer_orders/domain/usecases/get_producer_order_detail.dart'
@@ -595,6 +597,11 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i671.ActivateAdminProducer>(),
       ),
     );
+    gh.lazySingleton<_i474.ConfirmProducerDeliveryWithCode>(
+      () => _i474.ConfirmProducerDeliveryWithCode(
+        gh<_i649.ProducerOrdersRepository>(),
+      ),
+    );
     gh.lazySingleton<_i141.ConfirmProducerOrder>(
       () => _i141.ConfirmProducerOrder(gh<_i649.ProducerOrdersRepository>()),
     );
@@ -685,16 +692,17 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i774.ConfirmCustomerDelivery>(),
       ),
     );
+    gh.factory<_i432.RateProducerBloc>(
+      () => _i432.RateProducerBloc(gh<_i5.CreateReview>()),
+    );
     gh.factory<_i921.ProducerOrderDetailBloc>(
       () => _i921.ProducerOrderDetailBloc(
         gh<_i181.GetProducerOrderDetail>(),
         gh<_i141.ConfirmProducerOrder>(),
         gh<_i885.RefuseProducerOrder>(),
         gh<_i1038.UpdateProducerOrderStatus>(),
+        gh<_i474.ConfirmProducerDeliveryWithCode>(),
       ),
-    );
-    gh.factory<_i432.RateProducerBloc>(
-      () => _i432.RateProducerBloc(gh<_i5.CreateReview>()),
     );
     return this;
   }

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -80,6 +80,7 @@ abstract final class ApiEndpoints {
   static String get co2Calculate => '$_base/co2/calculate';
   static String get co2RecordSavings => '$_base/co2/record-savings';
   static String get co2Options => '$_base/co2/options';
+  static String get co2Emissions => '$_base/co2/emissions';
 
   // Routes (optimized via backend; the Google key stays on the server)
   static String get routesOptimize => '$_base/routes/optimize';

--- a/lib/features/impact/presentation/pages/impact_detail_page.dart
+++ b/lib/features/impact/presentation/pages/impact_detail_page.dart
@@ -2,10 +2,12 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/network/api_client.dart';
 import 'package:ragro_mobile/core/network/api_endpoints.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/producer_orders/data/models/co2_response_model.dart';
 
 const _kCloudSvg = '''
 <svg width="43" height="32" viewBox="0 0 43 32" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -25,6 +27,7 @@ class ImpactDetailPage extends StatefulWidget {
 class _ImpactDetailPageState extends State<ImpactDetailPage> {
   double _totalCo2Saved = 0;
   int _totalProducers = 0;
+  List<Co2EmissionRecord> _emissions = [];
   bool _loading = true;
 
   @override
@@ -42,21 +45,26 @@ class _ImpactDetailPageState extends State<ImpactDetailPage> {
           ApiEndpoints.producers,
           queryParameters: {'page': 0, 'size': 1},
         ),
+        apiClient.dio.get<List<dynamic>>(ApiEndpoints.co2Emissions),
       ]);
 
-      final co2Response = results[0];
-      final producersResponse = results[1];
+      final co2Response = results[0] as Response<Map<String, dynamic>>;
+      final producersResponse = results[1] as Response<Map<String, dynamic>>;
+      final emissionsResponse = results[2] as Response<List<dynamic>>;
 
       final total =
           (co2Response.data?['totalCo2Saved'] as num?)?.toDouble() ?? 0;
-
       final totalProducers =
           (producersResponse.data?['totalElements'] as num?)?.toInt() ?? 0;
+      final emissions = (emissionsResponse.data ?? [])
+          .map((e) => Co2EmissionRecord.fromJson(e as Map<String, dynamic>))
+          .toList();
 
       if (mounted) {
         setState(() {
           _totalCo2Saved = total;
           _totalProducers = totalProducers;
+          _emissions = emissions;
           _loading = false;
         });
       }
@@ -158,63 +166,69 @@ class _ImpactDetailPageState extends State<ImpactDetailPage> {
                                 ),
                               ),
                               const SizedBox(width: 16),
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  const Text(
-                                    'Mais de',
-                                    style: TextStyle(
-                                      fontFamily: 'Figtree',
-                                      fontSize: 14,
-                                      color: Color(0xFF64748B),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Text(
+                                      'Mais de',
+                                      style: TextStyle(
+                                        fontFamily: 'Figtree',
+                                        fontSize: 14,
+                                        color: Color(0xFF64748B),
+                                      ),
                                     ),
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Row(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.baseline,
-                                    textBaseline: TextBaseline.alphabetic,
-                                    children: [
-                                      Text(
-                                        co2Value,
-                                        style: const TextStyle(
-                                          fontFamily: 'Figtree',
-                                          fontWeight: FontWeight.w700,
-                                          fontSize: 56,
-                                          color: AppColors.darkGreen,
-                                          height: 1,
-                                        ),
+                                    const SizedBox(height: 2),
+                                    FittedBox(
+                                      fit: BoxFit.scaleDown,
+                                      alignment: Alignment.centerLeft,
+                                      child: Row(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.baseline,
+                                        textBaseline: TextBaseline.alphabetic,
+                                        children: [
+                                          Text(
+                                            co2Value,
+                                            style: const TextStyle(
+                                              fontFamily: 'Figtree',
+                                              fontWeight: FontWeight.w700,
+                                              fontSize: 56,
+                                              color: AppColors.darkGreen,
+                                              height: 1,
+                                            ),
+                                          ),
+                                          const Text(
+                                            't de CO',
+                                            style: TextStyle(
+                                              fontFamily: 'Figtree',
+                                              fontWeight: FontWeight.w500,
+                                              fontSize: 18,
+                                              color: AppColors.darkGreen,
+                                            ),
+                                          ),
+                                          const Text(
+                                            '₂',
+                                            style: TextStyle(
+                                              fontFamily: 'Figtree',
+                                              fontSize: 12,
+                                              color: AppColors.darkGreen,
+                                            ),
+                                          ),
+                                        ],
                                       ),
-                                      const Text(
-                                        't de CO',
-                                        style: TextStyle(
-                                          fontFamily: 'Figtree',
-                                          fontWeight: FontWeight.w500,
-                                          fontSize: 18,
-                                          color: AppColors.darkGreen,
-                                        ),
-                                      ),
-                                      const Text(
-                                        '₂',
-                                        style: TextStyle(
-                                          fontFamily: 'Figtree',
-                                          fontSize: 12,
-                                          color: AppColors.darkGreen,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: 4),
-                                  const Text(
-                                    'poupadas com a Ragro',
-                                    style: TextStyle(
-                                      fontFamily: 'Figtree',
-                                      fontSize: 13,
-                                      color: Color(0xFF64748B),
                                     ),
-                                  ),
-                                ],
+                                    const SizedBox(height: 4),
+                                    const Text(
+                                      'poupadas com a Ragro',
+                                      style: TextStyle(
+                                        fontFamily: 'Figtree',
+                                        fontSize: 13,
+                                        color: Color(0xFF64748B),
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ],
                           ),
@@ -233,7 +247,7 @@ class _ImpactDetailPageState extends State<ImpactDetailPage> {
                         ),
                         const SizedBox(height: 16),
 
-                        IntrinsicHeight(
+                        const IntrinsicHeight(
                           child: Row(
                             crossAxisAlignment: CrossAxisAlignment.stretch,
                             children: [
@@ -245,7 +259,7 @@ class _ImpactDetailPageState extends State<ImpactDetailPage> {
                                       'Conectamos você a produtores da sua região',
                                 ),
                               ),
-                              const SizedBox(width: 10),
+                              SizedBox(width: 10),
                               Expanded(
                                 child: _ImpactCard(
                                   icon: Icons.local_shipping_outlined,
@@ -254,7 +268,7 @@ class _ImpactDetailPageState extends State<ImpactDetailPage> {
                                       'Menor distância, menos emissões',
                                 ),
                               ),
-                              const SizedBox(width: 10),
+                              SizedBox(width: 10),
                               Expanded(
                                 child: _ImpactCard(
                                   icon: Icons.eco_outlined,
@@ -268,6 +282,28 @@ class _ImpactDetailPageState extends State<ImpactDetailPage> {
                         ),
 
                         const SizedBox(height: 36),
+
+                        if (_emissions.isNotEmpty) ...[
+                          const Text(
+                            'Seus trajetos',
+                            style: TextStyle(
+                              fontFamily: 'Figtree',
+                              fontWeight: FontWeight.w700,
+                              fontSize: 16,
+                              color: AppColors.darkGreen,
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          ListView.separated(
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            itemCount: _emissions.length,
+                            separatorBuilder: (_, __) =>
+                                const SizedBox(height: 8),
+                            itemBuilder: (_, i) => _EmissionTile(_emissions[i]),
+                          ),
+                          const SizedBox(height: 36),
+                        ],
 
                         const Text(
                           'Nosso impacto juntos',
@@ -429,6 +465,115 @@ class _ImpactDetailPageState extends State<ImpactDetailPage> {
                 ),
               ],
             ),
+    );
+  }
+}
+
+class _EmissionTile extends StatelessWidget {
+  const _EmissionTile(this.record);
+
+  final Co2EmissionRecord record;
+
+  static const _vehicleLabels = {
+    'MOTORCYCLE': 'Moto',
+    'CAR': 'Carro',
+    'VAN': 'Van',
+    'LIGHT_TRUCK': 'Caminhão leve',
+  };
+
+  static const _vehicleIcons = {
+    'MOTORCYCLE': Icons.two_wheeler,
+    'CAR': Icons.directions_car_outlined,
+    'VAN': Icons.airport_shuttle_outlined,
+    'LIGHT_TRUCK': Icons.local_shipping_outlined,
+  };
+
+  static const _fuelLabels = {
+    'GASOLINE': 'Gasolina',
+    'ETHANOL': 'Etanol',
+    'DIESEL': 'Diesel',
+    'ELECTRIC': 'Elétrico',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final date = DateFormat('dd/MM/yyyy').format(record.createdAt.toLocal());
+    final vehicleLabel =
+        _vehicleLabels[record.vehicleType] ?? record.vehicleType;
+    final fuelLabel = _fuelLabels[record.fuelType] ?? record.fuelType;
+    final icon =
+        _vehicleIcons[record.vehicleType] ?? Icons.directions_car_outlined;
+    final emissionKg = record.co2Emission.toStringAsFixed(2);
+    final distanceKm = record.routeDistanceKm.toStringAsFixed(1);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 44,
+            height: 44,
+            decoration: const BoxDecoration(
+              color: _kIconBg,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(icon, color: AppColors.darkGreen, size: 22),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '$vehicleLabel · $fuelLabel',
+                  style: const TextStyle(
+                    fontFamily: 'Figtree',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    color: AppColors.darkGreen,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '$distanceKm km · $date',
+                  style: const TextStyle(
+                    fontFamily: 'Figtree',
+                    fontSize: 12,
+                    color: Color(0xFF64748B),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '$emissionKg kg',
+                style: const TextStyle(
+                  fontFamily: 'Figtree',
+                  fontWeight: FontWeight.w700,
+                  fontSize: 14,
+                  color: AppColors.darkGreen,
+                ),
+              ),
+              const Text(
+                'CO₂',
+                style: TextStyle(
+                  fontFamily: 'Figtree',
+                  fontSize: 11,
+                  color: Color(0xFF64748B),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/producer_orders/data/models/co2_response_model.dart
+++ b/lib/features/producer_orders/data/models/co2_response_model.dart
@@ -27,10 +27,49 @@ class Co2CalculationResponse extends Equatable {
 
   @override
   List<Object?> get props => [
-        co2Emission,
-        distanceKm,
-        vehicleType,
-        fuelType,
-        averageConsumption,
-      ];
+    co2Emission,
+    distanceKm,
+    vehicleType,
+    fuelType,
+    averageConsumption,
+  ];
+}
+
+class Co2EmissionRecord extends Equatable {
+  const Co2EmissionRecord({
+    required this.id,
+    required this.routeDistanceKm,
+    required this.co2Emission,
+    required this.vehicleType,
+    required this.fuelType,
+    required this.createdAt,
+  });
+
+  factory Co2EmissionRecord.fromJson(Map<String, dynamic> json) {
+    return Co2EmissionRecord(
+      id: json['id'] as String,
+      routeDistanceKm: (json['routeDistanceKm'] as num).toDouble(),
+      co2Emission: (json['co2Emission'] as num).toDouble(),
+      vehicleType: json['vehicleType'] as String,
+      fuelType: json['fuelType'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  final String id;
+  final double routeDistanceKm;
+  final double co2Emission;
+  final String vehicleType;
+  final String fuelType;
+  final DateTime createdAt;
+
+  @override
+  List<Object?> get props => [
+    id,
+    routeDistanceKm,
+    co2Emission,
+    vehicleType,
+    fuelType,
+    createdAt,
+  ];
 }


### PR DESCRIPTION
## Summary

- Adds a **"Seus trajetos"** section to the Impact Detail page listing the authenticated user's past route emissions
- Each tile shows vehicle type, fuel type, distance (km), date, and CO₂ emitted (kg)
- Section is hidden when the user has no recorded routes
- Fixes a build failure caused by a stale `injection.config.dart` that was missing the `ConfirmProducerDeliveryWithCode` binding
- Fixes a layout overflow on the CO₂ savings card (wrapped text column in `Expanded` + `FittedBox`)
<img width="640" height="584" alt="image" src="https://github.com/user-attachments/assets/6922a0f3-2868-4d76-8f1d-62bd05691b2b" />

## Changed files

| File | Change |
|---|---|
| `lib/core/network/api_endpoints.dart` | Added `co2Emissions` endpoint (`GET /co2/emissions`) |
| `lib/features/producer_orders/data/models/co2_response_model.dart` | Added `Co2EmissionRecord` model |
| `lib/features/impact/presentation/pages/impact_detail_page.dart` | Fetches emissions in parallel, renders timeline, fixes overflow |
| `lib/core/di/injection.config.dart` | Regenerated — adds missing `ConfirmProducerDeliveryWithCode` |

## Test plan

- [ ] Log in as `customer@ragro.com.br` / `Test@123` against a local backend
- [ ] Tap **"Entender o impacto"** on the impact overview screen
- [ ] Confirm **"Seus trajetos"** section appears with route tiles (requires at least one `co2_emissions` row in the DB for that user)
- [ ] Confirm section is absent when no emission records exist for the user
- [ ] Confirm no layout overflow on the CO₂ savings card at the top
- [ ] Confirm the app builds on iOS without the `ProducerOrderDetailBloc` constructor arity error

## Screenshot
<!-- Add simulator screenshot here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CO₂ emission details display with individual route records showing date, vehicle type, fuel type, distance, and emission amount.
  * New "Seus trajetos" section displaying your emission history.
  * Improved spacing in the impact details page layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->