### PR TITLE
fix: manter o consumidor no marketplace ao adicionar produto

### DIFF
--- a/lib/features/home/presentation/pages/customer_home_page.dart
+++ b/lib/features/home/presentation/pages/customer_home_page.dart
@@ -138,7 +138,6 @@ class _CustomerHomeViewState extends State<_CustomerHomeView> {
                                     quantity: 1,
                                   ),
                                 );
-                                context.push('/customer/cart');
                               },
                             ),
                           ),

--- a/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
+++ b/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
@@ -424,7 +424,6 @@ class _ProducerPublicProfileViewState
                                           quantity: 1,
                                         ),
                                       );
-                                      context.push('/customer/cart');
                                     },
                                   );
                                 },

--- a/lib/features/product_detail/presentation/pages/product_detail_page.dart
+++ b/lib/features/product_detail/presentation/pages/product_detail_page.dart
@@ -325,7 +325,6 @@ class _ProductDetailView extends StatelessWidget {
                                 quantity: quantity.toDouble(),
                               ),
                             );
-                            context.push('/customer/cart');
                           },
                           child: Container(
                             height: 53,

--- a/lib/features/search/presentation/pages/search_result_page.dart
+++ b/lib/features/search/presentation/pages/search_result_page.dart
@@ -327,7 +327,6 @@ class _SearchResultsViewState extends State<_SearchResultsView> {
   void _onAddToCart(SearchResult result) {
     if (result.type != SearchResultType.product) return;
     getIt<CartBloc>().add(CartItemAdded(productId: result.id, quantity: 1));
-    context.push('/customer/cart');
   }
 
   String? _resolveProducerId(SearchResult result) {


### PR DESCRIPTION
## What changed?

- Removido o redirecionamento automático para o carrinho após adicionar um produto.
- O consumidor permanece na tela atual do marketplace.
- O carrinho continua sendo atualizado pelo `CartBloc`.
- A barra verde inferior continua disponível para o usuário acessar o carrinho quando desejar.
- Comportamento ajustado na tela inicial, resultados da busca, perfil público do produtor e detalhes do produto.

> Reabertura do #430 na direção correta (base `develop`, head `fix/keep-customer-on-marketplace-add`). O #430 estava com base/head invertidos e arrastava 44 commits já mergeados. Este PR contém apenas o fix real: 4 linhas removidas.

## Type of change

- [x] Bug fix

## How to test?

1. Adicionar um produto pela tela inicial, busca, perfil do produtor e detalhes do produto.
2. Confirmar que o usuário permanece na tela atual (sem ir para o carrinho).
3. Confirmar que a barra verde do carrinho é exibida/atualizada e abre o carrinho ao tocar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed automatic navigation to cart page when adding items from product grid, product details, search results, and producer profiles. Users can now continue shopping without forced redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->