### PR TITLE
fix: sprint 4 + alerta codigo

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -196,6 +196,8 @@ import 'package:ragro_mobile/features/orders/domain/usecases/get_customer_order_
     as _i961;
 import 'package:ragro_mobile/features/orders/domain/usecases/get_orders.dart'
     as _i52;
+import 'package:ragro_mobile/features/orders/presentation/bloc/active_delivery_cubit.dart'
+    as _i981;
 import 'package:ragro_mobile/features/orders/presentation/bloc/checkout_bloc.dart'
     as _i463;
 import 'package:ragro_mobile/features/orders/presentation/bloc/order_detail_bloc.dart'
@@ -683,6 +685,9 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i1038.UpdateProducerOrderStatus(
         gh<_i649.ProducerOrdersRepository>(),
       ),
+    );
+    gh.lazySingleton<_i981.ActiveDeliveryCubit>(
+      () => _i981.ActiveDeliveryCubit(gh<_i52.GetOrders>()),
     );
     gh.factory<_i226.OrdersBloc>(() => _i226.OrdersBloc(gh<_i52.GetOrders>()));
     gh.factory<_i1.ProducerOrdersBloc>(

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -511,7 +511,7 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i485.RequestPasswordReset>(
       () => _i485.RequestPasswordReset(gh<_i43.AuthRepository>()),
     );
-    gh.factory<_i205.InventoryBloc>(
+    gh.lazySingleton<_i205.InventoryBloc>(
       () => _i205.InventoryBloc(
         gh<_i252.GetInventoryProducts>(),
         gh<_i481.DeleteInventoryProduct>(),

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -5,8 +5,42 @@
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ragro_mobile/core/di/injection.config.dart';
+import 'package:ragro_mobile/features/cart/presentation/bloc/cart_bloc.dart';
+import 'package:ragro_mobile/features/home/presentation/bloc/home_bloc.dart';
+import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_bloc.dart';
+import 'package:ragro_mobile/features/orders/presentation/bloc/active_delivery_cubit.dart';
+import 'package:ragro_mobile/features/producer_management/presentation/bloc/producer_management_bloc.dart';
 
 final getIt = GetIt.instance;
 
 @InjectableInit()
 Future<void> configureDependencies() => getIt.init();
+
+/// Reseta os singletons que guardam dados da sessão do usuário, para que um
+/// próximo login não exiba (nem por um frame) dados do usuário anterior.
+///
+/// Cobre os blocs/cubits `@lazySingleton` providos por shell/página (re-lidos do
+/// get_it no próximo login). NÃO inclui:
+/// - factories (Orders/CustomerProfile/Recommendations): instância nova a cada uso;
+/// - NotificationsBloc: é segurado na raiz (app.dart) por toda a vida do app e
+///   já é limpo via evento `NotificationsReset` no logout — um reset no get_it
+///   deixaria a referência da raiz dessincronizada.
+///
+/// Reset SEM fechar de propósito: as instâncias antigas ainda podem estar
+/// montadas no IndexedStack do shell no momento do logout; o get_it passa a
+/// criar instâncias novas (estado inicial) no próximo acesso.
+void resetSessionScopedBlocs() {
+  // Guardado por isRegistered para não quebrar em testes que não rodam o
+  // configureDependencies completo.
+  _resetIfRegistered<HomeBloc>();
+  _resetIfRegistered<CartBloc>();
+  _resetIfRegistered<ProducerManagementBloc>();
+  _resetIfRegistered<InventoryBloc>();
+  _resetIfRegistered<ActiveDeliveryCubit>();
+}
+
+void _resetIfRegistered<T extends Object>() {
+  if (getIt.isRegistered<T>()) {
+    getIt.resetLazySingleton<T>();
+  }
+}

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -242,6 +242,11 @@ class AppRouter {
           routes: [
             GoRoute(
               path: 'detail',
+              // Sem a notificação no `extra` (ex.: deep link / refresh da URL no
+              // web) não há o que exibir — volta para a lista em vez de quebrar.
+              redirect: (_, state) => state.extra is AppNotificationEntity
+                  ? null
+                  : '/customer/notifications',
               builder: (_, state) => NotificationDetailPage(
                 notification: state.extra! as AppNotificationEntity,
               ),
@@ -418,6 +423,11 @@ class AppRouter {
           routes: [
             GoRoute(
               path: 'detail',
+              // Sem a notificação no `extra` (ex.: deep link / refresh da URL no
+              // web) não há o que exibir — volta para a lista em vez de quebrar.
+              redirect: (_, state) => state.extra is AppNotificationEntity
+                  ? null
+                  : '/producer/notifications',
               builder: (_, state) => NotificationDetailPage(
                 notification: state.extra! as AppNotificationEntity,
               ),

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -30,6 +30,8 @@ import 'package:ragro_mobile/features/inventory/presentation/pages/stock_entry_p
 import 'package:ragro_mobile/features/inventory/presentation/pages/stock_exit_page.dart';
 import 'package:ragro_mobile/features/inventory/presentation/pages/stock_movements_page.dart';
 import 'package:ragro_mobile/features/map/presentation/pages/map_page.dart';
+import 'package:ragro_mobile/features/notifications/domain/entities/notification.dart';
+import 'package:ragro_mobile/features/notifications/presentation/pages/notification_detail_page.dart';
 import 'package:ragro_mobile/features/notifications/presentation/pages/notifications_page.dart';
 import 'package:ragro_mobile/features/orders/presentation/pages/customer_orders_page.dart';
 import 'package:ragro_mobile/features/orders/presentation/pages/order_confirmation_page.dart';
@@ -237,6 +239,14 @@ class AppRouter {
         GoRoute(
           path: '/customer/notifications',
           builder: (_, __) => const NotificationsPage(),
+          routes: [
+            GoRoute(
+              path: 'detail',
+              builder: (_, state) => NotificationDetailPage(
+                notification: state.extra! as AppNotificationEntity,
+              ),
+            ),
+          ],
         ),
 
         // Cart & Checkout routes
@@ -374,6 +384,10 @@ class AppRouter {
                       builder: (_, __) => const ProducerSettingsPage(),
                     ),
                     GoRoute(
+                      path: 'faq',
+                      builder: (_, __) => const FaqPage(),
+                    ),
+                    GoRoute(
                       path: 'reviews',
                       builder: (context, state) {
                         final extra =
@@ -401,6 +415,14 @@ class AppRouter {
         GoRoute(
           path: '/producer/notifications',
           builder: (_, __) => const NotificationsPage(),
+          routes: [
+            GoRoute(
+              path: 'detail',
+              builder: (_, state) => NotificationDetailPage(
+                notification: state.extra! as AppNotificationEntity,
+              ),
+            ),
+          ],
         ),
 
         // Admin routes

--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/network/api_exception.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/get_current_user.dart';
 import 'package:ragro_mobile/features/auth/domain/usecases/logout.dart';
@@ -41,6 +42,9 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       // Logout failure (e.g. local storage error) — still clear local session
       // and unauthenticate the user in-memory.
     }
+    // Descarta blocs de sessão para o próximo login começar do zero (sem expor
+    // dados do usuário anterior). Ver [resetSessionScopedBlocs].
+    resetSessionScopedBlocs();
     emit(const AuthUnauthenticated());
   }
 

--- a/lib/features/auth/presentation/widgets/login_form.dart
+++ b/lib/features/auth/presentation/widgets/login_form.dart
@@ -8,6 +8,7 @@ import 'package:ragro_mobile/features/auth/presentation/bloc/login_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/login_state.dart';
 import 'package:ragro_mobile/features/auth/presentation/widgets/auth_submit_button.dart';
 import 'package:ragro_mobile/features/auth/presentation/widgets/auth_text_field.dart';
+import 'package:ragro_mobile/shared/widgets/terms_of_use_dialog.dart';
 
 /// Login form: email/password fields, submit button, and recovery/registration
 /// links. Requires a [LoginBloc] ancestor in the widget tree.
@@ -137,6 +138,19 @@ class _LoginFormState extends State<LoginForm> {
               ),
             ),
           ],
+          const SizedBox(height: 16),
+          Center(
+            child: GestureDetector(
+              onTap: () => showTermsOfUseDialog(context),
+              child: Text(
+                'Termos de Uso',
+                style: AppTextStyles.caption.copyWith(
+                  color: AppColors.darkGreen,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/features/home/presentation/pages/customer_home_page.dart
+++ b/lib/features/home/presentation/pages/customer_home_page.dart
@@ -11,6 +11,8 @@ import 'package:ragro_mobile/features/home/presentation/bloc/home_event.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_state.dart';
 import 'package:ragro_mobile/features/home/presentation/widgets/producers_section.dart';
 import 'package:ragro_mobile/features/home/presentation/widgets/products_grid.dart';
+import 'package:ragro_mobile/features/orders/presentation/bloc/active_delivery_cubit.dart';
+import 'package:ragro_mobile/features/orders/presentation/widgets/active_delivery_banner.dart';
 import 'package:ragro_mobile/features/recommendations/domain/entities/recommendation.dart';
 import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_bloc.dart';
 import 'package:ragro_mobile/features/recommendations/presentation/bloc/recommendations_event.dart';
@@ -29,6 +31,7 @@ class CustomerHomePage extends StatelessWidget {
           create: (_) =>
               getIt<RecommendationsBloc>()..add(const RecommendationsStarted()),
         ),
+        BlocProvider.value(value: getIt<ActiveDeliveryCubit>()),
       ],
       child: const _CustomerHomeView(),
     );
@@ -49,6 +52,9 @@ class _CustomerHomeViewState extends State<_CustomerHomeView> {
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
+    // Carrega o pedido a caminho (banner do topo). Recarregado no pull-to-refresh
+    // e ao reabrir a aba Início (CustomerShell).
+    context.read<ActiveDeliveryCubit>().load();
   }
 
   @override
@@ -94,6 +100,7 @@ class _CustomerHomeViewState extends State<_CustomerHomeView> {
                         context.read<RecommendationsBloc>().add(
                           const RecommendationsRefreshRequested(),
                         );
+                        await context.read<ActiveDeliveryCubit>().load();
                       },
                       child: CustomScrollView(
                         controller: _scrollController,
@@ -119,6 +126,7 @@ class _CustomerHomeViewState extends State<_CustomerHomeView> {
                               ),
                             ),
                           ),
+                          const SliverToBoxAdapter(child: ActiveDeliveryBanner()),
                           const SliverToBoxAdapter(child: SizedBox(height: 24)),
                           SliverToBoxAdapter(
                             child: ProducersSection(

--- a/lib/features/inventory/presentation/bloc/inventory_bloc.dart
+++ b/lib/features/inventory/presentation/bloc/inventory_bloc.dart
@@ -6,7 +6,7 @@ import 'package:ragro_mobile/features/inventory/domain/usecases/get_inventory_pr
 import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_event.dart';
 import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_state.dart';
 
-@injectable
+@lazySingleton
 class InventoryBloc extends Bloc<InventoryEvent, InventoryState> {
   InventoryBloc(this._getProducts, this._deleteProduct)
     : super(const InventoryInitial()) {

--- a/lib/features/inventory/presentation/pages/inventory_page.dart
+++ b/lib/features/inventory/presentation/pages/inventory_page.dart
@@ -16,11 +16,39 @@ class InventoryPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => getIt<InventoryBloc>()..add(const InventoryStarted()),
-      child: const _InventoryView(),
+    // Bloc is a singleton (see InventoryBloc): the shell triggers a refresh when
+    // the Estoque tab is reopened. Here we only provide the value; the loader
+    // handles the initial load.
+    return BlocProvider.value(
+      value: getIt<InventoryBloc>(),
+      child: const _InventoryLoader(),
     );
   }
+}
+
+class _InventoryLoader extends StatefulWidget {
+  const _InventoryLoader();
+
+  @override
+  State<_InventoryLoader> createState() => _InventoryLoaderState();
+}
+
+class _InventoryLoaderState extends State<_InventoryLoader> {
+  @override
+  void initState() {
+    super.initState();
+    final bloc = context.read<InventoryBloc>();
+    // First ever mount → load. Re-mount on a fresh session (singleton survived a
+    // previous login) → refresh, so stale data from another user never shows.
+    if (bloc.state is InventoryInitial) {
+      bloc.add(const InventoryStarted());
+    } else {
+      bloc.add(const InventoryRefreshed());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => const _InventoryView();
 }
 
 class _InventoryView extends StatelessWidget {

--- a/lib/features/inventory/presentation/pages/product_form_page.dart
+++ b/lib/features/inventory/presentation/pages/product_form_page.dart
@@ -175,7 +175,7 @@ class _ProductFormViewState extends State<_ProductFormView> {
               backgroundColor: AppColors.darkGreen,
             ),
           );
-          context.pop();
+          context.pop(true);
         }
         if (state is ProductFormFailure) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/notifications/presentation/pages/notification_detail_page.dart
+++ b/lib/features/notifications/presentation/pages/notification_detail_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/notifications/domain/entities/notification.dart';
+
+/// Tela de detalhe de uma notificação. Mostra título, mensagem completa (sem
+/// truncar como na lista) e a data formatada, com botão de voltar. Responsiva:
+/// o conteúdo é limitado a uma largura máxima em telas grandes.
+class NotificationDetailPage extends StatelessWidget {
+  const NotificationDetailPage({required this.notification, super.key});
+
+  final AppNotificationEntity notification;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      appBar: AppBar(
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        leading: const BackButton(color: AppColors.darkGreen),
+        title: const Text(
+          'Notificação',
+          style: TextStyle(
+            fontFamily: 'Figtree',
+            fontWeight: FontWeight.w700,
+            fontSize: 18,
+            color: AppColors.black,
+          ),
+        ),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _formatDate(notification.createdAt),
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w400,
+                      fontSize: 12,
+                      color: Color(0xFF9EB3C8),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    notification.title,
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w800,
+                      fontSize: 22,
+                      color: AppColors.black,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  SelectableText(
+                    notification.message,
+                    style: const TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w400,
+                      fontSize: 16,
+                      height: 1.5,
+                      color: AppColors.black,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return DateFormat("dd/MM/yyyy 'às' HH:mm").format(date.toLocal());
+  }
+}

--- a/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
 import 'package:ragro_mobile/features/notifications/domain/entities/notification.dart';
@@ -373,11 +374,18 @@ class _NotificationTile extends StatelessWidget {
       borderRadius: BorderRadius.circular(6),
       child: InkWell(
         borderRadius: BorderRadius.circular(6),
-        onTap: read
-            ? null
-            : () => context.read<NotificationsBloc>().add(
-                NotificationMarkedAsRead(notification.id),
-              ),
+        onTap: () {
+          if (!read) {
+            context.read<NotificationsBloc>().add(
+              NotificationMarkedAsRead(notification.id),
+            );
+          }
+          final base =
+              GoRouterState.of(context).matchedLocation.startsWith('/producer')
+              ? '/producer'
+              : '/customer';
+          context.push('$base/notifications/detail', extra: notification);
+        },
         child: Container(
           constraints: const BoxConstraints(minHeight: 62),
           padding: const EdgeInsets.fromLTRB(14, 11, 12, 10),

--- a/lib/features/orders/data/models/order_model.dart
+++ b/lib/features/orders/data/models/order_model.dart
@@ -18,6 +18,7 @@ class OrderModel extends Order {
     required super.deliveryAddress,
     required super.bankInfo,
     super.avaliado,
+    super.confirmationCode,
   });
 
   factory OrderModel.fromJson(Map<String, dynamic> json) {
@@ -75,6 +76,7 @@ class OrderModel extends Order {
       deliveryAddress: _parseAddress(addressJson),
       bankInfo: _parseBankInfo(bankJson),
       avaliado: _parseRated(json),
+      confirmationCode: json['confirmationCode'] as String?,
     );
   }
 

--- a/lib/features/orders/domain/entities/order.dart
+++ b/lib/features/orders/domain/entities/order.dart
@@ -57,6 +57,7 @@ class Order extends Equatable {
     required this.deliveryAddress,
     required this.bankInfo,
     this.avaliado = false,
+    this.confirmationCode,
   });
 
   final String id;
@@ -73,6 +74,10 @@ class Order extends Equatable {
   final ProducerBankInfo bankInfo;
   final bool avaliado;
 
+  /// Código de confirmação de entrega. O backend só o expõe enquanto o pedido
+  /// está IN_DELIVERY (a caminho); nos demais estados vem nulo.
+  final String? confirmationCode;
+
   Order copyWith({
     String? id,
     String? producerId,
@@ -87,6 +92,7 @@ class Order extends Equatable {
     DeliveryAddress? deliveryAddress,
     ProducerBankInfo? bankInfo,
     bool? avaliado,
+    String? confirmationCode,
   }) {
     return Order(
       id: id ?? this.id,
@@ -102,6 +108,7 @@ class Order extends Equatable {
       deliveryAddress: deliveryAddress ?? this.deliveryAddress,
       bankInfo: bankInfo ?? this.bankInfo,
       avaliado: avaliado ?? this.avaliado,
+      confirmationCode: confirmationCode ?? this.confirmationCode,
     );
   }
 
@@ -137,5 +144,6 @@ class Order extends Equatable {
     deliveryAddress,
     bankInfo,
     avaliado,
+    confirmationCode,
   ];
 }

--- a/lib/features/orders/presentation/bloc/active_delivery_cubit.dart
+++ b/lib/features/orders/presentation/bloc/active_delivery_cubit.dart
@@ -1,0 +1,55 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart' hide Order;
+import 'package:ragro_mobile/features/orders/domain/entities/order.dart';
+import 'package:ragro_mobile/features/orders/domain/entities/order_status.dart';
+import 'package:ragro_mobile/features/orders/domain/usecases/get_orders.dart';
+
+sealed class ActiveDeliveryState extends Equatable {
+  const ActiveDeliveryState();
+  @override
+  List<Object?> get props => [];
+}
+
+/// Nenhum pedido a caminho (ou ainda não carregado) — o banner fica escondido.
+class ActiveDeliveryNone extends ActiveDeliveryState {
+  const ActiveDeliveryNone();
+}
+
+/// Há um pedido a caminho com código de confirmação para exibir no banner.
+class ActiveDeliveryAvailable extends ActiveDeliveryState {
+  const ActiveDeliveryAvailable(this.order);
+  final Order order;
+  @override
+  List<Object?> get props => [order];
+}
+
+/// Cubit do banner "seu pedido está a caminho" na home do consumidor.
+/// Reusa [GetOrders] filtrando por IN_DELIVERY; o backend já devolve o
+/// `confirmationCode` apenas nesse estado. Falhas são silenciosas (banner some).
+@lazySingleton
+class ActiveDeliveryCubit extends Cubit<ActiveDeliveryState> {
+  ActiveDeliveryCubit(this._getOrders) : super(const ActiveDeliveryNone());
+
+  final GetOrders _getOrders;
+
+  Future<void> load() async {
+    try {
+      final orders = await _getOrders(status: OrderStatus.inDelivery);
+      final active = orders
+          .where(
+            (o) =>
+                o.status == OrderStatus.inDelivery &&
+                (o.confirmationCode?.isNotEmpty ?? false),
+          )
+          .toList();
+      emit(
+        active.isEmpty
+            ? const ActiveDeliveryNone()
+            : ActiveDeliveryAvailable(active.first),
+      );
+    } on Exception {
+      emit(const ActiveDeliveryNone());
+    }
+  }
+}

--- a/lib/features/orders/presentation/widgets/active_delivery_banner.dart
+++ b/lib/features/orders/presentation/widgets/active_delivery_banner.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/orders/presentation/bloc/active_delivery_cubit.dart';
+
+/// Banner no topo da home do consumidor (estilo iFood/Uber Eats): aparece
+/// quando há um pedido a caminho, mostrando o código de confirmação que o
+/// cliente deve informar ao produtor. Toque abre o detalhe do pedido.
+class ActiveDeliveryBanner extends StatelessWidget {
+  const ActiveDeliveryBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ActiveDeliveryCubit, ActiveDeliveryState>(
+      builder: (context, state) {
+        if (state is! ActiveDeliveryAvailable) return const SizedBox.shrink();
+        final order = state.order;
+        final code = order.confirmationCode ?? '';
+
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: Material(
+            color: AppColors.darkGreen,
+            borderRadius: BorderRadius.circular(20),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(20),
+              onTap: () => context.push('/customer/orders/${order.id}'),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 44,
+                      height: 44,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Icon(
+                        Icons.local_shipping_outlined,
+                        color: AppColors.white,
+                        size: 24,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  'Seu pedido está a caminho',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    fontFamily: 'Figtree',
+                                    fontWeight: FontWeight.w800,
+                                    fontSize: 15,
+                                    color: AppColors.white,
+                                  ),
+                                ),
+                              ),
+                              Icon(
+                                Icons.chevron_right,
+                                color: AppColors.white,
+                                size: 20,
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            order.farmName.isEmpty
+                                ? 'Toque para acompanhar a entrega'
+                                : '${order.farmName} • toque para acompanhar',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontFamily: 'Manrope',
+                              fontWeight: FontWeight.w500,
+                              fontSize: 12,
+                              color: Colors.white.withValues(alpha: 0.85),
+                            ),
+                          ),
+                          const SizedBox(height: 10),
+                          DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: AppColors.white,
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 6,
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Text(
+                                    'Código de entrega',
+                                    style: TextStyle(
+                                      fontFamily: 'Manrope',
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 12,
+                                      color: AppColors.placeholder,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    code,
+                                    style: const TextStyle(
+                                      fontFamily: 'Manrope',
+                                      fontWeight: FontWeight.w800,
+                                      fontSize: 16,
+                                      letterSpacing: 3,
+                                      color: AppColors.darkGreen,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/producer_management/presentation/pages/producer_settings_page.dart
+++ b/lib/features/producer_management/presentation/pages/producer_settings_page.dart
@@ -8,6 +8,7 @@ import 'package:ragro_mobile/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_event.dart';
 import 'package:ragro_mobile/features/auth/presentation/bloc/auth_state.dart';
 import 'package:ragro_mobile/shared/widgets/app_notification.dart';
+import 'package:ragro_mobile/shared/widgets/terms_of_use_dialog.dart';
 
 class ProducerSettingsPage extends StatelessWidget {
   const ProducerSettingsPage({super.key});
@@ -101,6 +102,52 @@ class ProducerSettingsPage extends StatelessWidget {
                       ),
                     );
                   },
+                ),
+                const Divider(height: 1, color: Color(0xFFE2E8F0)),
+                ListTile(
+                  onTap: () => showTermsOfUseDialog(context),
+                  leading: const Icon(
+                    Icons.help_outline,
+                    color: AppColors.black,
+                    size: 20,
+                  ),
+                  title: const Text(
+                    'Termos de uso',
+                    style: TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w500,
+                      fontSize: 16,
+                      color: AppColors.black,
+                    ),
+                  ),
+                  trailing: const Icon(
+                    Icons.chevron_right,
+                    color: AppColors.placeholder,
+                    size: 20,
+                  ),
+                ),
+                const Divider(height: 1, color: Color(0xFFE2E8F0)),
+                ListTile(
+                  onTap: () => context.push('/producer/profile/faq'),
+                  leading: const Icon(
+                    Icons.quiz_outlined,
+                    color: AppColors.black,
+                    size: 20,
+                  ),
+                  title: const Text(
+                    'FAQ',
+                    style: TextStyle(
+                      fontFamily: 'Figtree',
+                      fontWeight: FontWeight.w500,
+                      fontSize: 16,
+                      color: AppColors.black,
+                    ),
+                  ),
+                  trailing: const Icon(
+                    Icons.chevron_right,
+                    color: AppColors.placeholder,
+                    size: 20,
+                  ),
                 ),
                 const Divider(height: 1, color: Color(0xFFE2E8F0)),
                 ListTile(

--- a/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_order_detail_page.dart
@@ -811,6 +811,7 @@ class _ActionFooter extends StatelessWidget {
                               );
                               return _waitForBlocConfirmation(bloc);
                             },
+                            onCancelOrder: () => _confirmRefuse(context),
                           ),
                         );
                         if (success ?? false) {

--- a/lib/features/producer_profile/domain/entities/public_producer.dart
+++ b/lib/features/producer_profile/domain/entities/public_producer.dart
@@ -136,19 +136,23 @@ class PublicProducer extends Equatable {
   final List<HomeProduct>? products;
   final List<Review>? reviews;
 
-  int? get yearsOnPlatform {
+  /// Tempo no RAGRO formatado: anos quando >= 1 ano, senão meses (mínimo
+  /// "1 mês" para quem acabou de entrar). Null quando não há data de adesão.
+  String? get membershipLabel {
     final memberSince = this.memberSince;
     if (memberSince == null) return null;
 
     final now = DateTime.now();
-    var years = now.year - memberSince.year;
-    final anniversaryThisYear = DateTime(
-      now.year,
-      memberSince.month,
-      memberSince.day,
-    );
-    if (now.isBefore(anniversaryThisYear)) years--;
-    return years;
+    var months =
+        (now.year - memberSince.year) * 12 + (now.month - memberSince.month);
+    if (now.day < memberSince.day) months--;
+    if (months < 1) months = 1;
+
+    if (months < 12) {
+      return months == 1 ? '1 mês' : '$months meses';
+    }
+    final years = months ~/ 12;
+    return years == 1 ? '1 ano' : '$years anos';
   }
 
   @override

--- a/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
+++ b/lib/features/producer_profile/presentation/pages/producer_public_profile_page.dart
@@ -377,7 +377,7 @@ class _ProducerPublicProfileViewState
                             ProducerStatsRow(
                               productCount: producer.products?.length ?? 0,
                               rating: producer.averageRating,
-                              yearsOnPlatform: producer.yearsOnPlatform,
+                              membershipLabel: producer.membershipLabel,
                             ),
                             const SizedBox(height: 20),
                             if ((producer.products ?? const []).isNotEmpty)

--- a/lib/features/producer_profile/presentation/widgets/producer_stats_row.dart
+++ b/lib/features/producer_profile/presentation/widgets/producer_stats_row.dart
@@ -5,13 +5,13 @@ class ProducerStatsRow extends StatelessWidget {
   const ProducerStatsRow({
     required this.productCount,
     required this.rating,
-    required this.yearsOnPlatform,
+    required this.membershipLabel,
     super.key,
   });
 
   final int productCount;
   final double rating;
-  final int? yearsOnPlatform;
+  final String? membershipLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -22,9 +22,7 @@ class ProducerStatsRow extends StatelessWidget {
         _StatCard(value: rating.toStringAsFixed(1), label: 'AVALIAÇÃO'),
         const SizedBox(width: 16),
         _StatCard(
-          value: yearsOnPlatform == null
-              ? '--'
-              : '${yearsOnPlatform! > 0 ? yearsOnPlatform : 1} anos',
+          value: membershipLabel ?? '--',
           label: 'DE RAGRO',
         ),
       ],

--- a/lib/shared/widgets/confirm_delivery_code_dialog.dart
+++ b/lib/shared/widgets/confirm_delivery_code_dialog.dart
@@ -5,10 +5,15 @@ import 'package:ragro_mobile/core/theme/app_colors.dart';
 class ConfirmDeliveryCodeDialog extends StatefulWidget {
   const ConfirmDeliveryCodeDialog({
     required this.onConfirm,
+    this.onCancelOrder,
     super.key,
   });
 
   final Future<bool> Function(String code) onConfirm;
+
+  /// Quando informado, exibe uma ação secundária "Cancelar pedido" abaixo dos
+  /// botões. Ao tocar, o modal fecha e este callback é chamado.
+  final VoidCallback? onCancelOrder;
 
   @override
   State<ConfirmDeliveryCodeDialog> createState() =>
@@ -229,6 +234,25 @@ class _ConfirmDeliveryCodeDialogState extends State<ConfirmDeliveryCodeDialog> {
                 ),
               ],
             ),
+            if (widget.onCancelOrder != null) ...[
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: _isLoading
+                    ? null
+                    : () {
+                        Navigator.of(context).pop(false);
+                        widget.onCancelOrder!();
+                      },
+                style: TextButton.styleFrom(foregroundColor: AppColors.red),
+                child: const Text(
+                  'Cancelar pedido',
+                  style: TextStyle(
+                    fontFamily: 'Manrope',
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/shared/widgets/customer_shell.dart
+++ b/lib/shared/widgets/customer_shell.dart
@@ -11,6 +11,7 @@ import 'package:ragro_mobile/features/cart/presentation/widgets/cart_summary_bar
 import 'package:ragro_mobile/features/home/presentation/bloc/home_bloc.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_event.dart';
 import 'package:ragro_mobile/features/home/presentation/bloc/home_state.dart';
+import 'package:ragro_mobile/features/orders/presentation/bloc/active_delivery_cubit.dart';
 import 'package:ragro_mobile/shared/widgets/app_notification.dart';
 
 class CustomerShell extends StatefulWidget {
@@ -143,6 +144,11 @@ class _CustomerShellState extends State<CustomerShell> {
       index,
       initialLocation: index == widget.navigationShell.currentIndex,
     );
+    // Início (0): recarrega o banner "pedido a caminho" ao reabrir a aba, para
+    // refletir um pedido que saiu para entrega sem precisar reabrir o app.
+    if (index == 0) {
+      getIt<ActiveDeliveryCubit>().load();
+    }
   }
 }
 

--- a/lib/shared/widgets/producer_shell.dart
+++ b/lib/shared/widgets/producer_shell.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_bloc.dart';
+import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_event.dart';
+import 'package:ragro_mobile/features/inventory/presentation/bloc/inventory_state.dart';
 import 'package:ragro_mobile/features/producer_management/presentation/bloc/producer_management_bloc.dart';
 import 'package:ragro_mobile/features/producer_management/presentation/bloc/producer_management_event.dart';
 import 'package:ragro_mobile/features/producer_management/presentation/bloc/producer_management_state.dart';
@@ -65,6 +68,14 @@ class ProducerShell extends StatelessWidget {
       index,
       initialLocation: index == navigationShell.currentIndex,
     );
+    // Stock tab (1): reload the inventory on reopen so stock changes show up
+    // without restarting the app. Initial load is handled by the page's loader.
+    if (index == 1) {
+      final bloc = getIt<InventoryBloc>();
+      if (bloc.state is! InventoryInitial) {
+        bloc.add(const InventoryRefreshed());
+      }
+    }
     // Profile tab (2): reload the dashboard on reopen so fresh data shows up
     // (e.g. after a delivery) without restarting the app. The initial load is
     // handled by the page's own loader.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -988,10 +988,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1377,26 +1377,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:

--- a/test/features/producer_profile/data/models/public_producer_model_test.dart
+++ b/test/features/producer_profile/data/models/public_producer_model_test.dart
@@ -88,7 +88,7 @@ void main() {
       final model = PublicProducerModel.fromJson(json);
 
       expect(model.memberSince, isNull);
-      expect(model.yearsOnPlatform, isNull);
+      expect(model.membershipLabel, isNull);
     });
 
     test('parseia resposta camelCase com photoUrl opcional', () {


### PR DESCRIPTION
x Estoque nao esta atualizando automaticamente quando adiciona produtos ou remove do estoque - So quando produtor/farmer entra e sai do aplicativo - Estoque vendido
x 1 ano de ragro  esta sendo exibido quando produtor recem cadastrou, menos de 1 ano colocar em mes. x
x No modal de confirmar entrega com codigo, aparecer cancelar pedido para produtor.
x Codigo de entrega aparecer como notificacao do consumidor tambem
x Termos de uso aparecer na pagina de login
x Termos de uso e FAQ aparecer no menu breadcrumb do produtor assim como de consumidor. 
x Ao clicar na notificacao deve expandir a notificacao em nova tela, nova funcionalidade responsiva (ter botao de voltar)

- Adicionar estilo ifood alerta pedido a caminho com o codigo no topo da home

<img width="412" height="869" alt="image" src="https://github.com/user-attachments/assets/786594c8-c037-46d8-8c34-6431fd81d27f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notification detail pages with safe deep-link handling and back-to-list redirects
  * Introduced an “order on the way” banner on the home screen with delivery tracking navigation
  * Added “Termos de Uso” links in login and producer settings, plus a producer FAQ page
  * Show delivery confirmation codes during delivery
* **Improvements**
  * Refreshed notification tap behavior to mark as read when needed and open details
  * Improved producer membership display (membership label instead of years-on-platform)
  * Added order cancellation option in the delivery confirmation dialog
* **Other**
  * Improved inventory reload and refresh behavior when reopening relevant tabs
  * On logout, session-scoped screen state is reset; success flows now return the expected result
<!-- end of auto-generated comment: release notes by coderabbit.ai -->