### PR TITLE
feat(rota): pedido novo via pull, refresh em tempo real, loading temático e UX

### DIFF
--- a/lib/core/navigation/orders_route_observer.dart
+++ b/lib/core/navigation/orders_route_observer.dart
@@ -5,3 +5,8 @@ import 'package:flutter/material.dart';
 /// (e.g. returning from OrderDetailPage to CustomerOrdersPage).
 final RouteObserver<ModalRoute<void>> ordersRouteObserver =
     RouteObserver<ModalRoute<void>>();
+
+/// Same idea for the producer shell-branch navigator: lets ProducerOrdersPage
+/// refresh when a sub-route (route screen / order detail) is popped back to it.
+final RouteObserver<ModalRoute<void>> producerRouteObserver =
+    RouteObserver<ModalRoute<void>>();

--- a/lib/core/network/api_endpoints.dart
+++ b/lib/core/network/api_endpoints.dart
@@ -117,6 +117,8 @@ abstract final class ApiEndpoints {
   // /routes/optimize replaced by the persisted route (route_repository).
   static String get routes => '$_base/routes';
   static String get activeRoute => '$_base/routes/active';
+  static String routeAddStops(String routeId) =>
+      '$_base/routes/$routeId/add-stops';
   static String routeStop(String routeId, String stopId) =>
       '$_base/routes/$routeId/stops/$stopId';
 

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -302,6 +302,7 @@ class AppRouter {
           builder: (_, __, shell) => ProducerShell(navigationShell: shell),
           branches: [
             StatefulShellBranch(
+              observers: [producerRouteObserver],
               routes: [
                 GoRoute(
                   path: '/producer/home',

--- a/lib/core/utils/maps_directions.dart
+++ b/lib/core/utils/maps_directions.dart
@@ -1,0 +1,108 @@
+/// Builds the Google Maps Directions deep-link for the producer's route screen.
+///
+/// Why this is a pure function (and not inline in the page): the route screen
+/// feeds Google Maps with raw `lat,lng` stops coming from the backend. Two
+/// real-world traps break Maps and are handled here:
+///  - **`dir_action=navigate` + multiple waypoints**: turn-by-turn navigation
+///    does not reliably accept intermediate waypoints and errors out (the Maps
+///    app shows "Waypoint, Waypoint, ..." and fails to start). So navigate is
+///    used ONLY for a single destination; with waypoints we open the route
+///    preview instead (the user taps "Iniciar").
+///  - **degenerate / invalid coordinates**: empty, non-numeric, out-of-range,
+///    `NaN`/infinite or `0,0` (Null Island) points are dropped, and duplicate
+///    points (e.g. two orders at the same demo address) or a point equal to the
+///    origin are de-duplicated to avoid Google's "route not found".
+///
+/// The deep-link also has a practical waypoint cap ([kMaxMapsWaypoints]); extra
+/// stops are dropped and [MapsDirections.truncated] is set so the caller can
+/// warn the user.
+library;
+
+/// Practical limit of intermediate waypoints supported by the Google Maps
+/// universal URL (`/maps/dir/?api=1`). Stops beyond this are dropped.
+const int kMaxMapsWaypoints = 9;
+
+/// Result of [buildMapsDirectionsUri]: the [uri] to launch (null when there is
+/// no valid stop to route to) and whether waypoints were [truncated] by the cap.
+class MapsDirections {
+  const MapsDirections({required this.uri, this.truncated = false});
+
+  /// Deep-link to launch, or null when there is no valid destination.
+  final Uri? uri;
+
+  /// True when more than [kMaxMapsWaypoints] waypoints existed and were dropped.
+  final bool truncated;
+}
+
+/// Builds a Google Maps directions deep-link from [stops] (each `"lat,lng"`),
+/// already in the backend's optimized order. [originLat]/[originLng] pin the
+/// producer's GPS as the start when known (and valid); otherwise Maps starts
+/// from the device location.
+MapsDirections buildMapsDirectionsUri({
+  required List<String> stops,
+  double? originLat,
+  double? originLng,
+}) {
+  final origin = _validPoint(originLat, originLng);
+
+  // Parse + validate + de-duplicate (also dropping any stop at the origin),
+  // preserving the optimized order.
+  final seen = <String>{};
+  if (origin != null) seen.add(_key(origin.$1, origin.$2));
+  final points = <(double, double)>[];
+  for (final raw in stops) {
+    final p = _parseLatLng(raw);
+    if (p == null) continue;
+    if (seen.add(_key(p.$1, p.$2))) points.add(p);
+  }
+
+  if (points.isEmpty) {
+    return const MapsDirections(uri: null);
+  }
+
+  final destination = points.last;
+  var waypoints = points.sublist(0, points.length - 1);
+
+  final truncated = waypoints.length > kMaxMapsWaypoints;
+  if (truncated) {
+    waypoints = waypoints.sublist(0, kMaxMapsWaypoints);
+  }
+
+  final uri = Uri.https('www.google.com', '/maps/dir/', {
+    'api': '1',
+    if (origin != null) 'origin': _fmt(origin.$1, origin.$2),
+    'destination': _fmt(destination.$1, destination.$2),
+    if (waypoints.isNotEmpty)
+      'waypoints': waypoints.map((p) => _fmt(p.$1, p.$2)).join('|'),
+    'travelmode': 'driving',
+    // Turn-by-turn navigate is reliable only for a single destination; with
+    // waypoints it errors, so open the route preview instead.
+    if (waypoints.isEmpty) 'dir_action': 'navigate',
+  });
+
+  return MapsDirections(uri: uri, truncated: truncated);
+}
+
+/// Parses a `"lat,lng"` string into a coordinate, or null when invalid
+/// (wrong shape, non-numeric, non-finite, out of range, or `0,0`).
+(double, double)? _parseLatLng(String raw) {
+  final parts = raw.split(',');
+  if (parts.length != 2) return null;
+  final lat = double.tryParse(parts[0].trim());
+  final lng = double.tryParse(parts[1].trim());
+  return _validPoint(lat, lng);
+}
+
+(double, double)? _validPoint(double? lat, double? lng) {
+  if (lat == null || lng == null) return null;
+  if (!lat.isFinite || !lng.isFinite) return null;
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+  if (lat == 0 && lng == 0) return null; // Null Island
+  return (lat, lng);
+}
+
+/// De-dup key: rounds to 6 decimals (~11cm) so float noise doesn't defeat it.
+String _key(double lat, double lng) =>
+    '${lat.toStringAsFixed(6)},${lng.toStringAsFixed(6)}';
+
+String _fmt(double lat, double lng) => '$lat,$lng';

--- a/lib/features/inventory/presentation/pages/inventory_page.dart
+++ b/lib/features/inventory/presentation/pages/inventory_page.dart
@@ -245,7 +245,13 @@ class _InventoryView extends StatelessWidget {
                               ],
                             ),
                           )
-                        : ListView.separated(
+                        : RefreshIndicator(
+                            color: AppColors.darkGreen,
+                            onRefresh: () async => context
+                                .read<InventoryBloc>()
+                                .add(const InventoryRefreshed()),
+                            child: ListView.separated(
+                            physics: const AlwaysScrollableScrollPhysics(),
                             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                             itemCount: state.products.length,
                             separatorBuilder: (_, __) =>
@@ -306,6 +312,7 @@ class _InventoryView extends StatelessWidget {
                                 ),
                               );
                             },
+                          ),
                           ),
                   ),
                 ] else if (state is InventoryLoading) ...[

--- a/lib/features/orders/presentation/pages/customer_orders_page.dart
+++ b/lib/features/orders/presentation/pages/customer_orders_page.dart
@@ -233,25 +233,38 @@ class _OrdersContent extends StatelessWidget {
         );
 
         if (filteredOrders.isEmpty) {
-          return Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Icons.shopping_bag_outlined,
-                  size: 64,
-                  color: AppColors.placeholder,
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  'Nenhum pedido ${state.activeTab.label.toLowerCase()}',
-                  style: const TextStyle(
-                    fontFamily: 'Manrope',
-                    fontSize: 16,
-                    color: AppColors.placeholder,
+          return RefreshIndicator(
+            color: AppColors.darkGreen,
+            onRefresh: () async =>
+                context.read<OrdersBloc>().add(const OrdersRefreshed()),
+            child: LayoutBuilder(
+              builder: (context, constraints) => SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.shopping_bag_outlined,
+                          size: 64,
+                          color: AppColors.placeholder,
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          'Nenhum pedido ${state.activeTab.label.toLowerCase()}',
+                          style: const TextStyle(
+                            fontFamily: 'Manrope',
+                            fontSize: 16,
+                            color: AppColors.placeholder,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ],
+              ),
             ),
           );
         }
@@ -273,11 +286,17 @@ class _OrdersList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-      itemCount: orders.length,
-      separatorBuilder: (_, __) => const SizedBox(height: 13),
-      itemBuilder: (context, index) => OrderCard(order: orders[index]),
+    return RefreshIndicator(
+      color: AppColors.darkGreen,
+      onRefresh: () async =>
+          context.read<OrdersBloc>().add(const OrdersRefreshed()),
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        itemCount: orders.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 13),
+        itemBuilder: (context, index) => OrderCard(order: orders[index]),
+      ),
     );
   }
 }

