### PR TITLE
fix: corrige botão Salvar Alterações na edição de perfil do consumidor

### DIFF
--- a/lib/features/customer_profile/presentation/pages/customer_edit_profile_page.dart
+++ b/lib/features/customer_profile/presentation/pages/customer_edit_profile_page.dart
@@ -283,12 +283,12 @@ class _CustomerEditProfilePageState extends State<CustomerEditProfilePage> {
                                           const Icon(
                                             Icons.save_outlined,
                                             color: AppColors.white,
-                                            size: 18,
+                                            size: 22,
                                           ),
                                           const SizedBox(width: 8),
                                         ],
                                         const Text(
-                                          'Salvar Alteracoes',
+                                          'Salvar Alterações',
                                           style: TextStyle(
                                             fontFamily: 'Figtree',
                                             fontWeight: FontWeight.w700,


### PR DESCRIPTION
## What changed?

- Corrigido o texto do botão de salvar na tela de edição de perfil do consumidor de `Salvar Alteracoes` para `Salvar Alterações`.
- Ajustado o tamanho do ícone de salvar (18 → 22) para ficar proporcional ao botão.

> Reabertura do #426 na direção correta (base `develop`, head `fix/customer-edit-profile-save-button`). O #426 estava com base/head invertidos e arrastava 44 commits já mergeados. Este PR contém apenas o fix real: 1 arquivo, +2/−2.

## Type of change

- [x] Bug fix

## How to test?

1. Acessar o fluxo do consumidor → perfil → editar perfil.
2. Verificar que o botão principal exibe `Salvar Alterações`.
3. Verificar que o ícone de salvar está proporcional ao texto e ao botão.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spelling error in the customer profile save button label, now displaying with correct Portuguese accents
  * Improved save button icon visibility by increasing its size

<!-- end of auto-generated comment: release notes by coderabbit.ai -->