--- a/lib/features/producer_orders/data/repositories/route_repository.dart
+++ b/lib/features/producer_orders/data/repositories/route_repository.dart
@@ -143,13 +143,26 @@ class RouteRepository {
   }
 
   /// Pulls newly accepted orders into the ACTIVE route (re-optimizes only the
-  /// pending portion, keeps delivered stops). Idempotent: with no new order the
-  /// backend returns the route unchanged. `null` when the route already
-  /// completed (404) — same contract as [getActiveRoute].
-  Future<DeliveryRoute?> addStops(String routeId) async {
+  /// pending portion, keeps delivered stops). When [originLatitude]/
+  /// [originLongitude] (the producer's current GPS) are provided, the remaining
+  /// route is re-anchored/re-optimized from there. Idempotent: with no new order
+  /// the backend returns the route unchanged (no re-anchor). `null` when the
+  /// route already completed (404) — same contract as [getActiveRoute].
+  Future<DeliveryRoute?> addStops(
+    String routeId, {
+    double? originLatitude,
+    double? originLongitude,
+  }) async {
     try {
+      final hasOrigin = originLatitude != null && originLongitude != null;
       final response = await _apiClient.dio.patch<Map<String, dynamic>>(
         ApiEndpoints.routeAddStops(routeId),
+        data: hasOrigin
+            ? {
+                'originLatitude': originLatitude,
+                'originLongitude': originLongitude,
+              }
+            : null,
       );
       return DeliveryRoute.fromJson(response.data ?? const {});
     } on DioException catch (e) {

--- a/lib/features/producer_orders/data/repositories/route_repository.dart
+++ b/lib/features/producer_orders/data/repositories/route_repository.dart
@@ -142,6 +142,23 @@ class RouteRepository {
     }
   }
 
+  /// Pulls newly accepted orders into the ACTIVE route (re-optimizes only the
+  /// pending portion, keeps delivered stops). Idempotent: with no new order the
+  /// backend returns the route unchanged. `null` when the route already
+  /// completed (404) — same contract as [getActiveRoute].
+  Future<DeliveryRoute?> addStops(String routeId) async {
+    try {
+      final response = await _apiClient.dio.patch<Map<String, dynamic>>(
+        ApiEndpoints.routeAddStops(routeId),
+      );
+      return DeliveryRoute.fromJson(response.data ?? const {});
+    } on DioException catch (e) {
+      final error = e.error;
+      if (error is NotFoundException) return null;
+      throw error as ApiException? ?? const UnknownApiException();
+    }
+  }
+
   /// Updates a stop (ARRIVED/DELIVERED/FAILED) and returns the updated route.
   /// [code] (customer's 4 digits) is REQUIRED when status is DELIVERED;
   /// otherwise the API returns 400.

--- a/lib/features/producer_orders/presentation/bloc/route_calculation_cubit.dart
+++ b/lib/features/producer_orders/presentation/bloc/route_calculation_cubit.dart
@@ -328,6 +328,7 @@ class RouteCalculationCubit extends Cubit<RouteCalculationState> {
 
   /// Resumes the active route or creates a new one from the producer's orders.
   Future<void> loadRoute() async {
+    emit(state.copyWith(status: RouteCalculationStatus.loading));
     try {
       var route = await _routeRepository.getActiveRoute();
       if (isClosed) return;
@@ -360,6 +361,20 @@ class RouteCalculationCubit extends Cubit<RouteCalculationState> {
       }
 
       _applyRoute(route);
+    } on ApiException catch (e) {
+      if (isClosed) return;
+      // Surface the backend's specific reason (e.g. "Nenhum pedido confirmado…"
+      // or the per-order geocode failure) instead of a generic message.
+      emit(
+        state.copyWith(
+          deliveries: const [],
+          orderedStops: const [],
+          totalDistanceKm: 0,
+          totalDurationMins: 0,
+          status: RouteCalculationStatus.error,
+          errorMessage: e.message,
+        ),
+      );
     } on Exception {
       if (isClosed) return;
       emit(
@@ -372,6 +387,57 @@ class RouteCalculationCubit extends Cubit<RouteCalculationState> {
           errorMessage:
               'Não foi possível montar a rota. Verifique se há pedidos '
               'confirmados e tente novamente.',
+        ),
+      );
+    }
+  }
+
+  /// Pull-to-refresh: pulls newly accepted orders into the active route
+  /// (backend re-optimizes only the pending portion, keeping delivered stops).
+  /// Falls back to [loadRoute] when there is no route yet. Idempotent on the
+  /// backend, so it is safe to call on every pull.
+  Future<void> refreshRoute() async {
+    final routeId = state.routeId;
+    if (routeId == null) {
+      await loadRoute();
+      return;
+    }
+    emit(state.copyWith(status: RouteCalculationStatus.loading));
+    try {
+      final route = await _routeRepository.addStops(routeId);
+      if (isClosed) return;
+
+      if (route == null) {
+        // Route completed while away: clear gracefully.
+        unawaited(_trackingPublisher.stop());
+        emit(
+          state.copyWith(
+            status: RouteCalculationStatus.initial,
+            deliveries: const [],
+            orderedStops: const [],
+            confirmedDeliveries: const {},
+            totalDistanceKm: 0,
+            totalDurationMins: 0,
+          ),
+        );
+      } else {
+        _applyRoute(route);
+      }
+      _refreshProducerDashboard();
+    } on ApiException catch (e) {
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          status: RouteCalculationStatus.error,
+          errorMessage: e.message,
+        ),
+      );
+    } on Exception {
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          status: RouteCalculationStatus.error,
+          errorMessage: 'Não foi possível atualizar a rota. Tente novamente.',
         ),
       );
     }
@@ -400,8 +466,17 @@ class RouteCalculationCubit extends Cubit<RouteCalculationState> {
       unawaited(_trackingPublisher.stop());
     }
 
+    // Route data arrived: clear a transient loading/error status, but preserve a
+    // CO2 'calculated' status so the result card stays after a delivery refresh.
+    final nextStatus =
+        state.status == RouteCalculationStatus.loading ||
+            state.status == RouteCalculationStatus.error
+        ? RouteCalculationStatus.initial
+        : state.status;
+
     emit(
       state.copyWith(
+        status: nextStatus,
         routeId: route.id,
         deliveries: [...pending.map(toDelivery), ...done.map(toDelivery)],
         orderedStops: pending.map((s) => '${s.latitude},${s.longitude}').toList(),

--- a/lib/features/producer_orders/presentation/bloc/route_calculation_cubit.dart
+++ b/lib/features/producer_orders/presentation/bloc/route_calculation_cubit.dart
@@ -403,8 +403,32 @@ class RouteCalculationCubit extends Cubit<RouteCalculationState> {
       return;
     }
     emit(state.copyWith(status: RouteCalculationStatus.loading));
+
+    // Best-effort fresh GPS so add-stops re-anchors/re-optimizes the remaining
+    // route from where the producer is NOW (they move during a delivery). Falls
+    // back to the last-known position; the backend keeps the origin if none sent.
+    var lat = state.producerLat;
+    var lng = state.producerLng;
     try {
-      final route = await _routeRepository.addStops(routeId);
+      final permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.whileInUse ||
+          permission == LocationPermission.always) {
+        final position = await Geolocator.getCurrentPosition();
+        if (isClosed) return;
+        lat = position.latitude;
+        lng = position.longitude;
+      }
+    } on Exception {
+      // Keep last-known position.
+    }
+    if (isClosed) return;
+
+    try {
+      final route = await _routeRepository.addStops(
+        routeId,
+        originLatitude: lat,
+        originLongitude: lng,
+      );
       if (isClosed) return;
 
       if (route == null) {
@@ -421,6 +445,10 @@ class RouteCalculationCubit extends Cubit<RouteCalculationState> {
           ),
         );
       } else {
+        // Reflect the fresh GPS so the mini-map and Maps deep-link use it too.
+        if (lat != null && lng != null) {
+          emit(state.copyWith(producerLat: lat, producerLng: lng));
+        }
         _applyRoute(route);
       }
       _refreshProducerDashboard();

--- a/lib/features/producer_orders/presentation/bloc/route_calculation_state.dart
+++ b/lib/features/producer_orders/presentation/bloc/route_calculation_state.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 
-enum RouteCalculationStatus { initial, calculating, calculated, error }
+enum RouteCalculationStatus { initial, loading, calculating, calculated, error }
 
 /// A route delivery stop, derived from an accepted/in-delivery order.
 class RouteDelivery extends Equatable {

--- a/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
+++ b/lib/features/producer_orders/presentation/pages/producer_orders_page.dart
@@ -1,10 +1,14 @@
 // Producer Orders screen (US-20). Route: GET /orders/producer.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
+import 'package:ragro_mobile/core/navigation/orders_route_observer.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/features/notifications/data/services/notification_service.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order.dart';
 import 'package:ragro_mobile/features/producer_orders/domain/entities/producer_order_status.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/producer_orders_bloc.dart';
@@ -34,9 +38,68 @@ class _ProducerOrdersView extends StatefulWidget {
   State<_ProducerOrdersView> createState() => _ProducerOrdersViewState();
 }
 
-class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
+class _ProducerOrdersViewState extends State<_ProducerOrdersView>
+    with WidgetsBindingObserver
+    implements RouteAware {
   bool _selectionMode = false;
   final Set<String> _selectedIds = {};
+  StreamSubscription<void>? _foregroundSub;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // Live auto-refresh: any foreground push (e.g. a new order) re-fetches.
+    _foregroundSub = getIt<NotificationService>().onForegroundMessage.listen((
+      _,
+    ) {
+      if (mounted) {
+        context.read<ProducerOrdersBloc>().add(const ProducerOrdersRefreshed());
+      }
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      producerRouteObserver.subscribe(this, route);
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Reopened/foregrounded: pick up orders that arrived while away.
+    if (state == AppLifecycleState.resumed && mounted) {
+      context.read<ProducerOrdersBloc>().add(const ProducerOrdersRefreshed());
+    }
+  }
+
+  @override
+  void dispose() {
+    producerRouteObserver.unsubscribe(this);
+    WidgetsBinding.instance.removeObserver(this);
+    _foregroundSub?.cancel();
+    super.dispose();
+  }
+
+  // Returning to this page (e.g. from the route screen) refreshes the list.
+  @override
+  void didPopNext() {
+    if (mounted) {
+      context.read<ProducerOrdersBloc>().add(const ProducerOrdersRefreshed());
+    }
+  }
+
+  @override
+  void didPush() {}
+
+  @override
+  void didPop() {}
+
+  @override
+  void didPushNext() {}
 
   void _enterSelectionMode() => setState(() {
     _selectionMode = true;
@@ -228,25 +291,45 @@ class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
                         .toList();
 
                     if (orders.isEmpty) {
-                      return Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(
-                              Icons.shopping_bag_outlined,
-                              size: 64,
-                              color: AppColors.placeholder,
-                            ),
-                            const SizedBox(height: 16),
-                            Text(
-                              'Nenhum pedido ${activeTab.label.toLowerCase()}',
-                              style: const TextStyle(
-                                fontFamily: 'Manrope',
-                                fontSize: 16,
-                                color: AppColors.placeholder,
+                      // Scrollable so pull-to-refresh works on an empty tab too
+                      // (e.g. "Pendentes" empty → new order arrives → pull).
+                      return RefreshIndicator(
+                        color: AppColors.darkGreen,
+                        onRefresh: () async => context
+                            .read<ProducerOrdersBloc>()
+                            .add(const ProducerOrdersRefreshed()),
+                        child: LayoutBuilder(
+                          builder: (context, constraints) =>
+                              SingleChildScrollView(
+                                physics: const AlwaysScrollableScrollPhysics(),
+                                child: ConstrainedBox(
+                                  constraints: BoxConstraints(
+                                    minHeight: constraints.maxHeight,
+                                  ),
+                                  child: Center(
+                                    child: Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        const Icon(
+                                          Icons.shopping_bag_outlined,
+                                          size: 64,
+                                          color: AppColors.placeholder,
+                                        ),
+                                        const SizedBox(height: 16),
+                                        Text(
+                                          'Nenhum pedido '
+                                          '${activeTab.label.toLowerCase()}',
+                                          style: const TextStyle(
+                                            fontFamily: 'Manrope',
+                                            fontSize: 16,
+                                            color: AppColors.placeholder,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
                               ),
-                            ),
-                          ],
                         ),
                       );
                     }
@@ -268,8 +351,14 @@ class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
                             ),
                           ),
                         Expanded(
-                          child: ListView.separated(
-                            padding: EdgeInsets.fromLTRB(
+                          child: RefreshIndicator(
+                            color: AppColors.darkGreen,
+                            onRefresh: () async => context
+                                .read<ProducerOrdersBloc>()
+                                .add(const ProducerOrdersRefreshed()),
+                            child: ListView.separated(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              padding: EdgeInsets.fromLTRB(
                               16,
                               12,
                               16,
@@ -336,6 +425,7 @@ class _ProducerOrdersViewState extends State<_ProducerOrdersView> {
                                     : null,
                               );
                             },
+                          ),
                           ),
                         ),
                         if (activeTab == ProducerOrderStatus.inDelivery)

--- a/lib/features/producer_orders/presentation/pages/route_calculation_page.dart
+++ b/lib/features/producer_orders/presentation/pages/route_calculation_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:ragro_mobile/core/di/injection.dart';
 import 'package:ragro_mobile/core/theme/app_colors.dart';
+import 'package:ragro_mobile/core/utils/maps_directions.dart';
 import 'package:ragro_mobile/core/utils/polyline_decoder.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/route_calculation_cubit.dart';
 import 'package:ragro_mobile/features/producer_orders/presentation/bloc/route_calculation_state.dart';
@@ -59,10 +60,22 @@ class _RouteCalculationViewState extends State<_RouteCalculationView> {
 
   Future<void> _openGoogleMaps() async {
     final state = context.read<RouteCalculationCubit>().state;
-    final stops = state.orderedStops;
+    final messenger = ScaffoldMessenger.of(context);
 
-    if (stops.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
+    // Build the deep-link from the pending stops (already in the backend's
+    // optimized order). The builder validates/de-duplicates coordinates, caps
+    // waypoints and drops `dir_action=navigate` when there are waypoints (the
+    // navigate mode errors with multiple stops — the "Waypoint, Waypoint..."
+    // failure). Origin is pinned only when the producer's real GPS is known.
+    final directions = buildMapsDirectionsUri(
+      stops: state.orderedStops,
+      originLat: state.producerLat,
+      originLng: state.producerLng,
+    );
+
+    final uri = directions.uri;
+    if (uri == null) {
+      messenger.showSnackBar(
         const SnackBar(
           content: Text('Nenhuma entrega pendente para abrir no mapa.'),
         ),
@@ -70,30 +83,40 @@ class _RouteCalculationViewState extends State<_RouteCalculationView> {
       return;
     }
 
-    final lat = state.producerLat;
-    final lng = state.producerLng;
-    final destination = stops.last;
-    final waypoints = stops.length > 1
-        ? stops.sublist(0, stops.length - 1)
-        : const <String>[];
+    // TODO(gustavo): remover após validar na próxima demo — confirma a URL
+    // real e a contagem de paradas no momento da falha.
+    debugPrint(
+      '[route][maps] stops=${state.orderedStops.length} '
+      'truncated=${directions.truncated} uri=$uri',
+    );
 
-    // Navigation deep-link (no API key needed); stops already in the backend's
-    // optimized order. Only pin `origin` when the producer's real GPS is known,
-    // else Maps starts from the device location (not the Goiânia fallback).
-    final uri = Uri.https('www.google.com', '/maps/dir/', {
-      'api': '1',
-      if (lat != null && lng != null) 'origin': '$lat,$lng',
-      'destination': destination,
-      if (waypoints.isNotEmpty) 'waypoints': waypoints.join('|'),
-      'travelmode': 'driving',
-      'dir_action': 'navigate',
-    });
+    if (directions.truncated) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Muitas paradas: abrindo apenas as primeiras no mapa.',
+          ),
+        ),
+      );
+    }
 
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    } else {
+    // Launch directly (no canLaunchUrl gate): per url_launcher docs canLaunchUrl
+    // can return false even when launchUrl would succeed.
+    try {
+      final launched = await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (!launched && mounted) {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text('Não foi possível abrir o Google Maps.'),
+          ),
+        );
+      }
+    } on Exception {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           const SnackBar(
             content: Text('Não foi possível abrir o Google Maps.'),
           ),
@@ -373,49 +396,67 @@ class _RouteCalculationViewState extends State<_RouteCalculationView> {
                         ),
 
                         const SizedBox(height: 24),
-                        const Text(
-                          'Sequência de Entregas',
-                          style: TextStyle(
-                            fontFamily: 'Figtree',
-                            fontWeight: FontWeight.w700,
-                            fontSize: 16,
-                            color: AppColors.black,
-                          ),
-                        ),
-                        const SizedBox(height: 16),
-
+                        // Pending stops feed the active numbered sequence;
+                        // delivered/failed stops move to a separate "Entregues"
+                        // section so the producer doesn't confuse finished
+                        // orders with the live route.
                         BlocBuilder<
                           RouteCalculationCubit,
                           RouteCalculationState
                         >(
                           builder: (context, state) {
-                            if (state.deliveries.isEmpty) {
-                              return const Padding(
-                                padding: EdgeInsets.symmetric(vertical: 12),
-                                child: Text(
-                                  'Nenhuma entrega pendente no momento.',
+                            final pending = state.deliveries
+                                .where(
+                                  (d) =>
+                                      !state.confirmedDeliveries.contains(d.id),
+                                )
+                                .toList();
+                            final done = state.deliveries
+                                .where(
+                                  (d) =>
+                                      state.confirmedDeliveries.contains(d.id),
+                                )
+                                .toList();
+
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Text(
+                                  'Sequência de Entregas',
                                   style: TextStyle(
-                                    fontSize: 13,
-                                    color: Colors.grey,
+                                    fontFamily: 'Figtree',
+                                    fontWeight: FontWeight.w700,
+                                    fontSize: 16,
+                                    color: AppColors.black,
                                   ),
                                 ),
-                              );
-                            }
-                            return Column(
-                              children: [
-                                for (
-                                  var i = 0;
-                                  i < state.deliveries.length;
-                                  i++
-                                ) ...[
-                                  _DeliveryItem(
-                                    id: state.deliveries[i].id,
-                                    number: i + 1,
-                                    title: state.deliveries[i].title,
-                                    subtitle: state.deliveries[i].subtitle,
+                                const SizedBox(height: 16),
+                                if (pending.isEmpty)
+                                  const Padding(
+                                    padding: EdgeInsets.symmetric(vertical: 12),
+                                    child: Text(
+                                      'Nenhuma entrega pendente no momento.',
+                                      style: TextStyle(
+                                        fontSize: 13,
+                                        color: Colors.grey,
+                                      ),
+                                    ),
+                                  )
+                                else
+                                  _DeliverySequence(items: pending),
+                                if (done.isNotEmpty) ...[
+                                  const SizedBox(height: 24),
+                                  const Text(
+                                    'Entregues',
+                                    style: TextStyle(
+                                      fontFamily: 'Figtree',
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 16,
+                                      color: AppColors.black,
+                                    ),
                                   ),
-                                  if (i != state.deliveries.length - 1)
-                                    const SizedBox(height: 16),
+                                  const SizedBox(height: 16),
+                                  _DeliverySequence(items: done),
                                 ],
                               ],
                             );
@@ -627,6 +668,31 @@ class _Co2ResultCard extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Renders a numbered list of [_DeliveryItem]s (1..n) with separators. Reused
+/// for both the pending sequence and the "Entregues" history.
+class _DeliverySequence extends StatelessWidget {
+  const _DeliverySequence({required this.items});
+
+  final List<RouteDelivery> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (var i = 0; i < items.length; i++) ...[
+          _DeliveryItem(
+            id: items[i].id,
+            number: i + 1,
+            title: items[i].title,
+            subtitle: items[i].subtitle,
+          ),
+          if (i != items.length - 1) const SizedBox(height: 16),
+        ],
+      ],
     );
   }
 }

--- a/lib/features/producer_orders/presentation/pages/route_calculation_page.dart
+++ b/lib/features/producer_orders/presentation/pages/route_calculation_page.dart
@@ -83,18 +83,12 @@ class _RouteCalculationViewState extends State<_RouteCalculationView> {
       return;
     }
 
-    // TODO(gustavo): remover após validar na próxima demo — confirma a URL
-    // real e a contagem de paradas no momento da falha.
-    debugPrint(
-      '[route][maps] stops=${state.orderedStops.length} '
-      'truncated=${directions.truncated} uri=$uri',
-    );
-
     if (directions.truncated) {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
-            'Muitas paradas: abrindo apenas as primeiras no mapa.',
+            'Muitas paradas: abrindo as primeiras ${kMaxMapsWaypoints + 1} '
+            'no mapa.',
           ),
         ),
       );
@@ -161,8 +155,13 @@ class _RouteCalculationViewState extends State<_RouteCalculationView> {
         backgroundColor: AppColors.white,
         body: Stack(
           children: [
-            CustomScrollView(
-              slivers: [
+            RefreshIndicator(
+              color: AppColors.darkGreen,
+              onRefresh: () =>
+                  context.read<RouteCalculationCubit>().refreshRoute(),
+              child: CustomScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                slivers: [
                 SliverAppBar(
                   backgroundColor: AppColors.white,
                   leading: GestureDetector(
@@ -249,13 +248,18 @@ class _RouteCalculationViewState extends State<_RouteCalculationView> {
                         ),
 
                         const SizedBox(height: 20),
-                        const Text(
-                          'A rota abaixo foi otimizada para\neconomizar tempo, combustível e emissões de CO2.',
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            fontFamily: 'Manrope',
-                            fontSize: 12,
-                            color: AppColors.black,
+                        // Full width so textAlign.center actually centers on screen
+                        // (the parent Column is crossAxisAlignment.start).
+                        const SizedBox(
+                          width: double.infinity,
+                          child: Text(
+                            'A rota abaixo foi otimizada para\neconomizar tempo, combustível e emissões de CO2.',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              fontFamily: 'Manrope',
+                              fontSize: 12,
+                              color: AppColors.black,
+                            ),
                           ),
                         ),
                         const SizedBox(height: 16),
@@ -467,6 +471,22 @@ class _RouteCalculationViewState extends State<_RouteCalculationView> {
                   ),
                 ),
               ],
+              ),
+            ),
+            // Themed loading overlay on the FIRST load (route not yet fetched).
+            // On pull-to-refresh of an existing route the RefreshIndicator spinner
+            // is enough, so this only shows when there is no route yet.
+            BlocBuilder<RouteCalculationCubit, RouteCalculationState>(
+              buildWhen: (p, c) =>
+                  p.status != c.status || p.routeId != c.routeId,
+              builder: (context, state) {
+                final initialLoading =
+                    state.status == RouteCalculationStatus.loading &&
+                    state.routeId == null;
+                return initialLoading
+                    ? const Positioned.fill(child: _RouteLoadingView())
+                    : const SizedBox.shrink();
+              },
             ),
             Positioned(
               left: 0,
@@ -667,6 +687,76 @@ class _Co2ResultCard extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Themed full-screen loader shown while the route is first being built/fetched,
+/// so the producer never sees the misleading "0 min / 0 km / no deliveries"
+/// empty state. Green progress ring around a dark-green route badge.
+class _RouteLoadingView extends StatelessWidget {
+  const _RouteLoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: AppColors.white,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 96,
+              height: 96,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  const SizedBox(
+                    width: 96,
+                    height: 96,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 3,
+                      color: AppColors.lightGreen,
+                    ),
+                  ),
+                  Container(
+                    width: 64,
+                    height: 64,
+                    decoration: const BoxDecoration(
+                      color: AppColors.darkGreen,
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(
+                      Icons.alt_route_rounded,
+                      color: Colors.white,
+                      size: 32,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'Montando sua rota...',
+              style: TextStyle(
+                fontFamily: 'Figtree',
+                fontWeight: FontWeight.w700,
+                fontSize: 16,
+                color: AppColors.darkGreen,
+              ),
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Otimizando suas entregas de hoje',
+              style: TextStyle(
+                fontFamily: 'Manrope',
+                fontSize: 12,
+                color: AppColors.black,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/core/utils/maps_directions_test.dart
+++ b/test/core/utils/maps_directions_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ragro_mobile/core/utils/maps_directions.dart';
+
+void main() {
+  group('buildMapsDirectionsUri', () {
+    test('single pending stop uses dir_action=navigate without waypoints', () {
+      final result = buildMapsDirectionsUri(
+        stops: const ['-16.70,-49.25'],
+        originLat: -16.68,
+        originLng: -49.26,
+      );
+
+      final uri = result.uri!;
+      expect(result.truncated, isFalse);
+      expect(uri.host, 'www.google.com');
+      expect(uri.path, '/maps/dir/');
+      expect(uri.queryParameters['origin'], '-16.68,-49.26');
+      expect(uri.queryParameters['destination'], '-16.7,-49.25');
+      expect(uri.queryParameters.containsKey('waypoints'), isFalse);
+      expect(uri.queryParameters['dir_action'], 'navigate');
+      expect(uri.queryParameters['travelmode'], 'driving');
+    });
+
+    test('multiple pending stops DROP dir_action=navigate and add waypoints',
+        () {
+      final result = buildMapsDirectionsUri(
+        stops: const ['-16.70,-49.25', '-16.72,-49.27', '-16.74,-49.29'],
+        originLat: -16.68,
+        originLng: -49.26,
+      );
+
+      final uri = result.uri!;
+      // navigate mode errors with waypoints — must be absent here.
+      expect(uri.queryParameters.containsKey('dir_action'), isFalse);
+      expect(uri.queryParameters['destination'], '-16.74,-49.29');
+      expect(
+        uri.queryParameters['waypoints'],
+        '-16.7,-49.25|-16.72,-49.27',
+      );
+    });
+
+    test('omits origin when GPS is unknown', () {
+      final result = buildMapsDirectionsUri(
+        stops: const ['-16.70,-49.25', '-16.72,-49.27'],
+      );
+
+      final uri = result.uri!;
+      expect(uri.queryParameters.containsKey('origin'), isFalse);
+      expect(uri.queryParameters['destination'], '-16.72,-49.27');
+      expect(uri.queryParameters['waypoints'], '-16.7,-49.25');
+    });
+
+    test('de-duplicates identical coordinates (same demo address)', () {
+      // Two orders at the same address must not become waypoint==destination
+      // (Google "route not found").
+      final result = buildMapsDirectionsUri(
+        stops: const ['-16.70,-49.25', '-16.70,-49.25'],
+        originLat: -16.68,
+        originLng: -49.26,
+      );
+
+      final uri = result.uri!;
+      expect(uri.queryParameters['destination'], '-16.7,-49.25');
+      expect(uri.queryParameters.containsKey('waypoints'), isFalse);
+      // Collapses to a single stop -> navigate is valid again.
+      expect(uri.queryParameters['dir_action'], 'navigate');
+    });
+
+    test('drops a stop equal to the origin', () {
+      final result = buildMapsDirectionsUri(
+        stops: const ['-16.68,-49.26', '-16.72,-49.27'],
+        originLat: -16.68,
+        originLng: -49.26,
+      );
+
+      final uri = result.uri!;
+      expect(uri.queryParameters['destination'], '-16.72,-49.27');
+      expect(uri.queryParameters.containsKey('waypoints'), isFalse);
+    });
+
+    test('drops invalid coordinates (empty, non-numeric, 0,0, out of range)',
+        () {
+      final result = buildMapsDirectionsUri(
+        stops: const [
+          '',
+          'abc',
+          '0.0,0.0',
+          '999,999',
+          '-16.72,-49.27',
+        ],
+        originLat: -16.68,
+        originLng: -49.26,
+      );
+
+      final uri = result.uri!;
+      expect(uri.queryParameters['destination'], '-16.72,-49.27');
+      expect(uri.queryParameters.containsKey('waypoints'), isFalse);
+    });
+
+    test('caps waypoints at kMaxMapsWaypoints and flags truncated', () {
+      // 12 stops -> 11 waypoints + 1 destination; cap drops to 9 waypoints.
+      final stops = [for (var i = 0; i < 12; i++) '-16.${700 + i},-49.25'];
+      final result = buildMapsDirectionsUri(
+        stops: stops,
+        originLat: -16.68,
+        originLng: -49.26,
+      );
+
+      final uri = result.uri!;
+      expect(result.truncated, isTrue);
+      expect(
+        uri.queryParameters['waypoints']!.split('|').length,
+        kMaxMapsWaypoints,
+      );
+      // Destination is still the last stop, not dropped by the cap.
+      expect(uri.queryParameters['destination'], '-16.711,-49.25');
+    });
+
+    test('returns null uri when no valid stop remains', () {
+      final result = buildMapsDirectionsUri(
+        stops: const ['', '0.0,0.0', 'abc'],
+        originLat: -16.68,
+        originLng: -49.26,
+      );
+
+      expect(result.uri, isNull);
+      expect(result.truncated, isFalse);
+    });
+
+    test('empty stop list returns null uri', () {
+      final result = buildMapsDirectionsUri(stops: const []);
+      expect(result.uri, isNull);
+    });
+
+    test('ignores a 0,0 origin (treated as unknown GPS)', () {
+      final result = buildMapsDirectionsUri(
+        stops: const ['-16.72,-49.27'],
+        originLat: 0,
+        originLng: 0,
+      );
+
+      final uri = result.uri!;
+      expect(uri.queryParameters.containsKey('origin'), isFalse);
+      expect(uri.queryParameters['destination'], '-16.72,-49.27');
+    });
+  });
+}

--- a/test/features/producer_orders/presentation/bloc/route_calculation_cubit_test.dart
+++ b/test/features/producer_orders/presentation/bloc/route_calculation_cubit_test.dart
@@ -330,4 +330,85 @@ void main() {
       await cubit.close();
     });
   });
+
+  group('refreshRoute', () {
+    test('calls addStops and applies the returned route', () async {
+      final cubit = await buildLoadedCubit();
+      when(() => routeRepository.addStops(any())).thenAnswer(
+        (_) async => _route(stops: [_stop(id: 'stop-1'), _stop(id: 'stop-2')]),
+      );
+
+      await cubit.refreshRoute();
+
+      verify(() => routeRepository.addStops('route-1')).called(1);
+      expect(cubit.state.deliveries.length, 2);
+      expect(cubit.state.status, isNot(RouteCalculationStatus.loading));
+      await cubit.close();
+    });
+
+    test('clears state when the route completed (addStops -> null)', () async {
+      final cubit = await buildLoadedCubit();
+      when(() => routeRepository.addStops(any())).thenAnswer((_) async => null);
+
+      await cubit.refreshRoute();
+
+      expect(cubit.state.deliveries, isEmpty);
+      expect(cubit.state.orderedStops, isEmpty);
+      await cubit.close();
+    });
+
+    test('falls back to loadRoute (no addStops) when there is no route yet', () async {
+      when(() => routeRepository.getActiveRoute()).thenAnswer((_) async => null);
+      final cubit = RouteCalculationCubit(
+        co2Repository,
+        routeRepository,
+        trackingPublisher,
+        refuseProducerOrder,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      await cubit.refreshRoute();
+
+      verifyNever(() => routeRepository.addStops(any()));
+      await cubit.close();
+    });
+
+    test('emits the backend message on ApiException', () async {
+      final cubit = await buildLoadedCubit();
+      when(
+        () => routeRepository.addStops(any()),
+      ).thenThrow(const UnknownApiException('Falha ao otimizar a rota'));
+
+      await cubit.refreshRoute();
+
+      expect(cubit.state.status, RouteCalculationStatus.error);
+      expect(cubit.state.errorMessage, 'Falha ao otimizar a rota');
+      await cubit.close();
+    });
+  });
+
+  group('loadRoute', () {
+    test('surfaces the backend ApiException message (not a generic one)', () async {
+      when(() => routeRepository.getActiveRoute()).thenThrow(
+        const UnknownApiException(
+          'Não foi possível localizar o endereço de entrega do pedido',
+        ),
+      );
+      final cubit = RouteCalculationCubit(
+        co2Repository,
+        routeRepository,
+        trackingPublisher,
+        refuseProducerOrder,
+      );
+      await cubit.stream
+          .firstWhere((s) => s.status == RouteCalculationStatus.error)
+          .timeout(const Duration(seconds: 2), onTimeout: () => cubit.state);
+
+      expect(
+        cubit.state.errorMessage,
+        'Não foi possível localizar o endereço de entrega do pedido',
+      );
+      await cubit.close();
+    });
+  });
 }

--- a/test/features/producer_orders/presentation/bloc/route_calculation_cubit_test.dart
+++ b/test/features/producer_orders/presentation/bloc/route_calculation_cubit_test.dart
@@ -334,13 +334,23 @@ void main() {
   group('refreshRoute', () {
     test('calls addStops and applies the returned route', () async {
       final cubit = await buildLoadedCubit();
-      when(() => routeRepository.addStops(any())).thenAnswer(
+      when(() => routeRepository.addStops(
+        any(),
+        originLatitude: any(named: 'originLatitude'),
+        originLongitude: any(named: 'originLongitude'),
+      )).thenAnswer(
         (_) async => _route(stops: [_stop(id: 'stop-1'), _stop(id: 'stop-2')]),
       );
 
       await cubit.refreshRoute();
 
-      verify(() => routeRepository.addStops('route-1')).called(1);
+      verify(
+        () => routeRepository.addStops(
+          'route-1',
+          originLatitude: any(named: 'originLatitude'),
+          originLongitude: any(named: 'originLongitude'),
+        ),
+      ).called(1);
       expect(cubit.state.deliveries.length, 2);
       expect(cubit.state.status, isNot(RouteCalculationStatus.loading));
       await cubit.close();
@@ -348,7 +358,11 @@ void main() {
 
     test('clears state when the route completed (addStops -> null)', () async {
       final cubit = await buildLoadedCubit();
-      when(() => routeRepository.addStops(any())).thenAnswer((_) async => null);
+      when(() => routeRepository.addStops(
+        any(),
+        originLatitude: any(named: 'originLatitude'),
+        originLongitude: any(named: 'originLongitude'),
+      )).thenAnswer((_) async => null);
 
       await cubit.refreshRoute();
 
@@ -369,14 +383,22 @@ void main() {
 
       await cubit.refreshRoute();
 
-      verifyNever(() => routeRepository.addStops(any()));
+      verifyNever(() => routeRepository.addStops(
+        any(),
+        originLatitude: any(named: 'originLatitude'),
+        originLongitude: any(named: 'originLongitude'),
+      ));
       await cubit.close();
     });
 
     test('emits the backend message on ApiException', () async {
       final cubit = await buildLoadedCubit();
       when(
-        () => routeRepository.addStops(any()),
+        () => routeRepository.addStops(
+        any(),
+        originLatitude: any(named: 'originLatitude'),
+        originLongitude: any(named: 'originLongitude'),
+      ),
       ).thenThrow(const UnknownApiException('Falha ao otimizar a rota'));
 
       await cubit.refreshRoute();


### PR DESCRIPTION
## O quê
- **Pull-to-refresh** na tela de rota chama `add-stops` (com GPS atual) → incorpora
  pedidos aceitos no meio da entrega; estado de **loading temático** ("Montando sua rota…").
- **Google Maps deep-link robusto**: remove `dir_action=navigate` quando há waypoints
  (corrige o erro "Waypoint, Waypoint…"), valida/deduplica coordenadas e limita waypoints
  (util puro `buildMapsDirectionsUri`, testado).
- Pedidos entregues em seção **"Entregues"** separada (pendentes renumerados).
- **Refresh sem reabrir o app**: `producer_orders` ganha RefreshIndicator + RouteAware
  (didPopNext) + lifecycle resume + push FCM; RefreshIndicator também em `customer_orders`
  e `inventory`.
- Mensagem de erro específica do backend preservada (catch `ApiException`); texto
  "A rota abaixo…" centralizado.

## Testes
- 232/232 verdes (`buildMapsDirectionsUri`, `refreshRoute`, etc.); `flutter analyze` limpo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pull-to-refresh capability to producer orders and route calculation pages
  * Added auto-refresh when app returns to foreground and when new orders arrive
  * Enhanced Google Maps directions with improved waypoint handling

* **Improvements**
  * Pull-to-refresh now available on inventory and customer orders pages
  * Improved route updates when accepting new orders
  * Better organization of pending vs. completed deliveries in route view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->